### PR TITLE
Set PYTHONPATH for all python packages specified as run dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -593,18 +593,17 @@ class Python(AutotoolsPackage):
 
         # For run time environment set path for all dependent_spec
         # recursively and prepend it to PYTHONPATH
-        python_paths = []
+        python_paths = set()
         if dependent_spec.package.extends(self.spec):
             path = join_path(dependent_spec.prefix, self.site_packages_dir)
-            python_paths.append(path)
+            python_paths.add(path)
         for em in run_env.env_modifications:
             if em.name == 'PYTHONPATH':
-                python_paths.append(em.value)
+                python_paths.add(em.value)
         for d in dependent_spec.traverse(deptype=('run')):
             if d.package.extends(self.spec):
-                if path not in python_paths:
-                    path = join_path(d.prefix, self.site_packages_dir)
-                    python_paths.append(path)
+                path = join_path(d.prefix, self.site_packages_dir)
+                python_paths.add(path)
         for path in python_paths:
             run_env.prepend_path('PYTHONPATH', path)
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -602,10 +602,11 @@ class Python(AutotoolsPackage):
                 python_paths.append(em.value)
         for d in dependent_spec.traverse(deptype=('run')):
             if d.package.extends(self.spec):
-                path = join_path(d.prefix, self.site_packages_dir)
-                python_paths.append(path)
-        pythonpath = ':'.join(python_paths)
-        run_env.set('PYTHONPATH', pythonpath)
+                if path not in python_paths:
+                    path = join_path(d.prefix, self.site_packages_dir)
+                    python_paths.append(path)
+        for path in python_paths:
+            run_env.prepend_path('PYTHONPATH', path)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before python modules' install() methods.


### PR DESCRIPTION
If we have a package with python packages as run dependencies:

```
class Mod2c(CMakePackage):
     ......
    version('develop', git=url, preferred=True)

    depends_on('cmake@2.8.12:', type='build')
    depends_on('py-six', type='run')
    depends_on('py-urwid', type='run')
```

and 

```
→ spack spec mod2c
Input spec
--------------------------------
mod2c

Concretized
--------------------------------
mod2c@develop%clang@9.0.0-apple build_type=RelWithDebInfo arch=darwin-sierra-x86_64
    ^cmake@3.18.2%clang@9.0.0-apple~doc+ncurses+openssl+ownlibs~qt arch=darwin-sierra-x86_64
    ^py-six@1.11.0%clang@9.0.0-apple arch=darwin-sierra-x86_64
        ^py-urwid@1.3.0%clang@9.0.0-apple arch=darwin-sierra-x86_64
            ^py-enum34@1.1.6%clang@9.0.0-apple arch=darwin-sierra-x86_64
                ^py-setuptools@40.2.0%clang@9.0.0-apple arch=darwin-sierra-x86_64
                    ^python@2.7.10%clang@9.0.0-apple+dbm~optimizations patches=123082ab3483ded78e86d7c809e98a804b3465b4683c96bd79a2fd799f572244 +pic+pythoncmd+shared~tk~ucs4 arch=darwin-sierra-x86_64
```

If we generate module for `mod2c`, we expect `PYTHONPATH` env variable set for `py-six`, `py-urwid` and `py-enum34`. Same way for module file for `py-urwid`.

With this PR, the module file generate has:

```
→ module show mod2c
-------------------------------------------------------------------
/Users/kumbhar/workarena/software/sources/spack/share/spack/modules/darwin-sierra-x86_64/py-urwid/1.3.0-clang:

module-whatis	A full-featured console UI library
conflict	py-urwid
......
setenv		PYTHONPATH	
/Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/py-enum34-1.1.6-q2i6u5lhp6viflhcdqvjf5v4pfqnyehm/lib/python2.7/site-packages
:/Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/py-six-1.11.0-giabqufepo4gb7qq367qnie3ptmik4ry/lib/python2.7/site-packages
:/Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/py-urwid-1.3.0-63wq4ijhhedzba2tvlhzmnmosmwl4s5u/lib/python2.7/site-packages
```