### PR TITLE
Adding BBP/HBP cellular simulation packages

### DIFF
--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -1,0 +1,139 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+
+
+class Coreneuron(CMakePackage):
+
+    """CoreNEURON is a simplified engine for the NEURON simulator
+    optimised for both memory usage and computational speed. Its goal
+    is to simulate massive cell networks with minimal memory footprint
+    and optimal performance."""
+
+    homepage = "https://github.com/BlueBrain/CoreNeuron"
+    url      = "https://github.com/BlueBrain/CoreNeuron"
+
+    version('develop', git=url, submodules=True)
+    version('hippocampus', git=url, submodules=True)
+    version('plasticity', git=url, branch='profile_update', preferred=True, submodules=True)
+
+    variant('gpu', default=False, description="Enable GPU build")
+    variant('knl', default=False, description="Enable KNL specific flags")
+    variant('mpi', default=True, description="Enable MPI support")
+    variant('openmp', default=True, description="Enable OpenMP support")
+    variant('profile', default=False, description="Enable profiling using Tau")
+    variant('report', default=True, description="Enable reports using ReportingLib")
+    variant('shared', default=True, description="Build shared library")
+    variant('tests', default=False, description="Enable building tests")
+
+    depends_on('boost', when='+tests')
+    depends_on('cmake@3:', type='build')
+    depends_on('cuda', when='+gpu')
+    depends_on('mpi', when='+mpi')
+    depends_on('neurodamus-base@plasticity', when='@plasticity')
+    depends_on('neurodamus-base@hippocampus', when='@hippocampus')
+    depends_on('reportinglib', when='+report')
+    depends_on('reportinglib+profile', when='+report+profile')
+    depends_on('tau', when='+profile')
+
+    @run_before('build')
+    def profiling_wrapper_on(self):
+        os.environ["USE_PROFILER_WRAPPER"] = "1"
+
+    @run_after ('install')
+    def profiling_wrapper_off(self):
+        del os.environ["USE_PROFILER_WRAPPER"]
+
+    def get_flags(self):
+        flags = "-g -O2"
+        if 'bgq' in self.spec.architecture and '%xl' in self.spec:
+            flags = '-O3 -qtune=qp -qarch=qp -q64 -qhot=simd -qsmp -qthreaded -g'
+        if '+knl' in self.spec and '%intel' in self.spec:
+            flags = '-g -xMIC-AVX512 -O2 -qopt-report=5'
+        if '+profile' in self.spec:
+            flags += ' -DTAU'
+        return flags
+
+    def cmake_args(self):
+        spec   = self.spec
+        flags = self.get_flags()
+
+        if spec.satisfies('+profile'):
+            env['CC']  = 'tau_cc'
+            env['CXX'] = 'tau_cxx'
+        elif 'bgq' in spec.architecture and spec.satisfies('+mpi'):
+            env['CC']  = spec['mpi'].mpicc
+            env['CXX'] = spec['mpi'].mpicxx
+
+        options = ['-DENABLE_SPLAYTREE_QUEUING=ON',
+                   '-DCMAKE_C_FLAGS=%s' % flags,
+                   '-DCMAKE_CXX_FLAGS=%s' % flags,
+                   '-DCMAKE_BUILD_TYPE=CUSTOM',
+                   '-DENABLE_REPORTINGLIB=%s' % ('ON' if '+report' in spec else 'OFF'),
+                   '-DENABLE_MPI=%s' % ('ON' if '+mpi' in spec else 'OFF'),
+                   '-DCORENEURON_OPENMP=%s' % ('ON' if '+openmp' in spec else 'OFF'),
+                   '-DUNIT_TESTS=%s' % ('ON' if '+tests' in spec else 'OFF'),
+                   '-DFUNCTIONAL_TESTS=%s' % ('ON' if '+tests' in spec else 'OFF')
+                   ]
+
+        if spec.satisfies('~shared'):
+            options.append('-DCOMPILE_LIBRARY_TYPE=STATIC')
+
+        if 'bgq' in spec.architecture and '%xl' in spec:
+            options.append('-DCMAKE_BUILD_WITH_INSTALL_RPATH=1')
+
+        if spec.satisfies('+gpu'):
+            gcc = which("gcc")
+            options.extend(['-DCUDA_HOST_COMPILER=%s' % gcc,
+                            '-DCUDA_PROPAGATE_HOST_FLAGS=OFF',
+                            '-DENABLE_SELECTIVE_GPU_PROFILING=ON',
+                            '-DENABLE_OPENACC=ON',
+                            '-DENABLE_OPENACC_INFO=ON'])
+            # PGI compiler not able to compile nrnreport.cpp when enabled
+            # OpenMP, OpenACC and Reporting. Disable ReportingLib for GPU
+            options.append('-DENABLE_REPORTINGLIB=OFF')
+
+        if '^neurodamus-base' in spec:
+            modlib_dir = self.spec['neurodamus-base'].prefix.lib.modlib
+            modfile_list = '%s/coreneuron_modlist.txt' % modlib_dir
+            options.append('-DADDITIONAL_MECHS=%s' % modfile_list)
+            options.append('-DADDITIONAL_MECHPATH=%s' % modlib_dir)
+
+        return options
+
+    @property
+    def libs(self):
+        """Export the coreneuron library.
+        Sample usage: spec['coreneuron'].libs.ld_flags
+        """
+        search_paths = [[self.prefix.lib, False], [self.prefix.lib64, False]]
+        is_shared = '+shared' in self.spec
+        for path, recursive in search_paths:
+            libs = find_libraries('libcoreneuron', root=path,
+                                  shared=is_shared, recursive=False)
+            if libs:
+                return libs
+        return None

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -40,6 +40,7 @@ class Coreneuron(CMakePackage):
     version('hippocampus', git=url, submodules=True)
     version('plasticity', git=url, preferred=True, submodules=True)
 
+    variant('debug', default=False, description='Build debug with O0')
     variant('gpu', default=False, description="Enable GPU build")
     variant('knl', default=False, description="Enable KNL specific flags")
     variant('mpi', default=True, description="Enable MPI support")
@@ -73,6 +74,8 @@ class Coreneuron(CMakePackage):
             flags = '-O3 -qtune=qp -qarch=qp -q64 -qhot=simd -qsmp -qthreaded -g'
         if '+knl' in self.spec and '%intel' in self.spec:
             flags = '-g -xMIC-AVX512 -O2 -qopt-report=5'
+        if '+debug' in self.spec:
+            flags = '-g -O0'
         if '+profile' in self.spec:
             flags += ' -DTAU'
         return flags

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -38,7 +38,7 @@ class Coreneuron(CMakePackage):
 
     version('develop', git=url, submodules=True)
     version('hippocampus', git=url, submodules=True)
-    version('plasticity', git=url, branch='profile_update', preferred=True, submodules=True)
+    version('plasticity', git=url, preferred=True, submodules=True)
 
     variant('gpu', default=False, description="Enable GPU build")
     variant('knl', default=False, description="Enable KNL specific flags")

--- a/var/spack/repos/builtin/packages/mod2c/package.py
+++ b/var/spack/repos/builtin/packages/mod2c/package.py
@@ -1,0 +1,49 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+
+
+class Mod2c(CMakePackage):
+
+    """MOD2C is NMODL to C converter adapted for CoreNEURON simulator.
+    More information about NMODL can be found NEURON simulator
+    documentation at Yale University."""
+
+    homepage = "https://github.com/BlueBrain/mod2c"
+    url      = "https://github.com/BlueBrain/mod2c.git"
+
+    version('develop', git=url, preferred=True)
+
+    depends_on('cmake@2.8.12:', type='build')
+
+    def cmake_args(self):
+        spec = self.spec
+        options = []
+        if 'bgq' in spec.architecture and '%xl' in spec:
+            options.append('-DCMAKE_BUILD_WITH_INSTALL_RPATH=1')
+        return options
+
+    def setup_environment(self, spack_env, run_env):
+        run_env.set('MODLUNIT', join_path(self.prefix, 'share/nrnunits.lib'))

--- a/var/spack/repos/builtin/packages/neurodamus-base/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-base/package.py
@@ -1,0 +1,41 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+import shutil
+
+
+class NeurodamusBase(Package):
+    """Library of channels developed by Blue Brain Project, EPFL"""
+
+    homepage = "ssh://bbpcode.epfl.ch/sim/neurodamus/bbp"
+    url      = "ssh://bbpcode.epfl.ch/sim/neurodamus/bbp"
+
+    version('master',      git=url)
+    version('hippocampus', git=url, branch='sandbox/king/hippocampus')
+    version('plasticity',  git=url, branch='sandbox/king/saveupdate_v6support_mask', preferred=True)
+
+    def install(self, spec, prefix):
+        shutil.copytree('lib', '%s/lib' % (prefix), symlinks=False)

--- a/var/spack/repos/builtin/packages/neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus/package.py
@@ -1,0 +1,103 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+from spack.pkg.builtin.neurodamus_base import NeurodamusBase
+import llnl.util.tty as tty
+import os
+
+
+class Neurodamus(NeurodamusBase):
+
+    """Package used for building special from NeurodamusBase package"""
+
+    variant('coreneuron', default=True, description="Enable CoreNEURON Support")
+    variant('profile', default=False, description="Enable profiling using Tau")
+
+    depends_on("hdf5")
+    depends_on("mpi")
+    depends_on("neuron")
+    depends_on('reportinglib')
+    depends_on("zlib")
+
+    depends_on('coreneuron', when='+coreneuron')
+    depends_on('coreneuron+profile', when='+profile')
+    depends_on('coreneuron@plasticity', when='@plasicity')
+    depends_on('coreneuron@hippocampus', when='@hippocampus')
+
+    depends_on('neurodamus-base@master', when='@master')
+    depends_on('neurodamus-base@hippocampus', when='@hippocampus')
+    depends_on('neurodamus-base@plasticity', when='@plasicity')
+
+    depends_on("neuron+profile", when='+profile')
+    depends_on('reportinglib+profile', when='+profile')
+    depends_on('tau', when='+profile')
+
+    # coreneuron support is available for plasticity model
+    # and requires python support in neuron
+    conflicts('@hippocampus', when='+coreneuron')
+    conflicts('@master', when='+coreneuron')
+    conflicts('^neuron~python', when='+coreneuron')
+
+    @run_before('install')
+    def profiling_wrapper_on(self):
+        os.environ["USE_PROFILER_WRAPPER"] = "1"
+
+    @run_after('install')
+    def profiling_wrapper_off(self):
+        del os.environ["USE_PROFILER_WRAPPER"]
+
+    def install(self, spec, prefix):
+        with working_dir(prefix):
+            modlib = os.path.relpath(self.spec['neurodamus-base'].prefix.lib.modlib)
+            profile_flag = '-DENABLE_TAU_PROFILER' if '+profile' in spec else ''
+            include_flag = ''
+            link_flag = ''
+
+            if '+coreneuron' in spec:
+                include_flag += ' -DENABLE_CORENEURON -I%s' % (spec['coreneuron'].prefix.include)
+                link_flag += ' %s' % (spec['coreneuron'].libs.ld_flags)
+
+            include_flag += ' -I%s -I%s %s' % (spec['reportinglib'].prefix.include,
+                                              spec['hdf5'].prefix.include,
+                                              profile_flag)
+            link_flag += ' %s -L%s -lhdf5 -L%s -lz' % (
+                         spec['reportinglib'].libs.ld_flags,
+                         spec['hdf5'].prefix.lib,
+                         spec['zlib'].prefix.lib)
+
+            nrnivmodl = which('nrnivmodl')
+            nrnivmodl('-incflags', include_flag,
+                      '-loadflags', link_flag,
+                      modlib)
+
+    @run_after('install')
+    def check_install(self):
+        special = '%s/special' % join_path(self.prefix, os.path.basename(self.neuron_archdir))
+        if not os.path.isfile(special):
+            raise RuntimeError("Neurodamus installion check failed, %s not created!" % special)
+
+    def setup_environment(self, spack_env, run_env):
+        run_env.prepend_path('PATH', join_path(self.prefix, os.path.basename(self.neuron_archdir)))
+        run_env.set('HOC_LIBRARY_PATH', self.spec['neurodamus-base'].prefix.lib.hoclib)

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -50,7 +50,6 @@ class Neuron(Package):
     variant('coreneuron',    default=True, description="Patch hh.mod for CoreNEURON compatibility")
     variant('cross-compile', default=False, description='Build for cross-compile environment')
     variant('debug',         default=False, description='Build debug with O0')
-    variant('knl',           default=False, description="Enable KNL specific flags")
     variant('mpi',           default=True,  description='Enable MPI parallelism')
     variant('multisend',     default=True,  description="Enable multi-send spike exchange")
     variant('profile',       default=False, description="Enable Tau profiling")

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -44,26 +44,30 @@ class Neuron(Package):
     version('7.4', '2c0bbee8a9e55d60fa26336f4ab7acbf')
     version('7.3', '993e539cb8bf102ca52e9fefd644ab61')
     version('7.2', '5486709b6366add932e3a6d141c4f7ad')
-    version('develop', git=github)
+    version('develop', git=github, commit='be4357579', preferred=True)
 
-    variant('mpi',           default=True,  description='Enable MPI parallelism')
-    variant('python',        default=True,  description='Enable python')
-    variant('shared',        default=False, description='Build shared libraries')
+    variant('binary',        default=True, description="Create special as a binary instead of shell script")
+    variant('coreneuron',    default=True, description="Patch hh.mod for CoreNEURON compatibility")
     variant('cross-compile', default=False, description='Build for cross-compile environment')
+    variant('knl',           default=False, description="Enable KNL specific flags")
+    variant('mpi',           default=True,  description='Enable MPI parallelism')
     variant('multisend',     default=True,  description="Enable multi-send spike exchange")
+    variant('profile',       default=False, description="Enable Tau profiling")
+    variant('python',        default=True,  description='Enable python')
+    variant('shared',        default=True, description='Build shared libraries')
     variant('rx3d',          default=False, description="Enable cython translated 3-d rxd")
 
-    depends_on('flex',       type='build')
-    depends_on('bison',      type='build')
-    depends_on('automake',   type='build')
-    depends_on('automake',   type='build')
     depends_on('autoconf',   type='build')
+    depends_on('automake',   type='build')
+    depends_on('bison',      type='build')
+    depends_on('flex',       type='build')
     depends_on('libtool',    type='build')
     depends_on('pkg-config', type='build')
 
     depends_on('mpi',         when='+mpi')
-    depends_on('python@2.6:', when='+python')
     depends_on('ncurses',     when='~cross-compile')
+    depends_on('python@2.6:', when='+python')
+    depends_on('tau',         when='+profile')
 
     conflicts('~shared', when='+python')
 
@@ -92,6 +96,17 @@ class Neuron(Package):
         newpath = 'aclocal -I m4 %s %s' % (pkgconf_inc, libtool_inc)
         filter_file(r'aclocal -I m4', r'%s' % newpath, "build.sh")
 
+        # patch hh.mod to be compatible with coreneuron
+        if self.spec.satisfies('+coreneuron'):
+            filter_file(r'GLOBAL minf', r'RANGE minf', 'src/nrnoc/hh.mod')
+            filter_file(r'TABLE minf', r':TABLE minf', "src/nrnoc/hh.mod")
+
+    def profiling_wrapper_on(self):
+        os.environ["USE_PROFILER_WRAPPER"] = "1"
+
+    def profiling_wrapper_off(self):
+        del os.environ["USE_PROFILER_WRAPPER"]
+
     def get_arch_options(self, spec):
         options = []
 
@@ -99,7 +114,6 @@ class Neuron(Package):
             options.extend(['cross_compiling=yes',
                             '--without-memacs',
                             '--without-nmodl'])
-
         # need to enable bg-q arch
         if 'bgq' in self.spec.architecture:
             options.extend(['--enable-bluegeneQ',
@@ -169,7 +183,6 @@ class Neuron(Package):
         make('install')
 
     def install(self, spec, prefix):
-
         options = ['--prefix=%s' % prefix,
                    '--without-iv',
                    '--without-x',
@@ -189,12 +202,22 @@ class Neuron(Package):
             options.append('--without-paranrn')
 
         if spec.satisfies('~shared'):
-            options.extend(['--disable-shared',
-                            'linux_nrnmech=no'])
+            options.append('--disable-shared')
+
+        if spec.satisfies('+binary'):
+            options.append('linux_nrnmech=no')
 
         options.extend(self.get_arch_options(spec))
         options.extend(self.get_python_options(spec))
         options.extend(self.get_compiler_options(spec))
+
+        # -M option to Tau disables instrumentation
+        if spec.satisfies('+profile'):
+            options.extend(['--disable-dependency-tracking',
+                            'CC=%s' % 'tau_cc',
+                            'CXX=%s' % 'tau_cxx',
+                            'MPICC=%s' % 'tau_cc',
+                            'MPICXX=%s' % 'tau_cxx'])
 
         build = Executable('./build.sh')
         build()
@@ -205,8 +228,26 @@ class Neuron(Package):
             srcpath = self.stage.source_path
             configure = Executable(join_path(srcpath, 'configure'))
             configure(*options)
+            self.profiling_wrapper_on()
             make('VERBOSE=1')
             make('install')
+            self.profiling_wrapper_off()
+
+    @run_after('install')
+    def filter_compilers(self):
+        """run after install to avoid spack compiler wrappers
+        getting embded into nrnivmodl script"""
+
+        arch = self.get_neuron_archdir()
+        nrnmakefile = join_path(self.prefix, arch, 'bin/nrniv_makefile')
+
+        kwargs = {
+            'backup': False,
+            'string': True
+        }
+
+        filter_file(env['CC'],  self.compiler.cc, nrnmakefile, **kwargs)
+        filter_file(env['CXX'], self.compiler.cxx, nrnmakefile, **kwargs)
 
     def setup_environment(self, spack_env, run_env):
         neuron_archdir = self.get_neuron_archdir()
@@ -219,3 +260,7 @@ class Neuron(Package):
         spack_env.prepend_path('PATH', join_path(neuron_archdir, 'bin'))
         spack_env.prepend_path(
             'LD_LIBRARY_PATH', join_path(neuron_archdir, 'lib'))
+
+    def setup_dependent_package(self, module, dependent_spec):
+        neuron_archdir = self.get_neuron_archdir()
+        dependent_spec.package.neuron_archdir = neuron_archdir

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -49,6 +49,7 @@ class Neuron(Package):
     variant('binary',        default=True, description="Create special as a binary instead of shell script")
     variant('coreneuron',    default=True, description="Patch hh.mod for CoreNEURON compatibility")
     variant('cross-compile', default=False, description='Build for cross-compile environment')
+    variant('debug',         default=False, description='Build debug with O0')
     variant('knl',           default=False, description="Enable KNL specific flags")
     variant('mpi',           default=True,  description='Enable MPI parallelism')
     variant('multisend',     default=True,  description="Enable multi-send spike exchange")
@@ -152,8 +153,11 @@ class Neuron(Package):
     def get_compiler_options(self, spec):
         flags = '-O2 -g'
 
-        if 'bgq' in self.spec.architecture:
+        if 'bgq' in spec.architecture:
             flags = '-O3 -qtune=qp -qarch=qp -q64 -qstrict -qnohot -g'
+
+        if spec.satisfies('+debug'):
+            flags = '-g -O0'
 
         if self.spec.satisfies('%pgi'):
             flags += ' ' + self.compiler.pic_flag

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -44,7 +44,7 @@ class Neuron(Package):
     version('7.4', '2c0bbee8a9e55d60fa26336f4ab7acbf')
     version('7.3', '993e539cb8bf102ca52e9fefd644ab61')
     version('7.2', '5486709b6366add932e3a6d141c4f7ad')
-    version('develop', git=github, commit='be4357579', preferred=True)
+    version('develop', git=github, preferred=True)
 
     variant('binary',        default=True, description="Create special as a binary instead of shell script")
     variant('coreneuron',    default=True, description="Patch hh.mod for CoreNEURON compatibility")

--- a/var/spack/repos/builtin/packages/reportinglib/package.py
+++ b/var/spack/repos/builtin/packages/reportinglib/package.py
@@ -1,0 +1,88 @@
+##############################################################################
+# Copyright (c) 2017, Los Alamos National Security, LLC
+# Produced at the Los Alamos National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack import *
+import os
+
+
+class Reportinglib(CMakePackage):
+
+    """Soma and full compartment report library developed by Blue Brain Project, EPFL"""
+
+    homepage = "https://bbpcode.epfl.ch/code/a/sim/reportinglib/bbp"
+    url      = "ssh://bbpcode.epfl.ch/sim/reportinglib/bbp"
+
+    version('develop', git=url, preferred=True)
+
+    variant('profile', default=False, description="Enable profiling using Tau")
+    variant('shared', default=True, description="Build shared library")
+    variant('tests', default=False, description="Build unit tests")
+
+    depends_on('cmake@2.8.12:', type='build')
+    depends_on('boost', when='+tests')
+    depends_on('mpi')
+    depends_on('tau', when='+profile')
+
+    @run_before('build')
+    def profiling_wrapper_on(self):
+        if self.spec.satisfies('+profile'):
+            os.environ["USE_PROFILER_WRAPPER"] = "1"
+
+    @run_after ('install')
+    def profiling_wrapper_off(self):
+        if self.spec.satisfies('+profile'):
+            del os.environ["USE_PROFILER_WRAPPER"]
+
+    def cmake_args(self):
+        spec   = self.spec
+        options = []
+
+        if spec.satisfies('+profile'):
+            env['CC']  = 'tau_cc'
+            env['CXX'] = 'tau_cxx'
+        elif 'bgq' in self.spec.architecture:
+            env['CC']  = spec['mpi'].mpicc
+            env['CXX'] = spec['mpi'].mpicxx
+
+        if spec.satisfies('~shared'):
+            options.append('-DCOMPILE_LIBRARY_TYPE=STATIC')
+
+        if spec.satisfies('~tests'):
+            options.append('-DUNIT_TESTS=OFF')
+
+        return options
+
+    @property
+    def libs(self):
+        """Export the reportinglib library.
+        Sample usage: spec['reportinglib'].libs.ld_flags
+        """
+        search_paths = [[self.prefix.lib, False], [self.prefix.lib64, False]]
+        is_shared = '+shared' in self.spec
+        for path, recursive in search_paths:
+            libs = find_libraries('libreportinglib', root=path,
+                                  shared=is_shared, recursive=False)
+            if libs:
+                return libs
+        return None

--- a/var/spack/repos/builtin/packages/reportinglib/package.py
+++ b/var/spack/repos/builtin/packages/reportinglib/package.py
@@ -46,13 +46,11 @@ class Reportinglib(CMakePackage):
 
     @run_before('build')
     def profiling_wrapper_on(self):
-        if self.spec.satisfies('+profile'):
-            os.environ["USE_PROFILER_WRAPPER"] = "1"
+        os.environ["USE_PROFILER_WRAPPER"] = "1"
 
     @run_after ('install')
     def profiling_wrapper_off(self):
-        if self.spec.satisfies('+profile'):
-            del os.environ["USE_PROFILER_WRAPPER"]
+        del os.environ["USE_PROFILER_WRAPPER"]
 
     def cmake_args(self):
         spec   = self.spec


### PR DESCRIPTION
These packages were part of separate report repository.
We are integrating into main BBP spack repository.
 - Added mod2c
 - Added reportinglib
 - Added coreneuron
 - Added neurondamus-base (obly mod and hoc files without compilation)
 - Added coreneuron (can be built with neurodamus-base)
 - Added neurondamus (can be built with neurodamus-base and coreneuron)
 - Updated neuron packahe (will push changes upstream soon)

Todo : may be some cleanup/cosmetic changes (?)