### PR TITLE
Allow PETSc to build with Python 3.

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -120,7 +120,11 @@ class Petsc(Package):
     depends_on('mpi', when='+mpi')
 
     # Build dependencies
-    depends_on('python@2.6:2.8', type='build')
+    depends_on('python@2.6:2.8', type='build', when='@:3.8.99')
+
+    # With >=3.9 version petsc will find python2 on the system and continue
+    # build even if launched with python3. See https://github.com/spack/spack/pull/7926
+    depends_on('python', type='build', when='@3.9:')
 
     # Other dependencies
     depends_on('metis@5:~int64+real64', when='@:3.7.99+metis~int64+double')
@@ -348,6 +352,11 @@ class Petsc(Package):
         # Set PETSC_DIR in the module file
         run_env.set('PETSC_DIR', self.prefix)
         run_env.unset('PETSC_ARCH')
+
+        # Petsc build will use python2 internaly
+        if self.spec.satisfies('^python@3:'):
+             spack_env.unset('PYTHONPATH')
+             spack_env.unset('PYTHONHOME')
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         # Set up PETSC_DIR for everyone using PETSc package


### PR DESCRIPTION
Currently PETSc can be built with only Python2. This means, if package like STEPs need to be built with Python3 then we get : 

```
→ spack spec steps+petsc ^python@3
Input spec
--------------------------------
steps+petsc
    ^python@3

Concretized
--------------------------------
==> Error: An unsatisfiable version constraint has been detected for spec:

    python@3

while trying to concretize the partial spec:

    petsc
        ^blas
        ^lapack
petsc requires python version 2.6:2.8, but spec asked for 3
```

This is because PETSc package has:

```
    # Build dependencies
    depends_on('python@2.6:2.8', type='build')
```

At the moment Spack doesn't allow to have two python version in the dependency tree i.e. python2 for PETSc and python3 for STEPs. See [this](https://github.com/spack/spack/pull/4595) PR for more details. This is current limitation of Spack concretiser algorithm. This limitation will be addressed in the next release (in coming month/months).

PETSc >=3.9 version allow to launch configure with python3 (see [comment](https://github.com/spack/spack/pull/7926#issuecomment-384768276)). In this case PETSc will internally check for python2 executable and if found, will continue build with python2. In this case we assume that python2 exist.

* Why to unset PYTHONPATH?

When user does `spack install petsc^python@3` then Spack will set PYTHONPATH & PYTHONHOME to python3 install prefix. But PETSc is internally going to launch python2 executable. This will result in import error. And hence we unset those env variables.
