### PR TITLE
fixed tau package.py to be python 3.6 compatible

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 import os
+import stat
 import sys
 import glob
 from llnl.util.filesystem import join_path
@@ -227,7 +228,9 @@ class Tau(Package):
             content += 'fi'
             f.write(content)
             f.close()
-            os.chmod(fname, 0755)
+            os.chmod(fname, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+                            stat.S_IRGRP | stat.S_IXGRP |
+                            stat.S_IROTH | stat.S_IXOTH)
 
     def get_makefiles(self):
         pattern = join_path(self.prefix.lib, 'Makefile.*')


### PR DESCRIPTION
replaced numeric chmod permission with stat bits
this makes the code py2 and py3 compatible