### PR TITLE
Support intel-mpi when it is specified as external package via modules

### DIFF
--- a/sysconfig/bb5/users/packages.yaml
+++ b/sysconfig/bb5/users/packages.yaml
@@ -71,8 +71,8 @@ packages:
             intel-mkl@2018.1.163: /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mkl-2018.1.163-l32qhs
         version: [2018.1.163]
     intel-mpi:
-        paths:
-            intel-mpi@2018.1.163: /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mpi-2018.1.163-p7q2uq
+        modules:
+            intel-mpi@2018.1.163: intel-mpi/2018.1.163
         version: [2018.1.163]
     intel-parallel-studio:
         modules:

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -102,7 +102,12 @@ class IntelMpi(IntelPackage):
         # and friends are set to point to the Intel compilers, but in
         # practice, mpicc fails to compile some applications while
         # mpiicc works.
+        #
+        # Also, if intel mpi is an external package then bin directory
+        # exist in prefix directory already
         bindir = self.prefix.compilers_and_libraries.linux.mpi.intel64.bin
+        if not os.path.exists(bindir):
+            bindir = self.prefix.bin
 
         if self.compiler.name == 'intel':
             self.spec.mpicc  = bindir.mpiicc


### PR DESCRIPTION
- Also handle prefix/bin correctly

@ohm314 : this now builds `spack install petsc ^intel-mpi` fine.