### PR TITLE
Revert "Use YAML merge key to factor configuration"

### DIFF
--- a/sysconfig/bb5/compilers/modules.yaml
+++ b/sysconfig/bb5/compilers/modules.yaml
@@ -21,7 +21,21 @@ modules:
       - PKG_CONFIG_PATH
     '':
       - CMAKE_PREFIX_PATH
-  tcl: &tcl_config
+  lmod:
+    core_compilers:
+      - 'gcc@4.8.5'
+    hash_length: 0
+    whitelist:
+      - 'gcc'
+      - 'pgi'
+      - 'intel-parallel-studio'
+      - 'llvm'
+    blacklist:
+      - '%gcc'
+    all:
+      filter:
+        environment_blacklist: ['CPATH', 'LIBRARY_PATH']
+  tcl:
     all:
       filter:
         environment_blacklist: ['CPATH', 'LIBRARY_PATH']
@@ -29,12 +43,8 @@ modules:
     hash_length: 0
     whitelist:
       - 'gcc'
+      - 'pgi'
       - 'intel-parallel-studio'
       - 'llvm'
-      - 'pgi'
     blacklist:
       - '%gcc'
-  lmod:
-    <<: *tcl_config
-    core_compilers:
-      - 'gcc@4.8.5'


### PR DESCRIPTION
This reverts commit f6355144936d3686359f224344c7d76902616cec.

@tristan0x : reverting this for now because some yaml stuff in spack not parsing configs correctly. I have asked about this upstream. I will re-apply this once got fixed.