### PR TITLE
{,py-}arrow: add version 0.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -34,6 +34,7 @@ class Arrow(CMakePackage):
     homepage = "http://arrow.apache.org"
     url      = "https://github.com/apache/arrow/archive/apache-arrow-0.9.0.tar.gz"
 
+    version('0.11.0', '0ac629a7775d86108e403eb66d9f1a3d3bdd6b3a497a86228aa4e8143364b7cc')
     version('0.9.0', 'ebbd36c362b9e1d398ca612f6d2531ec')
     version('0.8.0', '56436f6f61ccc68686b7e0ea30bf4d09')
 
@@ -51,6 +52,7 @@ class Arrow(CMakePackage):
             description='CMake build type',
             values=('Debug', 'FastDebug', 'Release'))
     variant('python', default=False, description='Build Python interface')
+    variant('parquet', default=False, description='Build Parquet interface')
 
     root_cmakelists_dir = 'cpp'
 
@@ -72,6 +74,8 @@ class Arrow(CMakePackage):
         ]
         if self.spec.satisfies('+python'):
             args.append("-DARROW_PYTHON:BOOL=ON")
+        if self.spec.satisfies('+parquet'):
+            args.append("-DARROW_PARQUET:BOOL=ON")
         for dep in ('flatbuffers', 'rapidjson', 'snappy', 'zlib', 'zstd'):
             args.append("-D{0}_HOME={1}".format(dep.upper(),
                                                 self.spec[dep].prefix))

--- a/var/spack/repos/builtin/packages/parquet-converters/package.py
+++ b/var/spack/repos/builtin/packages/parquet-converters/package.py
@@ -38,7 +38,7 @@ class ParquetConverters(CMakePackage):
 
     depends_on('hdf5+mpi')
     depends_on('highfive+mpi')
-    depends_on('parquet')
+    depends_on('arrow+parquet')
     depends_on('snappy~shared')
     depends_on('synapsetool+mpi')
     depends_on('mpi')

--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -34,6 +34,7 @@ class PyPyarrow(PythonPackage):
     homepage = "http://arrow.apache.org"
     url      = "https://pypi.org/packages/source/p/pyarrow/pyarrow-0.9.0.tar.gz"
 
+    version('0.11.0', sha256='07a6fd71c5d7440f2c42383dd2c5daa12d7f0a012f1e88288ed08a247032aead')
     version('0.9.0', sha256='7db8ce2f0eff5a00d6da918ce9f9cfec265e13f8a119b4adb1595e5b19fd6242')
 
     variant('parquet', default=False, description="Build with Parquet support")
@@ -44,7 +45,7 @@ class PyPyarrow(PythonPackage):
     depends_on('py-cython', type='build')
 
     depends_on('arrow+python')
-    depends_on('parquet', when='+parquet')
+    depends_on('arrow+parquet+python', when='+parquet')
 
     phases = ['build_ext', 'install']
 


### PR DESCRIPTION
The Parquet library moved into the Arrow organisation, hence add a
parquet flavor and adapt dependencies.

Not sure how to handle this from a packaging perspective, the best move may be to remove the `parquet` package altogether?