### PR TITLE
Avoid setting MPI compiler wrappers as C/C++ compilers

### DIFF
--- a/var/spack/repos/builtin/packages/hpctools/package.py
+++ b/var/spack/repos/builtin/packages/hpctools/package.py
@@ -31,6 +31,7 @@ class Hpctools(CMakePackage):
     homepage = "https://bbpcode.epfl.ch/code/#/admin/projects/hpc/HPCTools"
     url      = "ssh://bbpcode.epfl.ch/hpc/HPCTools"
 
+    version('develop', git=url)
     version('3.5.1', tag='3.5.1', git=url, preferred=True)
     version('3.1.0', tag='3.1.0', git=url)
 
@@ -44,7 +45,7 @@ class Hpctools(CMakePackage):
     def cmake_args(self):
         args = [
             '-DUSE_OPENMP:BOOL={}'.format('+openmp' in self.spec),
-            '-DCMAKE_C_COMPILER={}'.format(self.spec['mpi'].mpicc),
-            '-DCMAKE_CXX_COMPILER={}'.format(self.spec['mpi'].mpicxx),
+            '-DMPI_C_COMPILER={}'.format(self.spec['mpi'].mpicc),
+            '-DMPI_CXX_COMPILER={}'.format(self.spec['mpi'].mpicxx),
         ]
         return args


### PR DESCRIPTION
Some MPI libraries like HPE-MPI brings extra link libraries when mpicxx wrappers are used. For example, below error :

    libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore


Here is full error while running tests on BB5:

```
cd /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit && /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/cmake-3.12.0-ybmxsc/bin/cmake -E cmake_link_script CMakeFiles/boost_hpctools_unit_test.dir/link.txt --verbose=1
/opt/hpe/hpc/mpt/mpt-2.16/bin/mpicxx   -qopenmp -g -Wall -Wextra -O2 -DNDEBUG  -rdynamic CMakeFiles/boost_hpctools_unit_test.dir/main_tests.cpp.o  -o boost_hpctools_unit_test -Wl,-rpath,/gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/hpctools:/gpfs/bbp.cscs.ch/apps/hpc/spack-deployments/18-06-2018/install/linux-rhel7-x86_64/gcc-6.4.0/boost-1.67.0-6skhmz/lib ../../hpctools/libHPCTools.so.3.5.1 /gpfs/bbp.cscs.ch/apps/hpc/spack-deployments/18-06-2018/install/linux-rhel7-x86_64/gcc-6.4.0/boost-1.67.0-6skhmz/lib/libboost_unit_test_framework-mt.so -lxml2
make[2]: Leaving directory `/gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi'
[100%] Built target boost_hpctools_unit_test
make[1]: Leaving directory `/gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi'
/gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/cmake-3.12.0-ybmxsc/bin/cmake -E cmake_progress_start /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/CMakeFiles 0
kumbhar@r1i4n33:/gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi$ ctest -VV
UpdateCTestConfiguration  from :/gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/DartConfiguration.tcl
UpdateCTestConfiguration  from :/gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/DartConfiguration.tcl
Test project /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi
Constructing a list of tests
Done constructing a list of tests
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: hpctools_unit_tests

1: Test command: /opt/hpe/hpc/mpt/mpt-2.16/bin/mpiexec "-n" "36" "/gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test"
1: Test timeout computed to be: 9.99988e+06
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
1: /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/HPCTools/buildi/test/unit/boost_hpctools_unit_test: symbol lookup error: /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so: undefined symbol: mpi_sgi_status_ignore
```