### PR TITLE
Synapse tool defaults build with MPI, like others

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus/package.py
@@ -53,7 +53,7 @@ class Neurodamus(NeurodamusBase):
 
     depends_on("neuron+profile", when='+profile')
     depends_on('reportinglib+profile', when='+profile')
-    depends_on('synapsetool~shared',   when='+syn2')
+    depends_on('synapsetool~shared', when='+syn2')
     depends_on('tau', when='+profile')
 
     # coreneuron support is available for plasticity model

--- a/var/spack/repos/builtin/packages/neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus/package.py
@@ -53,7 +53,7 @@ class Neurodamus(NeurodamusBase):
 
     depends_on("neuron+profile", when='+profile')
     depends_on('reportinglib+profile', when='+profile')
-    depends_on('synapsetool~mpi~shared', when='+syn2')
+    depends_on('synapsetool~shared',   when='+syn2')
     depends_on('tau', when='+profile')
 
     # coreneuron support is available for plasticity model

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -40,7 +40,7 @@ class Synapsetool(CMakePackage):
     version('0.2.1', git=url, tag='v0.2.1', submodules=True)
     version('0.2.0', git=url, tag='v0.2.0', submodules=True)
 
-    variant('mpi', default=False, description="Enable MPI backend")
+    variant('mpi', default=True, description="Enable MPI backend")
     variant('shared', default=True, description="Build shared library")
 
     depends_on('boost@1.55:')


### PR DESCRIPTION
Synapse tool defaults build with MPI, like other tools inthe stack, e.g. hdf5 and HighFive. Without this current versions of spack are lame enough to just use the defaults instead of trying to match.

Allow neurodamus to link against whichever synapsetool was specified. User can then build mods with or without mpi. 