### PR TITLE
Setup environment for python extensions

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -471,3 +471,10 @@ class PythonPackage(PackageBase):
                 view.remove_file(src, dst)
             else:
                 os.remove(dst)
+
+    def setup_environment(self, spack_env, run_env):
+        """Set up the compile and runtime environments for a package.
+           Set PYTHONPATH if package is specified as external.
+	"""
+        if self.spec.external:
+            run_env.prepend_path('PYTHONPATH', self.prefix)


### PR DESCRIPTION
@matz-e  : this allows to generate module for python extensions even if they are external in packages.yaml. But, as you know, the dependencies are trimmed, we can't get package dependencies in PYTHONPATH. 

Not sure if this is useful and whether we should merge this, but adding here for reference.