### PR TITLE
Avoid using modules with Intel compiler configuration

### DIFF
--- a/sysconfig/bb5/users/compilers.yaml
+++ b/sysconfig/bb5/users/compilers.yaml
@@ -29,15 +29,13 @@ compilers:
     environment: {}
     extra_rpaths: []
     flags: {}
-    modules:
-    - gcc/6.4.0
-    - intel/18.0.1
+    modules: []
     operating_system: rhel7
     paths:
-      cc: /gpfs/bbp.cscs.ch/apps/compilers/install/intel-parallel-studio-cluster.2018.1/compilers_and_libraries_2018.1.163/linux/bin/intel64/icc
-      cxx: /gpfs/bbp.cscs.ch/apps/compilers/install/intel-parallel-studio-cluster.2018.1/compilers_and_libraries_2018.1.163/linux/bin/intel64/icpc
-      f77: /gpfs/bbp.cscs.ch/apps/compilers/install/intel-parallel-studio-cluster.2018.1/compilers_and_libraries_2018.1.163/linux/bin/intel64/ifort
-      fc: /gpfs/bbp.cscs.ch/apps/compilers/install/intel-parallel-studio-cluster.2018.1/compilers_and_libraries_2018.1.163/linux/bin/intel64/ifort
+      cc: /gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/compilers_and_libraries_2018.1.163/linux/bin/intel64/icc
+      cxx: /gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/compilers_and_libraries_2018.1.163/linux/bin/intel64/icpc
+      f77: /gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/compilers_and_libraries_2018.1.163/linux/bin/intel64/ifort
+      fc: /gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/compilers_and_libraries_2018.1.163/linux/bin/intel64/ifort
     spec: intel@18.0.1
     target: x86_64
 - compiler:


### PR DESCRIPTION
In the past when we installed packages with intel compiler and try to run exe, we got errors like:

```
/bin/some_exe: /usr/lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /gpfs/bbp.cscs.ch/proje...som_path/lib64/libsomeproj.so.1)
```

One needs to load gcc/6.4.0 before running above package. With suggestions in #97, we have added following:

```
$ cat /gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/compilers_and_libraries_2018.1.163/linux/bin/intel64/icpc.cfg
-gcc-name=/gpfs/bbp.cscs.ch/apps/compilers/install/gcc-6.4.0/bin/gcc #
-Xlinker -rpath=/gpfs/bbp.cscs.ch/apps/compilers/install/gcc-6.4.0/lib #
-Xlinker -rpath=/gpfs/bbp.cscs.ch/apps/compilers/install/gcc-6.4.0/lib64 #
-Xlinker -rpath=/gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/lib/intel64_lin
```

With this, intel use latest gcc and add rpath entries:

```
$ module purge
$ ldd /gpfs/bbp.cscs.ch/ssd/slurmTmpFS/kumbhar/177245/spack-stage/spack-stage-Hc4JNi/HPCTools/spack-build/test/unit/boost_hpctools_unit_test
	linux-vdso.so.1 =>  (0x00007fffedb05000)
	libHPCTools.so.3 => /gpfs/bbp.cscs.ch/project/proj20/pramod_scratch/report_flush/tmp_new/install/linux-rhel7-x86_64/intel-18.0.1/hpctools-3.5.1-kwh3he/lib64/libHPCTools.so.3 (0x00007fffed8c1000)
	libboost_unit_test_framework.so.1.67.0 => /gpfs/bbp.cscs.ch/apps/hpc/spack-deployments/18-06-2018/install/linux-rhel7-x86_64/gcc-6.4.0/boost-1.67.0-6skhmz/lib/libboost_unit_test_framework.so.1.67.0 (0x00007fffed5f5000)
	libpthread.so.0 => /usr/lib64/libpthread.so.0 (0x00007fffed3a0000)
	libmpi++abi1002.so => /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi++abi1002.so (0x00007fffed165000)
	libmpi.so => /opt/hpe/hpc/mpt/mpt-2.16/lib/libmpi.so (0x00007fffecd90000)
	libxml2.so.2 => /usr/lib64/libxml2.so.2 (0x00007fffeca26000)
	libstdc++.so.6 => /gpfs/bbp.cscs.ch/apps/compilers/install/gcc-6.4.0/lib64/libstdc++.so.6 (0x00007fffec6a5000)
	libm.so.6 => /usr/lib64/libm.so.6 (0x00007fffec3a3000)
	libiomp5.so => /gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/lib/intel64_lin/libiomp5.so (0x00007fffebfea000)
	libgcc_s.so.1 => /gpfs/bbp.cscs.ch/apps/compilers/install/gcc-6.4.0/lib64/libgcc_s.so.1 (0x00007fffebdd2000)
	libc.so.6 => /usr/lib64/libc.so.6 (0x00007fffeba0f000)
	libdl.so.2 => /usr/lib64/libdl.so.2 (0x00007fffeb80b000)
	libimf.so => /gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/lib/intel64_lin/libimf.so (0x00007fffeb27c000)
	libsvml.so => /gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/lib/intel64_lin/libsvml.so (0x00007fffe9bc9000)
	libirng.so => /gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/lib/intel64_lin/libirng.so (0x00007fffe9854000)
	libintlc.so.5 => /gpfs/bbp.cscs.ch/apps/compilers/install/intel-18.0.1/lib/intel64_lin/libintlc.so.5 (0x00007fffe95e7000)
	libboost_timer.so.1.67.0 => /gpfs/bbp.cscs.ch/apps/hpc/spack-deployments/18-06-2018/install/linux-rhel7-x86_64/gcc-6.4.0/boost-1.67.0-6skhmz/lib/libboost_timer.so.1.67.0 (0x00007fffe93e0000)
	libboost_system.so.1.67.0 => /gpfs/bbp.cscs.ch/apps/hpc/spack-deployments/18-06-2018/install/linux-rhel7-x86_64/gcc-6.4.0/boost-1.67.0-6skhmz/lib/libboost_system.so.1.67.0 (0x00007fffe91db000)
	librt.so.1 => /usr/lib64/librt.so.1 (0x00007fffe8fd3000)
	/lib64/ld-linux-x86-64.so.2 (0x0000555555554000)
	libcpuset.so.1 => /usr/lib64/libcpuset.so.1 (0x00007fffe8dc5000)
	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffe8baf000)
	liblzma.so.5 => /usr/lib64/liblzma.so.5 (0x00007fffe8989000)
	libboost_chrono.so.1.67.0 => /gpfs/bbp.cscs.ch/apps/hpc/spack-deployments/18-06-2018/install/linux-rhel7-x86_64/gcc-6.4.0/boost-1.67.0-6skhmz/lib/libboost_chrono.so.1.67.0 (0x00007fffe8780000)
	libbitmask.so.1 => /usr/lib64/libbitmask.so.1 (0x00007fffe857a000)
```

And can be launched without any module:

```
$ module purge
$ srun -n 1 test/unit/boost_hpctools_unit_test
Running 4 test cases...
TEST: UserMem: 8667136 404052389888
TEST: UserMem: 61329408 404052389888
sin1 0.362358,0.169967,-0.0291997 cos_res 0.362358,0.169967,-0.0291997
Warning: Using the stub function MPIX_Pset_same_comm_create to simulate a BG implementation...
```

@matz-e  : before merging this, we should test whole pipeline.