### PR TITLE
Touch detector to use gcc by default

### DIFF
--- a/sysconfig/bb5/users/packages.yaml
+++ b/sysconfig/bb5/users/packages.yaml
@@ -164,6 +164,8 @@ packages:
         paths:
             tcl@8.5.13: /usr
         version: [8.5.13]
+    touchdetector:
+        compiler: [gcc]
     trilinos:
         variants: +kokkos+teuchos~amesos~hypre~superlu-dist~mumps~metis~suite-sparse
         version: [develop]


### PR DESCRIPTION
Touch detector shall be built by default in gcc.
Tests rely on results using gcc, and depending on the Spack configuration / jenking flags, it could happen it builds with intel.