### PR TITLE
Improvement for Neuron, HighFive and SynapseTool 

### DIFF
--- a/sysconfig/bb5/users/modules.yaml
+++ b/sysconfig/bb5/users/modules.yaml
@@ -34,6 +34,7 @@ modules:
     whitelist:
       - functionalizer
       - git
+      - neuron
       - neurodamus
       - parquet-converters
       - python

--- a/var/spack/repos/builtin/packages/highfive/package.py
+++ b/var/spack/repos/builtin/packages/highfive/package.py
@@ -45,8 +45,9 @@ class Highfive(CMakePackage):
     variant('mpi', default=True, description='Support MPI')
 
     depends_on('boost @1.41:', when='+boost')
-    depends_on('hdf5 ~mpi', when='~mpi')
-    depends_on('hdf5 +mpi', when='+mpi')
+    depends_on('hdf5',         when='~mpi')
+    depends_on('hdf5+mpi',     when='+mpi')
+    depends_on('mpi',          when='^hdf5+mpi')
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/neurodamus-base/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-base/package.py
@@ -38,4 +38,6 @@ class NeurodamusBase(Package):
     version('plasticity',  git=url, branch='sandbox/king/saveupdate_v6support_mask', preferred=True)
 
     def install(self, spec, prefix):
-        shutil.copytree('lib', '%s/lib' % (prefix), symlinks=False)
+        shutil.copytree('lib', prefix.lib)
+        if os.path.isdir('python'):
+            shutil.copytree('python', prefix.python)

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 import os
 from spack import *
+from contextlib import contextmanager
 
 
 class Neuron(Package):
@@ -46,16 +47,17 @@ class Neuron(Package):
     version('7.2', '5486709b6366add932e3a6d141c4f7ad')
     version('develop', git=git, commit='9f36b132ce1b5e4', preferred=True)
 
-    variant('binary',        default=True, description="Create special as a binary instead of shell script")
-    variant('coreneuron',    default=True, description="Patch hh.mod for CoreNEURON compatibility")
+    variant('binary',        default=True,  description="Create special as a binary instead of shell script")
+    variant('coreneuron',    default=True,  description="Patch hh.mod for CoreNEURON compatibility")
     variant('cross-compile', default=False, description='Build for cross-compile environment')
     variant('debug',         default=False, description='Build debug with O0')
     variant('mpi',           default=True,  description='Enable MPI parallelism')
     variant('multisend',     default=True,  description="Enable multi-send spike exchange")
     variant('profile',       default=False, description="Enable Tau profiling")
     variant('python',        default=True,  description='Enable python')
-    variant('shared',        default=True, description='Build shared libraries')
-    variant('rx3d',          default=False, description="Enable cython translated 3-d rxd")
+    variant('shared',        default=True,  description='Build shared libraries')
+    variant('pysetup',       default=True,  description="Build Python module with setup.py")
+    variant('rx3d',          default=False, description="Enable cython translated 3-d rxd. Depends on pysetup")
 
     depends_on('autoconf',   type='build')
     depends_on('automake',   type='build')
@@ -63,14 +65,32 @@ class Neuron(Package):
     depends_on('flex',       type='build')
     depends_on('libtool',    type='build')
     depends_on('pkgconfig',  type='build')
+    depends_on('readline')
 
     depends_on('mpi',         when='+mpi')
     depends_on('ncurses',     when='~cross-compile')
     depends_on('python@2.6:', when='+python')
-    depends_on('readline',    when='+python')
     depends_on('tau',         when='+profile')
 
-    conflicts('~shared', when='+python')
+    conflicts('~shared',  when='+python')
+    conflicts('+pysetup', when='~python')
+    conflicts('+rx3d',    when='~pysetup')
+
+    _default_options = ['--without-iv',
+                        '--without-x']
+    _specs_to_options = {
+        '+cross-compile': ['cross_compiling=yes',
+                           '--without-memacs',
+                           '--without-nmodl'],
+        '~python':    ['--without-nrnpython'],
+        '~pysetup':   ['--disable-pysetup'],
+        '+multisend': ['--with-multisend'],
+        '~rx3d':      ['--disable-rx3d'],
+        '~mpi':       ['--without-paranrn'],
+        '+mpi':       ['--with-paranrn'],
+        '~shared':    ['--disable-shared'],
+        '+binary':    ['linux_nrnmech=no'],
+    }
 
     filter_compiler_wrappers('*/bin/nrniv_makefile')
 
@@ -102,19 +122,8 @@ class Neuron(Package):
             filter_file(r'GLOBAL minf', r'RANGE minf', 'src/nrnoc/hh.mod')
             filter_file(r'TABLE minf', r':TABLE minf', "src/nrnoc/hh.mod")
 
-    def profiling_wrapper_on(self):
-        os.environ["USE_PROFILER_WRAPPER"] = "1"
-
-    def profiling_wrapper_off(self):
-        del os.environ["USE_PROFILER_WRAPPER"]
-
     def get_arch_options(self, spec):
         options = []
-
-        if spec.satisfies('+cross-compile'):
-            options.extend(['cross_compiling=yes',
-                            '--without-memacs',
-                            '--without-nmodl'])
         # need to enable bg-q arch
         if 'bgq' in self.spec.architecture:
             options.extend(['--enable-bluegeneQ',
@@ -127,6 +136,8 @@ class Neuron(Package):
         return options
 
     def get_python_options(self, spec):
+        """Determine config options for Python
+        """
         options = []
 
         if spec.satisfies('+python'):
@@ -138,15 +149,11 @@ class Neuron(Package):
                 py_lib = spec['python'].prefix.lib64
 
             options.extend(['--with-nrnpython=%s' % python_exec,
-                            #'--disable-pysetup',
                             'PYINCDIR=%s' % py_inc,
                             'PYLIBDIR=%s' % py_lib])
 
             if spec.satisfies('~cross-compile'):
                 options.append('PYTHON_BLD=%s' % python_exec)
-
-        else:
-            options.append('--without-nrnpython')
 
         return options
 
@@ -162,8 +169,13 @@ class Neuron(Package):
         if self.spec.satisfies('%pgi'):
             flags += ' ' + self.compiler.pic_flag
 
-        return ['CFLAGS=%s' % flags,
-                'CXXFLAGS=%s' % flags]
+        options = ['CFLAGS=%s' % flags,
+                   'CXXFLAGS=%s' % flags]
+
+        if spec.satisfies('+mpi'):
+            options.extend(['MPICC=%s' % spec['mpi'].mpicc,
+                            'MPICXX=%s' % spec['mpi'].mpicxx])
+        return options
 
     def build_nmodl(self, spec, prefix):
         # build components for front-end arch in cross compiling environment
@@ -187,29 +199,10 @@ class Neuron(Package):
         make('install')
 
     def install(self, spec, prefix):
-        options = ['--prefix=%s' % prefix,
-                   '--without-iv',
-                   '--without-x',
-                   '--without-readline']
-
-        if spec.satisfies('+multisend'):
-            options.append('--with-multisend')
-
-        if spec.satisfies('~rx3d'):
-            options.append('--disable-rx3d')
-
-        if spec.satisfies('+mpi'):
-            options.extend(['MPICC=%s' % spec['mpi'].mpicc,
-                            'MPICXX=%s' % spec['mpi'].mpicxx,
-                            '--with-paranrn'])
-        else:
-            options.append('--without-paranrn')
-
-        if spec.satisfies('~shared'):
-            options.append('--disable-shared')
-
-        if spec.satisfies('+binary'):
-            options.append('linux_nrnmech=no')
+        options = ['--prefix=%s' % prefix] + self._default_options
+        for specname, spec_opts in self._specs_to_options.items():
+            if spec.satisfies(specname):
+                options.extend(spec_opts)
 
         options.extend(self.get_arch_options(spec))
         options.extend(self.get_python_options(spec))
@@ -231,11 +224,11 @@ class Neuron(Package):
                 self.build_nmodl(spec, prefix)
             srcpath = self.stage.source_path
             configure = Executable(join_path(srcpath, 'configure'))
+            print("Configuring with options: " + ", ".join(options))
             configure(*options)
-            self.profiling_wrapper_on()
-            make('VERBOSE=1')
-            make('install')
-            self.profiling_wrapper_off()
+            with profiling_wrapper_on():
+                make('VERBOSE=1')
+                make('install')
 
     @run_after('install')
     def filter_compilers(self):
@@ -268,3 +261,11 @@ class Neuron(Package):
     def setup_dependent_package(self, module, dependent_spec):
         neuron_archdir = self.get_neuron_archdir()
         dependent_spec.package.neuron_archdir = neuron_archdir
+
+
+@contextmanager
+def profiling_wrapper_on():
+    os.environ["USE_PROFILER_WRAPPER"] = "1"
+    yield
+    del os.environ["USE_PROFILER_WRAPPER"]
+

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -67,6 +67,7 @@ class Neuron(Package):
     depends_on('mpi',         when='+mpi')
     depends_on('ncurses',     when='~cross-compile')
     depends_on('python@2.6:', when='+python')
+    depends_on('readline',    when='+python')
     depends_on('tau',         when='+profile')
 
     conflicts('~shared', when='+python')
@@ -137,7 +138,7 @@ class Neuron(Package):
                 py_lib = spec['python'].prefix.lib64
 
             options.extend(['--with-nrnpython=%s' % python_exec,
-                            '--disable-pysetup',
+                            #'--disable-pysetup',
                             'PYINCDIR=%s' % py_inc,
                             'PYLIBDIR=%s' % py_lib])
 

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -45,12 +45,11 @@ class Synapsetool(CMakePackage):
 
     depends_on('boost@1.55:')
     depends_on('cmake', type='build')
-    depends_on('hdf5+mpi', when='+mpi')
-    depends_on('hdf5~mpi', when='~mpi')
+    depends_on('hdf5+mpi',     when='+mpi')
+    depends_on('hdf5',         when='~mpi')
     depends_on('highfive+mpi', when='+mpi')
-    depends_on('highfive~mpi', when='~mpi')
-    depends_on('mpi', when='+mpi')
-    depends_on('python')
+    depends_on('highfive',     when='~mpi')
+    depends_on('mpi',          when='^hdf5+mpi')
 
     @property
     def libs(self):
@@ -66,12 +65,14 @@ class Synapsetool(CMakePackage):
 
     def cmake_args(self):
         args = []
-        if self.spec.satisfies('+mpi'):
+        if self.spec.satisfies('^mpi'):
             args.extend([
                 '-DCMAKE_C_COMPILER:STRING={}'.format(self.spec['mpi'].mpicc),
                 '-DCMAKE_CXX_COMPILER:STRING={}'.format(self.spec['mpi'].mpicxx),
-                '-DSYNTOOL_WITH_MPI:BOOL=ON',
             ])
+        if self.spec.satisfies('+mpi'):
+            args.extend(['-DSYNTOOL_WITH_MPI:BOOL=ON'])
+
         if self.spec.satisfies('~shared'):
             args.append('-DCOMPILE_LIBRARY_TYPE=STATIC')
         return args


### PR DESCRIPTION
This PR adds the following feature:
- Ability for HighFive and SynapseTool to build non-mpi versions linked to parallel-hdf5

And restructures Neuron spec