### PR TITLE
git: fix bb5 users sysconfig

### DIFF
--- a/sysconfig/bb5/users/modules.yaml
+++ b/sysconfig/bb5/users/modules.yaml
@@ -30,10 +30,11 @@ modules:
     naming_scheme: '${PACKAGE}/${VERSION}'
     hash_length: 0
     whitelist:
-      - 'functionalizer'
-      - 'neurodamus'
-      - 'parquet-converters'
-      - 'touchdetector'
+      - functionalizer
+      - git
+      - neurodamus
+      - parquet-converters
+      - touchdetector
     blacklist:
       - '%gcc'
       - '%intel'

--- a/sysconfig/bb5/users/packages.yaml
+++ b/sysconfig/bb5/users/packages.yaml
@@ -39,10 +39,6 @@ packages:
         paths:
             fontconfig@2.10.95: /usr
         version: [2.10.95]
-    gettext:
-        paths:
-            gettext@0.19.8.1: /usr
-        version: [0.19.8.1]
     glib:
         paths:
             glib@2.50.3: /usr
@@ -129,7 +125,7 @@ packages:
         version: [1.40.4]
     pcre:
         paths:
-            pcre@8.32: /usr
+            pcre@8.32+jit+utf: /usr
         version: [8.32]
     perl:
         paths:


### PR DESCRIPTION
This pull-request allows me to use a recent version of git on BB5 instead of the one provided by the system. (1.8.3.1 has been released on **10-Jun-2013**)

I had to remove some system packages in `packages.yml` to make it work. I don't know if there is another way. See commit message for more details.