### PR TITLE
Added setgid option for likwid

### DIFF
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -115,9 +115,12 @@ class Likwid(Package):
         env['PWD'] = os.getcwd()
         make()
         make('install')
-        if spec.satisfies('+setgid'):
-          accessD = os.path.join(prefix,'sbin','likwid-accessD')
-          chgrp = which('chgrp')
-          chmod = which('chmod')
-          chgrp('likwid', accessD)
-          chmod('g+s', accessD)
+
+    @run_after('install')
+    def change_group(self):
+        accessD = join_path(self.prefix.sbin, 'likwid-accessD')
+        if self.spec.satisfies('+setgid'):
+            chgrp = which('chgrp')
+            chmod = which('chmod')
+            chgrp('likwid', accessD)
+            chmod('g+s', accessD)

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -54,8 +54,8 @@ class Likwid(Package):
     depends_on('perl', type=('build', 'run'))
 
     variant('setgid', default=False, description='enable setgid flag '
-            + 'for likwid-accessD and change its group to likwid. '
-            + 'Note: this requires the likwid group to already exist.')
+            + 'for likwid-accessD and change its group to LIWKID_GROUP. '
+            + 'Note: set LIWKID_GROUP env variable')
 
     conflicts('+setgid', when='@:4.0.1')  # accessD was added in 4.1
 
@@ -120,7 +120,10 @@ class Likwid(Package):
     def change_group(self):
         accessD = join_path(self.prefix.sbin, 'likwid-accessD')
         if self.spec.satisfies('+setgid'):
+            likwid_group = 'likwid'
+            if 'LIKWID_GROUP' in os.environ:
+                likwid_group = os.environ['LIKWID_GROUP']
             chgrp = which('chgrp')
             chmod = which('chmod')
-            chgrp('likwid', accessD)
+            chgrp(likwid_group, accessD)
             chmod('g+s', accessD)

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -53,6 +53,12 @@ class Likwid(Package):
 
     depends_on('perl', type=('build', 'run'))
 
+    variant('setgid', default=False, description='enable setgid flag '
+            + 'for likwid-accessD and change its group to likwid. '
+            + 'Note: this requires the likwid group to already exist.')
+
+    conflicts('+setgid', when='@:4.0.1')  # accessD was added in 4.1
+
     supported_compilers = {'clang': 'CLANG', 'gcc': 'GCC', 'intel': 'ICC'}
 
     def patch(self):
@@ -109,3 +115,9 @@ class Likwid(Package):
         env['PWD'] = os.getcwd()
         make()
         make('install')
+        if spec.satisfies('+setgid'):
+          accessD = os.path.join(prefix,'sbin','likwid-accessD')
+          chgrp = which('chgrp')
+          chmod = which('chmod')
+          chgrp('likwid', accessD)
+          chmod('g+s', accessD)


### PR DESCRIPTION
This feature is needed because msr and PCI devices need elevated privileges. Using the setgid trick described here:
https://github.com/RRZE-HPC/likwid/wiki/likwid-accessD
we can accomplish this securely.