### PR TITLE
Set KMP_INIT_AT_FORK to FALSE in likwid module to avoid

### DIFF
--- a/sysconfig/bbpv/tools/modules.yaml
+++ b/sysconfig/bbpv/tools/modules.yaml
@@ -76,6 +76,10 @@ modules:
       - '%clang'
       - '%pgi'
       - 'cmake'
+    likwid:
+      environment:
+        set:
+          KMP_INIT_AT_FORK: 'FALSE'
   tcl:
     all:
       filter:
@@ -128,3 +132,7 @@ modules:
       - '%clang'
       - '%pgi'
       - 'cmake'
+    likwid:
+      environment:
+        set:
+          KMP_INIT_AT_FORK: 'FALSE'


### PR DESCRIPTION
issue with likwid + Intel compiler.

(see https://github.com/RRZE-HPC/likwid/issues/157 and https://bbpteam.epfl.ch/project/issues/browse/HELP-8691)