### PR TITLE
Fix neuron version : latest master can't be used with coreneuron master (bbcore_write_version 1.2)

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -44,7 +44,7 @@ class Neuron(Package):
     version('7.4', '2c0bbee8a9e55d60fa26336f4ab7acbf')
     version('7.3', '993e539cb8bf102ca52e9fefd644ab61')
     version('7.2', '5486709b6366add932e3a6d141c4f7ad')
-    version('develop', git=git, preferred=True)
+    version('develop', git=git, commit='9f36b132ce1b5e4', preferred=True)
 
     variant('binary',        default=True, description="Create special as a binary instead of shell script")
     variant('coreneuron',    default=True, description="Patch hh.mod for CoreNEURON compatibility")


### PR DESCRIPTION
Until we merge direct memory transfer functionality into coreneuron, we have to use current master.