### PR TITLE
Fix intel-mpi module to support GPFS on BB5

### DIFF
--- a/sysconfig/bb5/tools/modules.yaml
+++ b/sysconfig/bb5/tools/modules.yaml
@@ -79,6 +79,12 @@ modules:
       environment:
         set:
           KMP_INIT_AT_FORK: 'FALSE'
+    intel-mpi:
+      environment:
+        set:
+          I_MPI_ROOT: '${PREFIX}'
+          I_MPI_EXTRA_FILESYSTEM: '1'
+          I_MPI_EXTRA_FILESYSTEM_LIST: gpfs
   tcl:
     all:
       filter:
@@ -134,3 +140,9 @@ modules:
       environment:
         set:
           KMP_INIT_AT_FORK: 'FALSE'
+    intel-mpi:
+      environment:
+        set:
+          I_MPI_ROOT: '${PREFIX}'
+          I_MPI_EXTRA_FILESYSTEM: '1'
+          I_MPI_EXTRA_FILESYSTEM_LIST: gpfs


### PR DESCRIPTION
@jplanasc  : this should fix your issue. I have updated module on BB5:

```
$ module show intel-mpi/2018.1.163
-------------------------------------------------------------------
/gpfs/bbp.cscs.ch/apps/tools/modules/tcl/linux-rhel7-x86_64/intel-mpi/2018.1.163:

module-whatis	 Intel MPI
prepend-path	 PATH /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mpi-2018.1.163-p7q2uq/bin
prepend-path	 CMAKE_PREFIX_PATH /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mpi-2018.1.163-p7q2uq/
prepend-path	 CLASSPATH /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mpi-2018.1.163-p7q2uq/compilers_and_libraries_2018.1.163/linux/mpi/intel64/lib/mpi.jar
setenv		 I_MPI_ROOT /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mpi-2018.1.163-p7q2uq/compilers_and_libraries_2018.1.163/linux/mpi
prepend-path	 LD_LIBRARY_PATH /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mpi-2018.1.163-p7q2uq/compilers_and_libraries_2018.1.163/linux/mpi/intel64/lib:/gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mpi-2018.1.163-p7q2uq/compilers_and_libraries_2018.1.163/linux/mpi/mic/lib
prepend-path	 MANPATH /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mpi-2018.1.163-p7q2uq/compilers_and_libraries_2018.1.163/linux/mpi/man
prepend-path	 PATH /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mpi-2018.1.163-p7q2uq/compilers_and_libraries_2018.1.163/linux/mpi/intel64/bin
setenv		 I_MPI_ROOT /gpfs/bbp.cscs.ch/apps/tools/install/linux-rhel7-x86_64/gcc-4.8.5/intel-mpi-2018.1.163-p7q2uq
setenv		 I_MPI_EXTRA_FILESYSTEM 1
setenv		 I_MPI_EXTRA_FILESYSTEM_LIST gpfs
-------------------------------------------------------------------
```