### PR TITLE
Update STEPS with proper petsc+mpi dependency

### DIFF
--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -45,7 +45,8 @@ class Steps(CMakePackage):
     depends_on("blas")
     depends_on("lapack", when="+lapack")
     depends_on("mpi", when="+mpi")
-    depends_on("petsc^debug+int64", when="+petsc")
+    depends_on("petsc+int64+mpi", when="+petsc+mpi")
+    depends_on("petsc+int64~mpi", when="+petsc~mpi")
     depends_on("python")
     depends_on("py-cython")
 


### PR DESCRIPTION
Fixes #89. I think @tristan0x might have updated recipe but I am submitting this as placeholder to fix #89.


@WeiliangChenOIST : I assume we want to support following scenarios:

```
# user want to install steps  (with mpi)
 → spack spec steps
Input spec
--------------------------------
steps

Concretized
--------------------------------
steps@3.3.0%clang@9.0.0-apple build_type=RelWithDebInfo ~lapack+mpi+native~petsc arch=darwin-sierra-x86_64
    ^cmake@3.8.2%clang@9.0.0-apple~doc+ncurses+openssl+ownlibs~qt arch=darwin-sierra-x86_64
    ^mpich@3.2%clang@9.0.0-apple device=ch3 +hydra netmod=tcp patches=e591891fae6a1d029b95edbc93865c57d165784e77cf8b5822ae7d014b137a03 +pmi+romio~verbs arch=darwin-sierra-x86_64
    ^openblas@0.3.0%clang@9.0.0-apple cpu_target= ~ilp64 patches=47cfa7a952ac7b2e4632c73ae199d69fb54490627b66a62c681e21019c4ddc9d +pic+shared threads=none ~virtual_machine arch=darwin-sierra-x86_64
    ^py-cython@0.28.3%clang@9.0.0-apple arch=darwin-sierra-x86_64
        ^python@2.7.10%clang@9.0.0-apple+dbm~optimizations patches=123082ab3483ded78e86d7c809e98a804b3465b4683c96bd79a2fd799f572244 +pic+pythoncmd+shared~tk~ucs4 arch=darwin-sierra-x86_64


# user want to install steps with petsc (both mpi)
 → spack spec steps+petsc
Input spec
--------------------------------
steps+petsc

Concretized
--------------------------------
steps@3.3.0%clang@9.0.0-apple build_type=RelWithDebInfo ~lapack+mpi+native+petsc arch=darwin-sierra-x86_64
    ^cmake@3.8.2%clang@9.0.0-apple~doc+ncurses+openssl+ownlibs~qt arch=darwin-sierra-x86_64
    ^mpich@3.2%clang@9.0.0-apple device=ch3 +hydra netmod=tcp patches=e591891fae6a1d029b95edbc93865c57d165784e77cf8b5822ae7d014b137a03 +pmi+romio~verbs arch=darwin-sierra-x86_64
    ^openblas@0.3.0%clang@9.0.0-apple cpu_target= ~ilp64 patches=47cfa7a952ac7b2e4632c73ae199d69fb54490627b66a62c681e21019c4ddc9d +pic+shared threads=none ~virtual_machine arch=darwin-sierra-x86_64
    ^petsc@3.9.3%clang@9.0.0-apple clanguage=C ~complex~debug+double+hdf5+hypre+int64+metis+mpi~mumps~patchmpi64+shared~suite-sparse+superlu-dist~trilinos arch=darwin-sierra-x86_64
        ^hdf5@1.8.17%clang@9.0.0-apple~cxx~debug~fortran+hl+mpi+pic+shared~szip~threadsafe arch=darwin-sierra-x86_64
            ^zlib@1.2.8%clang@9.0.0-apple+optimize+pic+shared arch=darwin-sierra-x86_64
        ^hypre@2.14.0%clang@9.0.0-apple+int64~internal-superlu+mpi~shared arch=darwin-sierra-x86_64
        ^metis@5.1.0%clang@9.0.0-apple build_type=Release ~gdb+int64 patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1 ~real64+shared arch=darwin-sierra-x86_64
        ^parmetis@4.0.3%clang@9.0.0-apple build_type=RelWithDebInfo ~gdb patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d +shared arch=darwin-sierra-x86_64
        ^python@2.7.10%clang@9.0.0-apple+dbm~optimizations patches=123082ab3483ded78e86d7c809e98a804b3465b4683c96bd79a2fd799f572244 +pic+pythoncmd+shared~tk~ucs4 arch=darwin-sierra-x86_64
        ^superlu-dist@5.2.2%clang@9.0.0-apple+int64 arch=darwin-sierra-x86_64
    ^py-cython@0.28.3%clang@9.0.0-apple arch=darwin-sierra-x86_64


# user want to install steps with petsc but no mpi involved
 → spack spec steps~mpi+petsc
Input spec
--------------------------------
steps~mpi+petsc

Concretized
--------------------------------
steps@3.3.0%clang@9.0.0-apple build_type=RelWithDebInfo ~lapack~mpi+native+petsc arch=darwin-sierra-x86_64
    ^cmake@3.8.2%clang@9.0.0-apple~doc+ncurses+openssl+ownlibs~qt arch=darwin-sierra-x86_64
    ^openblas@0.3.0%clang@9.0.0-apple cpu_target= ~ilp64 patches=47cfa7a952ac7b2e4632c73ae199d69fb54490627b66a62c681e21019c4ddc9d +pic+shared threads=none ~virtual_machine arch=darwin-sierra-x86_64
    ^petsc@3.9.3%clang@9.0.0-apple clanguage=C ~complex~debug+double+hdf5+hypre+int64+metis~mpi~mumps~patchmpi64+shared~suite-sparse+superlu-dist~trilinos arch=darwin-sierra-x86_64
        ^metis@5.1.0%clang@9.0.0-apple build_type=Release ~gdb+int64 patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1 ~real64+shared arch=darwin-sierra-x86_64
        ^python@2.7.10%clang@9.0.0-apple+dbm~optimizations patches=123082ab3483ded78e86d7c809e98a804b3465b4683c96bd79a2fd799f572244 +pic+pythoncmd+shared~tk~ucs4 arch=darwin-sierra-x86_64
        ^zlib@1.2.8%clang@9.0.0-apple+optimize+pic+shared arch=darwin-sierra-x86_64
    ^py-cython@0.28.3%clang@9.0.0-apple arch=darwin-sierra-x86_64

```

Let me know if this covers your use cases.