### PR TITLE
Sync BBP5 release branches to develop

### DIFF
--- a/sysconfig/bbpv/compilers/config.yaml
+++ b/sysconfig/bbpv/compilers/config.yaml
@@ -1,0 +1,9 @@
+config:
+  install_tree: $APPS_DIR_PATH/compilers/install
+  source_cache: $APPS_DIR_PATH/compilers/.cache
+  module_roots:
+    tcl: $APPS_DIR_PATH/compilers/modules/tcl
+    lmod: $APPS_DIR_PATH/compilers/modules/lmod
+  install_path_scheme: '${PACKAGE}-${VERSION}'
+  # The default number of jobs to use when running `make` in parallel.
+  # build_jobs: 8

--- a/sysconfig/bbpv/compilers/modules.yaml
+++ b/sysconfig/bbpv/compilers/modules.yaml
@@ -1,0 +1,50 @@
+modules:
+  enable::
+      - lmod
+      - tcl
+  prefix_inspections:
+    bin:
+      - PATH
+    bin64:
+      - PATH
+    share/man:
+      - MANPATH
+    man:
+      - MANPATH
+    lib:
+      - LD_LIBRARY_PATH
+    lib64:
+      - LD_LIBRARY_PATH
+    lib/pkgconfig:
+      - PKG_CONFIG_PATH
+    lib64/pkgconfig:
+      - PKG_CONFIG_PATH
+    '':
+      - CMAKE_PREFIX_PATH
+  lmod:
+    core_compilers:
+      - 'gcc@4.8.5'
+    hash_length: 0
+    whitelist:
+      - 'gcc'
+      - 'pgi'
+      - 'intel-parallel-studio'
+      - 'llvm'
+    blacklist:
+      - '%gcc'
+    all:
+      filter:
+        environment_blacklist: ['CPATH', 'LIBRARY_PATH']
+  tcl:
+    all:
+      filter:
+        environment_blacklist: ['CPATH', 'LIBRARY_PATH']
+    naming_scheme: '${PACKAGE}/${VERSION}'
+    hash_length: 0
+    whitelist:
+      - 'gcc'
+      - 'pgi'
+      - 'intel-parallel-studio'
+      - 'llvm'
+    blacklist:
+      - '%gcc'

--- a/sysconfig/bbpv/compilers/packages.yaml
+++ b/sysconfig/bbpv/compilers/packages.yaml
@@ -1,0 +1,73 @@
+packages:
+    autoconf:
+        paths:
+            autoconf@2.69: /usr
+        version: [2.63]
+    automake:
+        paths:
+            automake@1.13.4: /usr
+        version: [1.13.4]
+    bison:
+        paths:
+            bison@3.0.4: /usr
+        version: [3.0.4]
+    cmake:
+        paths:
+            cmake@2.8.12: /usr
+        version: [2.8.12]
+    curl:
+        paths:
+            curl@7.29.0: /usr
+        version: [7.29.0]
+    flex:
+        paths:
+            flex@2.5.37: /usr
+        version: [2.5.37]
+    gettext:
+        paths:
+            gettext@0.19.8: /usr
+        version: [0.19.8]
+    libedit:
+        paths:
+            libedit@3.0-12: /usr
+        version: [3.0-12]
+    libtool:
+        paths:
+            libtool@2.4.2: /usr
+        version: [2.4.2]
+    m4:
+        paths:
+            m4@1.4.16: /usr
+        version: [1.4.16]
+    ncurses:
+        paths:
+            ncurses@5.9: /usr
+        version: [5.9]
+    pcre:
+        paths:
+            pcre@8.32: /usr
+        version: [8.32]
+    perl:
+        paths:
+            perl@5.16.3: /usr
+        version: [5.16.3]
+    pkg-config:
+        paths:
+            pkg-config@0.27.1: /usr
+        version: [0.27.1]
+    python:
+        paths:
+            python@2.7.13: /usr
+        version: [2.7.13]
+    sqlite:
+        paths:
+            sqlite@3.7.17: /usr
+        version: [3.7.17]
+    tar:
+        paths:
+            tar@1.26: /usr
+        version: [1.26]
+    xz:
+        paths:
+            xz@5.2: /usr
+        version: [5.2]

--- a/sysconfig/bbpv/tools/config.yaml
+++ b/sysconfig/bbpv/tools/config.yaml
@@ -1,0 +1,10 @@
+config:
+  install_tree: $APPS_DIR_PATH/tools/install
+  source_cache: $APPS_DIR_PATH/tools/.cache
+  module_roots:
+    tcl: $APPS_DIR_PATH/tools/modules/tcl
+    lmod: $APPS_DIR_PATH/tools/modules/lmod
+  build_stage:
+    - $tempdir
+    - $APPS_DIR_PATH/tools/.stage
+  install_path_scheme: '${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH:6}'

--- a/sysconfig/bbpv/tools/modules.yaml
+++ b/sysconfig/bbpv/tools/modules.yaml
@@ -1,0 +1,140 @@
+modules:
+  enable::
+      - lmod
+      - tcl
+  prefix_inspections:
+    bin:
+      - PATH
+    bin64:
+      - PATH
+    share/man:
+      - MANPATH
+    man:
+      - MANPATH
+    lib:
+      - LD_LIBRARY_PATH
+    lib64:
+      - LD_LIBRARY_PATH
+    lib/pkgconfig:
+      - PKG_CONFIG_PATH
+    lib64/pkgconfig:
+      - PKG_CONFIG_PATH
+    '':
+      - CMAKE_PREFIX_PATH
+  lmod:
+    core_compilers:
+      - 'gcc@4.8.5'
+    hierarchy:
+      - 'mpi'
+      - 'lapack'
+    hash_length: 0
+    all:
+      suffixes:
+        '^cuda': gpu
+        '^python@3.5.2': python3
+        '^python@2': python2
+        '^openblas~openmp': blas
+        '^openblas+openmp': 'blas+thread'
+        '^intel-mkl~openmp': mkl
+        '^intel-mkl+openmp': 'mkl+thread'
+      filter:
+        environment_blacklist: ['CPATH', 'LIBRARY_PATH']
+    whitelist:
+      - mvapich2
+      - mpich
+      - intel-mpi
+      - openmpi
+      - ior
+      - darshan-runtime
+      - netlib-scalapack
+      - adios
+      - paraview
+      - petsc
+      - hdf5
+      - hpctoolkit
+      - scorep
+      - python
+      - py-numpy
+      - py-scipy
+      - py-theano
+      - caffe
+      - tau
+      - cudnn
+      - cuda
+      - py-ipython
+      - py-jupyter-notebook
+      - spark
+      - iozone
+      - qt
+      - zeromq
+      - intel-mkl
+      - 'openblas+openmp'
+      - gcc
+      - intel
+      - clang
+      - llvm
+      - pgi
+      - imb
+      - osu-micro-benchmarks
+      - 'cmake%gcc@4.8.5'
+    blacklist:
+      - '%gcc'
+      - '%intel'
+      - '%clang'
+      - '%pgi'
+      - 'cmake'
+  tcl:
+    all:
+      filter:
+        environment_blacklist: ['CPATH', 'LIBRARY_PATH']
+      suffixes:
+        '^mpich': mpich
+        '^mvapich2': mvapich2
+        '^openmpi': openmpi
+        '^intel-mpi': intel-mpi
+        '^cuda': gpu
+        '^python@3.5.2': python3
+        '^python@2': python2
+        '^openblas~openmp': blas
+        '^openblas+openmp': 'blas+thread'
+        '^intel-mkl~openmp': mkl
+        '^intel-mkl+openmp': 'mkl+thread'
+    naming_scheme: '${PACKAGE}/${VERSION}-${COMPILERNAME}-${COMPILERVER}'
+    hash_length: 0
+    whitelist:
+      - mvapich2
+      - mpich
+      - intel-mpi
+      - openmpi
+      - ior
+      - darshan-runtime
+      - netlib-scalapack
+      - adios
+      - paraview
+      - petsc
+      - hdf5
+      - hpctoolkit
+      - scorep
+      - python
+      - py-numpy
+      - py-scipy
+      - py-theano
+      - caffe
+      - tau
+      - cudnn
+      - cuda
+      - py-ipython
+      - py-jupyter-notebook
+      - spark
+      - iozone
+      - qt
+      - zeromq
+      - imb
+      - osu-micro-benchmarks
+      - 'cmake%gcc@4.8.5'
+    blacklist:
+      - '%gcc'
+      - '%intel'
+      - '%clang'
+      - '%pgi'
+      - 'cmake'

--- a/sysconfig/bbpv/tools/modules.yaml
+++ b/sysconfig/bbpv/tools/modules.yaml
@@ -100,7 +100,7 @@ modules:
         '^openblas+openmp': 'blas+thread'
         '^intel-mkl~openmp': mkl
         '^intel-mkl+openmp': 'mkl+thread'
-    naming_scheme: '${PACKAGE}/${VERSION}-${COMPILERNAME}'
+    naming_scheme: '${PACKAGE}/${VERSION}'
     hash_length: 0
     whitelist:
       - allinea-forge

--- a/sysconfig/bbpv/tools/modules.yaml
+++ b/sysconfig/bbpv/tools/modules.yaml
@@ -32,7 +32,6 @@ modules:
       suffixes:
         '^cuda': cuda
         '^python@3.5.2': python3
-        '^python@2': python2
         '^openblas~openmp': blas
         '^openblas+openmp': 'blas+thread'
         '^intel-mkl~openmp': mkl
@@ -51,22 +50,14 @@ modules:
       - adios
       - paraview
       - petsc
-      - hdf5
       - hpctoolkit
       - scorep
-      - python
-      - py-numpy
-      - py-scipy
-      - py-theano
       - caffe
       - tau
       - cudnn
       - cuda
-      - py-ipython
-      - py-jupyter-notebook
       - spark
       - iozone
-      - qt
       - zeromq
       - intel-mkl
       - 'openblas+openmp'
@@ -77,6 +68,7 @@ modules:
       - pgi
       - imb
       - osu-micro-benchmarks
+      - stat
       - 'cmake%gcc@4.8.5'
     blacklist:
       - '%gcc'
@@ -95,7 +87,6 @@ modules:
         '^intel-mpi': intel-mpi
         '^cuda': cuda
         '^python@3.5.2': python3
-        '^python@2': python2
         '^openblas~openmp': blas
         '^openblas+openmp': 'blas+thread'
         '^intel-mkl~openmp': mkl
@@ -114,25 +105,19 @@ modules:
       - adios
       - paraview
       - petsc
-      - hdf5
       - hpctoolkit
       - scorep
-      - python
-      - py-numpy
-      - py-scipy
-      - py-theano
       - caffe
       - tau
       - cudnn
       - cuda
-      - py-ipython
-      - py-jupyter-notebook
       - spark
       - iozone
       - qt
       - zeromq
       - imb
       - osu-micro-benchmarks
+      - stat
       - 'cmake%gcc@4.8.5'
     blacklist:
       - '%gcc'

--- a/sysconfig/bbpv/tools/modules.yaml
+++ b/sysconfig/bbpv/tools/modules.yaml
@@ -30,7 +30,7 @@ modules:
     hash_length: 0
     all:
       suffixes:
-        '^cuda': gpu
+        '^cuda': cuda
         '^python@3.5.2': python3
         '^python@2': python2
         '^openblas~openmp': blas
@@ -40,6 +40,7 @@ modules:
       filter:
         environment_blacklist: ['CPATH', 'LIBRARY_PATH']
     whitelist:
+      - allinea-forge
       - mvapich2
       - mpich
       - intel-mpi
@@ -92,16 +93,17 @@ modules:
         '^mvapich2': mvapich2
         '^openmpi': openmpi
         '^intel-mpi': intel-mpi
-        '^cuda': gpu
+        '^cuda': cuda
         '^python@3.5.2': python3
         '^python@2': python2
         '^openblas~openmp': blas
         '^openblas+openmp': 'blas+thread'
         '^intel-mkl~openmp': mkl
         '^intel-mkl+openmp': 'mkl+thread'
-    naming_scheme: '${PACKAGE}/${VERSION}-${COMPILERNAME}-${COMPILERVER}'
+    naming_scheme: '${PACKAGE}/${VERSION}-${COMPILERNAME}'
     hash_length: 0
     whitelist:
+      - allinea-forge
       - mvapich2
       - mpich
       - intel-mpi

--- a/sysconfig/bbpv/tools/packages.yaml
+++ b/sysconfig/bbpv/tools/packages.yaml
@@ -1,0 +1,133 @@
+packages:
+    autoconf:
+        paths:
+            autoconf@2.69: /usr
+        version: [2.63]
+    automake:
+        paths:
+            automake@1.13.4: /usr
+        version: [1.13.4]
+    bison:
+        paths:
+            bison@3.0.4: /usr
+        version: [3.0.4]
+    cairo:
+        paths:
+            cairo@1.8.10: /usr
+        version: [1.8.10]
+    cmake:
+        paths:
+            cmake@2.8.12: /usr
+        version: [2.8.12]
+    curl:
+        paths:
+            curl@7.29.0: /usr
+        version: [7.29.0]
+    flex:
+        paths:
+            flex@2.5.37: /usr
+        version: [2.5.37]
+    fontconfig:
+        paths:
+            fontconfig@2.10.95: /usr
+        version: [2.10.95]
+    glib:
+        paths:
+            glib@2.50.3: /usr
+        version: [2.50.3]
+    hwloc:
+        paths:
+            hwloc@1.11.2: /usr
+        version: [1.11.2]
+    libedit:
+        paths:
+            libedit@3.0-12: /usr
+        version: [3.0-12]
+    libjpeg:
+        paths:
+            libjpeg@1.2.90: /usr
+        version: [1.2.90]
+    libmng:
+        paths:
+            libmng@1.0.10: /usr
+        version: [1.0.10]
+    libtool:
+        paths:
+            libtool@2.4.2: /usr
+        version: [2.4.2]
+    m4:
+        paths:
+            m4@1.4.16: /usr
+        version: [1.4.16]
+    ncurses:
+        paths:
+            ncurses@5.9: /usr
+        version: [5.9]
+    pango:
+        paths:
+            pango@1.40.4: /usr
+        version: [1.40.4]
+    pcre:
+        paths:
+            pcre@8.32: /usr
+        version: [8.32]
+    perl:
+        paths:
+            perl@5.16.3: /usr
+        version: [5.16.3]
+    pkg-config:
+        paths:
+            pkg-config@0.27.1: /usr
+        version: [0.27.1]
+    readline:
+        paths:
+            readline@6.2.10: /usr
+        version: [6.2.10]
+    slurm:
+        paths:
+            slurm@17.02: /usr
+        buildable: False
+        version: [17.02]
+    sqlite:
+        paths:
+            sqlite@3.7.17: /usr
+        version: [3.7.17]
+    tar:
+        paths:
+            tar@1.26: /usr
+        version: [1.26]
+    tcl:
+        paths:
+            tcl@8.5.13: /usr
+        version: [8.5.13]
+    tk:
+        paths:
+            tk@8.5.13: /usr
+        version: [8.5.13]
+    xz:
+        paths:
+            xz@5.2: /usr
+        version: [5.2]
+    gcc:
+        paths:
+            gcc@5.4.0%gcc@4.8.5: $APPS_DIR_PATH/compilers/gcc-5.4.0
+            gcc@6.4.0%gcc@4.8.5: $APPS_DIR_PATH/compilers/gcc-6.4.0
+            gcc@7.3.0%gcc@4.8.5: $APPS_DIR_PATH/compilers/gcc-7.3.0
+        version: [5.4.0, 6.4.0, 7.3.0]
+    llvm:
+        paths:
+            llvm@4.0.1%gcc@4.8.5: $APPS_DIR_PATH/compilers/llvm-4.0.1
+            llvm@5.0.1%gcc@4.8.5: $APPS_DIR_PATH/compilers/llvm-5.0.1
+        version: [4.0.1, 5.0.1]
+    intel-parallel-studio:
+        paths:
+            intel-parallel-studio@cluster.2018.1%gcc@4.8.5: $APPS_DIR_PATH/compilers/intel-parallel-studio-cluster.2018.1
+        version: [cluster.2018.1]
+    intel:
+        paths:
+            intel@18.0.1%gcc@4.8.5: $APPS_DIR_PATH/compilers/intel-parallel-studio-cluster.2018.1
+        version: [18.0.1]
+    pgi:
+        paths:
+            pgi@17.10%gcc@4.8.5: $APPS_DIR_PATH/compilers/pgi-17.10
+        version: [17.10]

--- a/sysconfig/bbpv/tools/packages.yaml
+++ b/sysconfig/bbpv/tools/packages.yaml
@@ -11,6 +11,14 @@ packages:
         paths:
             bison@3.0.4: /usr
         version: [3.0.4]
+    boost:
+        paths:
+            boost@1.53.0: /usr
+        version: [1.53.0]
+    bzip2:
+        paths:
+            bzip2@1.0.6: /usr
+        version: [1.0.6]
     cairo:
         paths:
             cairo@1.8.10: /usr
@@ -35,6 +43,10 @@ packages:
         paths:
             glib@2.50.3: /usr
         version: [2.50.3]
+    gtkplus:
+        paths:
+            gtkplus@2.24.31: /usr
+        version: [2.24.31]
     hwloc:
         paths:
             hwloc@1.11.2: /usr
@@ -47,6 +59,10 @@ packages:
         paths:
             libjpeg@1.2.90: /usr
         version: [1.2.90]
+    libgcrypt:
+        paths:
+            libgcrypt@1.5.3: /usr
+        version: [1.5.3]
     libmng:
         paths:
             libmng@1.0.10: /usr
@@ -55,6 +71,10 @@ packages:
         paths:
             libtool@2.4.2: /usr
         version: [2.4.2]
+    libxml2:
+        paths:
+            libxml2@2.9.1: /usr
+        version: [2.9.1]
     m4:
         paths:
             m4@1.4.16: /usr
@@ -79,6 +99,14 @@ packages:
         paths:
             pkg-config@0.27.1: /usr
         version: [0.27.1]
+    python:
+        paths:
+            python@2.7.13: /usr
+        version: [2.7.13]
+    py-pygtk:
+        paths:
+            py-pygtk@2.24.0: /usr
+        version: [2.24.0]
     readline:
         paths:
             readline@6.2.10: /usr
@@ -88,6 +116,10 @@ packages:
             slurm@17.02: /usr
         buildable: False
         version: [17.02]
+    swig:
+        paths:
+            swig@2.0.10: /usr
+        version: [2.0.10]
     sqlite:
         paths:
             sqlite@3.7.17: /usr
@@ -108,6 +140,10 @@ packages:
         paths:
             xz@5.2: /usr
         version: [5.2]
+    zlib:
+        paths:
+            zlib@1.2.7: /usr
+        version: [1.2.7]
     gcc:
         paths:
             gcc@5.4.0%gcc@4.8.5: $APPS_DIR_PATH/compilers/install/gcc-5.4.0

--- a/sysconfig/bbpv/tools/packages.yaml
+++ b/sysconfig/bbpv/tools/packages.yaml
@@ -107,10 +107,6 @@ packages:
         paths:
             py-pygtk@2.24.0: /usr
         version: [2.24.0]
-    readline:
-        paths:
-            readline@6.2.10: /usr
-        version: [6.2.10]
     slurm:
         paths:
             slurm@17.02: /usr

--- a/sysconfig/bbpv/tools/packages.yaml
+++ b/sysconfig/bbpv/tools/packages.yaml
@@ -110,24 +110,27 @@ packages:
         version: [5.2]
     gcc:
         paths:
-            gcc@5.4.0%gcc@4.8.5: $APPS_DIR_PATH/compilers/gcc-5.4.0
-            gcc@6.4.0%gcc@4.8.5: $APPS_DIR_PATH/compilers/gcc-6.4.0
-            gcc@7.3.0%gcc@4.8.5: $APPS_DIR_PATH/compilers/gcc-7.3.0
+            gcc@5.4.0%gcc@4.8.5: $APPS_DIR_PATH/compilers/install/gcc-5.4.0
+            gcc@6.4.0%gcc@4.8.5: $APPS_DIR_PATH/compilers/install/gcc-6.4.0
+            gcc@7.3.0%gcc@4.8.5: $APPS_DIR_PATH/compilers/install/gcc-7.3.0
         version: [5.4.0, 6.4.0, 7.3.0]
-    llvm:
-        paths:
-            llvm@4.0.1%gcc@4.8.5: $APPS_DIR_PATH/compilers/llvm-4.0.1
-            llvm@5.0.1%gcc@4.8.5: $APPS_DIR_PATH/compilers/llvm-5.0.1
-        version: [4.0.1, 5.0.1]
-    intel-parallel-studio:
-        paths:
-            intel-parallel-studio@cluster.2018.1%gcc@4.8.5: $APPS_DIR_PATH/compilers/intel-parallel-studio-cluster.2018.1
-        version: [cluster.2018.1]
     intel:
         paths:
-            intel@18.0.1%gcc@4.8.5: $APPS_DIR_PATH/compilers/intel-parallel-studio-cluster.2018.1
+            intel@18.0.1%gcc@4.8.5: $APPS_DIR_PATH/compilers/install/intel-parallel-studio-cluster.2018.1
         version: [18.0.1]
     pgi:
         paths:
-            pgi@17.10%gcc@4.8.5: $APPS_DIR_PATH/compilers/pgi-17.10
+            pgi@17.10%gcc@4.8.5: $APPS_DIR_PATH/compilers/install/pgi-17.10
         version: [17.10]
+
+    intel-parallel-studio:
+        paths:
+            intel-parallel-studio@cluster.2018.1%gcc: $APPS_DIR_PATH/compilers/install/intel-parallel-studio-cluster.2018.1
+            intel-parallel-studio@cluster.2018.1%intel: $APPS_DIR_PATH/compilers/install/intel-parallel-studio-cluster.2018.1
+            intel-parallel-studio@cluster.2018.1%pgi: $APPS_DIR_PATH/compilers/install/intel-parallel-studio-cluster.2018.1
+        buildable: False
+        version: [cluster.2018.1]
+    all:
+        compiler: [gcc, intel]
+        providers:
+            mpi: [intel-parallel-studio]

--- a/var/spack/repos/builtin/packages/allinea-forge/package.py
+++ b/var/spack/repos/builtin/packages/allinea-forge/package.py
@@ -33,7 +33,8 @@ class AllineaForge(Package):
 
     homepage = "http://www.allinea.com/products/develop-allinea-forge"
 
-    version('6.0.4', 'df7f769975048477a36f208d0cd57d7e')
+    version('6.0', 'c85fec6d01680b5b46fea80111186244')
+    version('7.0', 'b70f4b140a71a5db0791d44684ac6cb5')
 
     # Licensing
     license_required = True
@@ -45,8 +46,8 @@ class AllineaForge(Package):
     def url_for_version(self, version):
         # TODO: add support for other architectures/distributions
         url = "http://content.allinea.com/downloads/"
-        return url + "allinea-forge-%s-Redhat-6.0-x86_64.tar" % version
+        return url + "arm-forge-latest-Redhat-%s-x86_64.tar" % version
 
     def install(self, spec, prefix):
-        textinstall = Executable('./textinstall.sh')
-        textinstall('--accept-licence', prefix)
+        bash = which("bash")
+        bash('./textinstall.sh', '--accept-licence', prefix)

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -58,6 +58,8 @@ class Dyninst(Package):
     patch('stat_dysect.patch', when='+stat_dysect')
     patch('stackanalysis_h.patch', when='@9.2.0')
 
+    parallel = False
+
     # new version uses cmake
     def install(self, spec, prefix):
         if spec.satisfies('@:8.1'):

--- a/var/spack/repos/builtin/packages/imb/package.py
+++ b/var/spack/repos/builtin/packages/imb/package.py
@@ -1,0 +1,56 @@
+##############################################################################
+# Copyright (c) 2013-2017, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+from shutil import copyfile
+from shutil import copymode
+import sys
+import os
+
+
+class Imb(MakefilePackage):
+    """Intel MPI Benchmark"""
+
+    homepage = "https://github.com/intel/mpi-benchmarks.git"
+    url      = "https://github.com/intel/mpi-benchmarks.git"
+
+    version('master',  git=url)
+
+    depends_on('mpi')
+
+    def edit(self, spec, prefix):
+        os.chdir("src")
+        makefile = FileFilter('make_ict')
+        makefile.filter('CC          = .*', 'CC = %s' %
+                            self.spec['mpi'].mpicc)
+
+    def build(self, spec, prefix):
+        make()
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        imb = join_path(prefix.bin, "IMB-MPI1")
+        copyfile("IMB-MPI1", imb)
+        chmod = which('chmod')
+        chmod('+x', imb)

--- a/var/spack/repos/builtin/packages/stat/package.py
+++ b/var/spack/repos/builtin/packages/stat/package.py
@@ -47,6 +47,7 @@ class Stat(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
     depends_on('libdwarf')
+    depends_on('binutils+libiberty')
     depends_on('dyninst', when='~dysect')
     depends_on('dyninst@8.2.1+stat_dysect', when='+dysect')
     depends_on('graphlib@2.0.0', when='@2.0.0:2.2.0')


### PR DESCRIPTION
From now on, we will be using develop branch for deployment.
At the time of new deployment, we will tag develop to new release.
This PR brings all `bbpv-*` changes to develop.