### PR TITLE
User configs should provide only shared library from /usr, Fixes #20

### DIFF
--- a/sysconfig/bb5/users/packages.yaml
+++ b/sysconfig/bb5/users/packages.yaml
@@ -148,7 +148,7 @@ packages:
         version: [5.2]
     zlib:
         paths:
-            zlib@1.2.7: /usr
+            zlib@1.2.7+shared: /usr
         version: [1.2.7]
     intel-parallel-studio:
         modules:


### PR DESCRIPTION
This helps to avoid installation failure if someone specifically ask for `~shared`.