### PR TITLE
steps: add "coverage" variant

### DIFF
--- a/var/spack/repos/builtin/packages/lcov/package.py
+++ b/var/spack/repos/builtin/packages/lcov/package.py
@@ -1,0 +1,39 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+from spack import *
+
+
+class Lcov(MakefilePackage):
+    """GCOV extension"""
+
+    homepage = "https://github.com/linux-test-project/lcov"
+    url      = "https://github.com/linux-test-project/lcov/archive/v1.13.tar.gz"
+
+    version('1.13', sha256='3650ad22773c56aaf8c5288e068dd35bd03f57659b6455dc6f8e21451c83b5e8')
+
+    depends_on('perl')
+
+    def install(self, spec, prefix):
+        make()
+        make("install", "PREFIX=" + prefix)

--- a/var/spack/repos/builtin/packages/py-gcovr/package.py
+++ b/var/spack/repos/builtin/packages/py-gcovr/package.py
@@ -1,0 +1,36 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+from spack import *
+
+
+class PyGcovr(PythonPackage):
+    """generate code coverage reports with gcc/gcov"""
+
+    homepage = "https://gcovr.com/"
+    url      = "https://github.com/gcovr/gcovr/archive/4.1.tar.gz"
+
+    version('4.1', sha256='1ad8042fd4dc4c355fd7e605d395eefa2a59b1677dfdc308e0ef00083e8b37ee')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-jinja2', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -41,14 +41,17 @@ class Steps(CMakePackage):
     variant("lapack", default=False, description="Use new BDSystem/Lapack code for E-Field solver")
     variant("petsc", default=False, description="Use PETSc library for parallel E-Field solver")
     variant("mpi", default=True, description="Use MPI for parallel solvers")
+    variant("coverage", default=False, description="Enable code coverage")
 
     depends_on("blas")
     depends_on("lapack", when="+lapack")
+    depends_on("lcov", when="+coverage", type="build")
     depends_on("mpi", when="+mpi")
-    depends_on("petsc+int64+mpi", when="+petsc+mpi")
-    depends_on("petsc+int64~mpi", when="+petsc~mpi")
-    depends_on("python")
+    depends_on("petsc~debug+int64+mpi", when="+petsc+mpi")
+    depends_on("petsc~debug+int64~mpi", when="+petsc~mpi")
     depends_on("py-cython")
+    depends_on("py-gcovr", when="+coverage", type="build")
+    depends_on("python")
 
     def cmake_args(self):
         args = []
@@ -74,8 +77,29 @@ class Steps(CMakePackage):
         else:
             args.append("-DUSE_MPI:BOOL=False")
 
+        if "+coverage" in spec:
+            args.append("-DENABLE_CODECOVERAGE:BOOL=True")
+
         args.append('-DBLAS_LIBRARIES=' + spec['blas'].libs.joined(";"))
         return args
+
+    @property
+    def build_targets(self):
+        targets = []
+        if "+coverage" in self.spec:
+            if self.compiler.name != "gcc":
+                raise ValueError(
+                    "Package " + self.name +
+                    " build with coverage enabled requires GCC to build"
+                )
+            targets = [
+                "CTEST_OUTPUT_ON_FAILURE=1",
+                "all",  # build
+                "coverage_init",  # initialize coverage counters
+                "test",  # run tests suite
+                "coverage"  #  collect coverage counters and build reports
+            ]
+        return targets
 
     def setup_environment(self, spack_env, run_env):
         run_env.prepend_path('PYTHONPATH', self.prefix)

--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -51,6 +51,12 @@ class Steps(CMakePackage):
     depends_on("petsc~debug+int64~mpi", when="+petsc~mpi")
     depends_on("py-cython")
     depends_on("py-gcovr", when="+coverage", type="build")
+    depends_on("py-nose", type="test", when="~coverage")
+    depends_on("py-nose", type=("build", "test"), when="+coverage")
+    depends_on("py-numpy", type="test", when="~coverage")
+    depends_on("py-numpy", type=("build", "test"), when="+coverage")
+    depends_on("py-unittest2", type="test", when="~coverage")
+    depends_on("py-unittest2", type=("build", "test"), when="+coverage")
     depends_on("python")
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -31,7 +31,7 @@ class Steps(CMakePackage):
     """STochastic Engine for Pathway Simulation"""
 
     homepage = "https://groups.oist.jp/cnu/software"
-    git      = "https://github.com/CNS-OIST/STEPS.git"
+    git      = "git@github.com:CNS-OIST/HBP_STEPS.git"
 
     version("3.3.0", submodules=True)
     version("3.2.0", submodules=True)


### PR DESCRIPTION
This pull-request provides:
* additional packages `py-covr` and `lcov` required by `steps` package to perform code coverage
* new "coverage" variant in `steps` package recipe to generate coverage reports (HTML and XML)
