### PR TITLE
Adding ime version for OpenMPI and MVAPICH2 (provided by DDN)

### DIFF
--- a/sysconfig/bb5/tools/modules.yaml
+++ b/sysconfig/bb5/tools/modules.yaml
@@ -70,13 +70,11 @@ modules:
       - imb
       - osu-micro-benchmarks
       - stat
-      - 'cmake%gcc@4.8.5'
     blacklist:
       - '%gcc'
       - '%intel'
       - '%clang'
       - '%pgi'
-      - 'cmake'
     likwid@:4.3.1:
       environment:
         set:
@@ -127,13 +125,11 @@ modules:
       - likwid
       - hpl
       - imb
-      - 'cmake%gcc@4.8.5'
     blacklist:
       - '%gcc'
       - '%intel'
       - '%clang'
       - '%pgi'
-      - 'cmake'
     likwid@:4.3.1:
       environment:
         set:

--- a/sysconfig/bb5/tools/packages.yaml
+++ b/sysconfig/bb5/tools/packages.yaml
@@ -176,6 +176,14 @@ packages:
             hpe-mpi%intel: /opt/hpe/hpc/mpt/mpt-2.16
             hpe-mpi%pgi: /opt/hpe/hpc/mpt/mpt-2.16
         version: [2.16]
+    mvapich2:
+        paths:
+            mvapich2@ime: /opt/ddn/mvapich
+        version: [ime]
+    openmpi:
+        paths:
+            openmpi@ime: /opt/ddn/openmpi
+        version: [ime]
     all:
         compiler: [gcc@4.8.5, gcc@5.4.0, intel]
         providers:

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -44,6 +44,9 @@ class Mvapich2(AutotoolsPackage):
     # Newer alpha release
     version('2.3a', '87c3fbf8a755b53806fa9ecb21453445')
 
+    # hpe-ddn specific external versions for ime
+    version('ime', 'nonexistenthash')
+
     # Prefer the latest stable release
     version('2.2', '939b65ebe5b89a5bc822cdab0f31f96e', preferred=True)
     version('2.1', '0095ceecb19bbb7fb262131cb9c2cdd6')

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -82,6 +82,9 @@ class Openmpi(AutotoolsPackage):
     # Current
     version('3.0.0', '757d51719efec08f9f1a7f32d58b3305')  # libmpi.so.40.00.0
 
+    # hpe-ddn specific external versions for ime
+    version('ime', 'nonexistenthash')
+
     # Still supported
     version('2.1.2', 'ff2e55cc529802e7b0738cf87acd3ee4')  # libmpi.so.20.10.2
     version('2.1.1', 'ae542f5cf013943ffbbeb93df883731b')  # libmpi.so.20.10.1


### PR DESCRIPTION
  - updated modules/tools configuration
  - remove un-necessary cmake module (which was system installed package)