### PR TITLE
Increase lock timeout to allow Jenkins parallel build

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -99,7 +99,7 @@ config:
   # when spack needs to manage its own package metadata and all operations are
   # expected to complete within the default time limit. The timeout should
   # therefore generally be left untouched.
-  db_lock_timeout: 120
+  db_lock_timeout: 600
 
   # How long to wait when attempting to modify a package (e.g. to install it).
   # This value should typically be 'null' (never time out) unless the Spack


### PR DESCRIPTION
I have seen timeout on Jenkins parallel build, e.g. [here](https://bbpcode.epfl.ch/ci/blue/organizations/jenkins/hpc.spack-testing/detail/hpc.spack-testing/241/pipeline):

```
+ case $_sp_subcommand in
+ command spack install --keep-stage --show-log-on-error neurodamus@plasticity
+ spack install --keep-stage --show-log-on-error neurodamus@plasticity
==> Error: Timed out waiting for lock.
```

Increase timeout by 5x (which should be better than serial build).

CC: @matz-e 