### PR TITLE
Improving neurodamus build w support for PythonND

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-base/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-base/package.py
@@ -33,7 +33,7 @@ class NeurodamusBase(Package):
     homepage = "ssh://bbpcode.epfl.ch/sim/neurodamus/bbp"
     url      = "ssh://bbpcode.epfl.ch/sim/neurodamus/bbp"
 
-    version('master',      git=url)
+    version('master',      git=url, branch='master')
     version('hippocampus', git=url, branch='sandbox/king/hippocampus')
     version('plasticity',  git=url, branch='sandbox/king/saveupdate_v6support_mask', preferred=True)
 


### PR DESCRIPTION
This change implements:

- Improved build, avoiding copying files by completely overriding the `do_stage` step. We split the build into "build" and "install", where build only builds the special, and install puts everything in a nice place without duplicating stuff. The new install structure is:
  - `$prefix/bin/special`
  - `$prefix/lib/modc` (mods c source)
  - `$prefix/lib/hoclib` (symlink to hoclib)
  - `$prefix/lib/modlib` (symlink to modlib)
  - `$prefix/lib/libnrnmech.so` (moved from ARCH if exists - compiled in shared lib mode)
  - `$prefix/python` (symlink to python srcs, if exists)
 - Support for a python variant, declaring dependencies
 - Rename of variant syn2 to syntool