### PR TITLE
Fix concretisation issues with python packages

### DIFF
--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -36,6 +36,7 @@ class NodeJs(Package):
 
     version('8.9.1', '7482b2523f72000d1b6060c38945026b')
     version('7.1.0', '1db5df2cb025f9c70e83d9cf21c4266a')
+    version('6.12.2', 'f007d1f5b00723821f67581293e8b3f6')
     version('6.3.0', '8c14e5c89d66d4d060c91b3ba15dfd31')
     version('6.2.2', '1120e8bf191fdaee42206d031935210d')
 
@@ -48,7 +49,9 @@ class NodeJs(Package):
 
     depends_on('libtool', type='build', when=sys.platform != 'darwin')
     depends_on('pkgconfig', type='build')
-    depends_on('python@2.7:2.8', type='build')
+    # todo : avoiding concretisation issue (will use system installed node-js)
+    # depends_on('python@2.7:2.8', type='build')
+    depends_on('python', type='build')
     # depends_on('bash-completion', when="+bash-completion")
     depends_on('icu4c', when='+icu4c')
     depends_on('openssl@1.0.2d:', when='+openssl')

--- a/var/spack/repos/builtin/packages/py-bluepymm/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepymm/package.py
@@ -32,12 +32,12 @@ class PyBluepymm(PythonPackage):
     url = "https://pypi.io/packages/source/b/bluepymm/bluepymm-0.6.38.tar.gz"
 
     version('0.6.38', sha256='3bba40c3553429b29a1567e5f443a0fae8b477872ea9e400b68d9f19404acc34')
-    
+
     depends_on('py-setuptools', type='build')
     depends_on('py-bluepyopt', type='run')
     depends_on('py-matplotlib', type='run')
     # The below dependency should disappear once the matplotlib package is fixed
-    depends_on('py-backports-functools-lru-cache', type='run')
+    depends_on('py-backports-functools-lru-cache', type='run', when="^python@:3.3.99")
     depends_on('py-pandas', type='run')
     depends_on('py-numpy', type='run')
     depends_on('py-ipyparallel', type='run')

--- a/var/spack/repos/builtin/packages/py-csvkit/package.py
+++ b/var/spack/repos/builtin/packages/py-csvkit/package.py
@@ -41,4 +41,4 @@ class PyCsvkit(PythonPackage):
     depends_on('py-xlrd', type=('build', 'run'))
     depends_on('py-sqlalchemy', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))
-    depends_on('py-openpyxl@2.2.0-b1', type=('build', 'run'))
+    depends_on('py-openpyxl', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -41,7 +41,7 @@ class PyH5py(PythonPackage):
     version('2.5.0', '6e4301b5ad5da0d51b0a1e5ac19e3b74')
     version('2.4.0', '80c9a94ae31f84885cc2ebe1323d6758')
 
-    variant('mpi', default=False, description='Build with MPI support')
+    variant('mpi', default=True, description='Build with MPI support')
 
     # Build dependencies
     depends_on('py-cython@0.23:', type='build')

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -41,7 +41,7 @@ class PyH5py(PythonPackage):
     version('2.5.0', '6e4301b5ad5da0d51b0a1e5ac19e3b74')
     version('2.4.0', '80c9a94ae31f84885cc2ebe1323d6758')
 
-    variant('mpi', default=True, description='Build with MPI support')
+    variant('mpi', default=False, description='Build with MPI support')
 
     # Build dependencies
     depends_on('py-cython@0.23:', type='build')

--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -39,12 +39,8 @@ class PyIpython(PythonPackage):
 
     depends_on('python@2.7:2.8,3.3:')
 
-    # These dependencies breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2")  # noqa
-    # depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3")
-    depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'))
-    depends_on('py-pathlib2',                   type=('build', 'run'))
+    depends_on('py-backports-shutil-get-terminal-size', type=('build', 'run'), when="^python@:3.2")  # noqa
+    depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3.3")
 
     depends_on('py-pygments',                   type=('build', 'run'))
     depends_on('py-pickleshare',                type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-markdown/package.py
+++ b/var/spack/repos/builtin/packages/py-markdown/package.py
@@ -36,6 +36,7 @@ class PyMarkdown(PythonPackage):
     homepage = "https://pythonhosted.org/Markdown/"
     url      = "https://pypi.io/packages/source/m/markdown/Markdown-2.6.11.tar.gz"
 
+    version('3.0.1', sha256='e45cda91bfd07195f17ca565226010238b8c90ccfa82a79b15f4379510576335')
     version('2.6.11', sha256='a856869c7ff079ad84a3e19cd87a64998350c2b94e9e08e44270faef33400f81')
     version('2.6.7', sha256='daebf24846efa7ff269cfde8c41a48bb2303920c7b2c7c5e04fa82e6282d05c0')
     version('2.6.6', sha256='9a292bb40d6d29abac8024887bcfc1159d7a32dc1d6f1f6e8d6d8e293666c504')
@@ -49,5 +50,5 @@ class PyMarkdown(PythonPackage):
     version('2.5.1', sha256='8f81ed12c18608a502828acb7d318f362c42f4eca97d01e93cadfc52c1e40b73')
     version('2.5', sha256='6ba74a1e7141c9603750d80711b639a7577bffb785708e6260090239ee5bc76d')
 
-    depends_on('python@2.7:2.8,3.2:3.4')
+    depends_on('python@2.7:2.8,3.2:3.7')
     depends_on('py-setuptools', type='build', when='@2.6.11:')

--- a/var/spack/repos/builtin/packages/py-markdown/package.py
+++ b/var/spack/repos/builtin/packages/py-markdown/package.py
@@ -36,7 +36,7 @@ class PyMarkdown(PythonPackage):
     homepage = "https://pythonhosted.org/Markdown/"
     url      = "https://pypi.io/packages/source/m/markdown/Markdown-2.6.11.tar.gz"
 
-    version('3.0.1', sha256='e45cda91bfd07195f17ca565226010238b8c90ccfa82a79b15f4379510576335')
+    version('3.0.1', sha256='d02e0f9b04c500cde6637c11ad7c72671f359b87b9fe924b2383649d8841db7c')
     version('2.6.11', sha256='a856869c7ff079ad84a3e19cd87a64998350c2b94e9e08e44270faef33400f81')
     version('2.6.7', sha256='daebf24846efa7ff269cfde8c41a48bb2303920c7b2c7c5e04fa82e6282d05c0')
     version('2.6.6', sha256='9a292bb40d6d29abac8024887bcfc1159d7a32dc1d6f1f6e8d6d8e293666c504')

--- a/var/spack/repos/builtin/packages/py-openpyxl/package.py
+++ b/var/spack/repos/builtin/packages/py-openpyxl/package.py
@@ -32,7 +32,6 @@ class PyOpenpyxl(PythonPackage):
     url      = "https://pypi.io/packages/source/o/openpyxl/openpyxl-2.4.5.tar.gz"
 
     version('2.4.5', '3de13dc9b731e1a9dd61b873d9b35a8a')
-    version('2.2.0-b1', 'eeefabe384f6e53166c8c2e6abe5d11b')
 
     depends_on('python@2.6:2.8,3.0:3.1,3.3:')
 

--- a/var/spack/repos/builtin/packages/py-ply/package.py
+++ b/var/spack/repos/builtin/packages/py-ply/package.py
@@ -30,5 +30,5 @@ class PyPly(PythonPackage):
     homepage = "http://www.dabeaz.com/ply"
     url      = "https://github.com/dabeaz/ply/archive/3.11.tar.gz"
 
-    version('3.11', '6465f602e656455affcd7c5734c638f8')
+    version('3.11', sha256='928c5642612f4710b168d3c49c25f6ece2913a5e8d1c5e37fde5d6162fec3fd2')
     version('3.8', '94726411496c52c87c2b9429b12d5c50', url='http://www.dabeaz.com/ply/ply-3.8.tar.gz')

--- a/var/spack/repos/builtin/packages/py-pytorch/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch/package.py
@@ -46,6 +46,7 @@ class PyPytorch(PythonPackage):
     conflicts('+magma', when='~cuda')
     conflicts('+mkldnn', when='@:0.3.2')
 
+    depends_on('cmake@3:', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('py-cffi', type='build')
     depends_on('py-numpy', type=('run', 'build'))

--- a/var/spack/repos/builtin/packages/py-symengine/package.py
+++ b/var/spack/repos/builtin/packages/py-symengine/package.py
@@ -32,15 +32,15 @@ class PySymengine(PythonPackage):
     url      = "https://github.com/symengine/symengine.py/archive/v0.2.0.tar.gz"
     git      = "https://github.com/symengine/symengine.py.git"
 
-    version('develop', branch='master')
-    version('0.2.0', 'e1d114fa12be4c8c7e9f24007e07718c')
+    version('develop',   branch='master')
+    version('0.3.0',     sha256='0ecccfe5a09b25b6640afca12de62062bdb60ed2712d6c16cc47fc1ba1e851ac')
 
     # Build dependencies
     depends_on('python@2.7:2.8,3.3:')
     depends_on('py-setuptools',     type='build')
     depends_on('py-cython@0.19.1:', type='build')
     depends_on('cmake@2.8.7:',      type='build')
-    depends_on('symengine@0.2.0:')
+    depends_on('symengine@0.3.0:')
 
     def build_args(self, spec, prefix):
-        return ['--symengine-dir={0}'.format(spec['symengine'].prefix)]
+        return ['build_ext', '--symengine-dir={0}'.format(spec['symengine'].prefix)]

--- a/var/spack/repos/builtin/packages/py-traitlets/package.py
+++ b/var/spack/repos/builtin/packages/py-traitlets/package.py
@@ -43,7 +43,5 @@ class PyTraitlets(PythonPackage):
     depends_on('py-decorator', type=('build', 'run'))
     depends_on('py-ipython-genutils', type=('build', 'run'))
 
-    # This dependency breaks concretization
-    # See https://github.com/spack/spack/issues/2793
-    # depends_on('py-enum34', when='^python@:3.3', type=('build', 'run'))
-    depends_on('py-enum34', type=('build', 'run'))
+    depends_on('py-enum34', when='^python@2.4:2.7.999,3.1:3.3.999',
+                type=('build', 'run'))


### PR DESCRIPTION
* allow node-js to concretise with python3
* fix py-ipython package as latest develop has fixed concretisation issues
* fix py-bluepymm for python > 3.4
* add new version of py-markdown compatible unto python 3.7