### PR TITLE
Adding new Synapsetool 0.3. Defaults to "develop"

### DIFF
--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -32,8 +32,8 @@ class Synapsetool(CMakePackage):
     homepage = "https://bbpcode.epfl.ch/code/#/admin/projects/hpc/synapse-tool"
     url      = "ssh://bbpcode.epfl.ch/hpc/synapse-tool"
 
-    version('develop', git=url, submodules=True, preferred=True)
-    version('0.3.0', git=url, tag='v0.3.0', submodules=True)
+    version('develop', git=url, submodules=True)
+    version('0.3.0', git=url, tag='v0.3.0', submodules=True, preferred=True)
     version('0.2.5', git=url, tag='v0.2.5', submodules=True)
     version('0.2.4', git=url, tag='v0.2.4', submodules=True)
     version('0.2.3', git=url, tag='v0.2.3', submodules=True)

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -32,8 +32,9 @@ class Synapsetool(CMakePackage):
     homepage = "https://bbpcode.epfl.ch/code/#/admin/projects/hpc/synapse-tool"
     url      = "ssh://bbpcode.epfl.ch/hpc/synapse-tool"
 
-    version('develop', git=url, submodules=True)
-    version('0.2.5', git=url, tag='v0.2.5', submodules=True, preferred=True)
+    version('develop', git=url, submodules=True, preferred=True)
+    version('0.3.0', git=url, tag='v0.3.0', submodules=True)
+    version('0.2.5', git=url, tag='v0.2.5', submodules=True)
     version('0.2.4', git=url, tag='v0.2.4', submodules=True)
     version('0.2.3', git=url, tag='v0.2.3', submodules=True)
     version('0.2.1', git=url, tag='v0.2.1', submodules=True)


### PR DESCRIPTION
Release synapsetool 3.0
Moreover I believe it's safe to use develop by default, since few projects depend on it