### PR TITLE
zee: fix regression during build

### DIFF
--- a/var/spack/repos/builtin/packages/zee/package.py
+++ b/var/spack/repos/builtin/packages/zee/package.py
@@ -36,7 +36,7 @@ class Zee(CMakePackage):
 
     version('develop', git=url, submodules=True)
 
-    variant('build_type', default=' ', description='CMake build type',
+    variant('build_type', default='', description='CMake build type',
             values=' ')
     variant('optimize', default=True,
             description='Compile C++ with optimization')


### PR DESCRIPTION
Previous patch fixed CMake options used to configure compiler options,
that require CMAKE_BUILD_TYPE to be unset.

See error without patch:
```
1 error found in build log:
     26    -- Found MPI: TRUE (found version "3.1")
     27    -- Zee_USE_Omega_h: ON
     28    -- Found ZLIB: /gpfs/bbp.cscs.ch/home/tcarel/spack/install/linux-rhel7-x86_64/gcc-6.4.0/zlib-1.2.11-w43e5
           6/lib/libz.a (found version "1.2.11")
     29    -- Omega_h_CONFIG: /gpfs/bbp.cscs.ch/home/tcarel/spack/install/linux-rhel7-x86_64/intel-18.0.1/omega-h-9.
           14.0-2nmmwq/lib/cmake/Omega_h/Omega_hConfig.cmake
     30    -- Omega_h_VERSION: 9.14.0
     31    -- Checking for one of the modules 'PETSc'
  >> 32    CMake Error at cmake/bob.cmake:97 (message):
     33      can't set CMAKE_BUILD_TYPE and use bob_*_cxx_flags
     34    Call Stack (most recent call first):
     35      CMakeLists.txt:25 (bob_begin_cxx_flags)
     36
     37
     38    -- Configuring incomplete, errors occurred!
```