### PR TITLE
Configure Intel compiler to use gcc@6.4.0 underneath instead of system gcc@4.8.5

### DIFF
--- a/sysconfig/bb5/users/compilers.yaml
+++ b/sysconfig/bb5/users/compilers.yaml
@@ -29,7 +29,8 @@ compilers:
     environment: {}
     extra_rpaths: []
     flags: {}
-    modules: []
+    modules:
+    - gcc/6.4.0
     operating_system: rhel7
     paths:
       cc: /gpfs/bbp.cscs.ch/apps/compilers/install/intel-parallel-studio-cluster.2018.1/compilers_and_libraries_2018.1.163/linux/bin/intel64/icc


### PR DESCRIPTION
@matz-e  : fixes #34.

@ohm314 @tristan0x : this is fundamental change in the sense that all stack will be built with gcc@6.4.0. Intel compiler uses system gcc/glibc by default. With this change, we load `gcc/6.4.0` and hence Intel will use new glibc. This way everything will be consistent with modern compiler.