### PR TITLE
trilinos: 12.12.1 -> xsdk-0.4.0-rc1

### DIFF
--- a/sysconfig/bb5/users/packages.yaml
+++ b/sysconfig/bb5/users/packages.yaml
@@ -168,7 +168,7 @@ packages:
         compiler: [gcc]
     trilinos:
         variants: +kokkos+teuchos~amesos~hypre~superlu-dist~mumps~metis~suite-sparse
-        version: [develop]
+        version: [xsdk-0.4.0-rc1]
     tk:
         paths:
             tk@8.5.13: /usr

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -51,6 +51,7 @@ class Trilinos(CMakePackage):
 
     # ###################### Versions ##########################
 
+    version('xsdk-0.4.0-rc1', tag='xsdk-0.4.0-rc1')
     version('xsdk-0.2.0', tag='xsdk-0.2.0')
     version('develop', branch='develop')
     version('master', branch='master')


### PR DESCRIPTION
omega-h build with trilinos@xsdk-0.4.0-rc1. So make it the default version instead of `develop`.