### PR TITLE
Adding support for sonata since synapsetool is static

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1107,6 +1107,19 @@ class LibraryList(FileList):
         return list(dedupe(names))
 
     @property
+    def rpath_flags(self):
+        """Rpath flags for the libraries
+
+        >>> l = LibraryList(['/dir1/liba.a', '/dir2/libb.a', '/dir1/liba.so'])
+        >>> l.rpath_flags
+        '-Wl,-rpath -Wl,/dir1 -Wl,-rpath -Wl,/dir2'
+
+        Returns:
+            str: A joined list of rpath flags
+        """
+        return ' '.join(['-Wl,-rpath,' + x for x in self.directories])
+
+    @property
     def search_flags(self):
         """Search flags for the libraries
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1112,7 +1112,7 @@ class LibraryList(FileList):
 
         >>> l = LibraryList(['/dir1/liba.a', '/dir2/libb.a', '/dir1/liba.so'])
         >>> l.rpath_flags
-        '-Wl,-rpath -Wl,/dir1 -Wl,-rpath -Wl,/dir2'
+        '-Wl,-rpath,/dir1 -Wl,-rpath,/dir2'
 
         Returns:
             str: A joined list of rpath flags

--- a/var/spack/repos/builtin/packages/neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus/package.py
@@ -93,9 +93,9 @@ class Neurodamus(NeurodamusBase):
         ld_flags = find_libraries('libsyn2', spec["synapsetool"].prefix, shared, True).ld_flags
         if not shared:
             for lib in ['libboost_system-mt', 'libboost_filesystem-mt']:
-                ld_flags += ' ' + find_libraries(lib, spec['boost'].prefix, False, True).ld_flags
+                ld_flags += ' ' + find_libraries(lib, spec['boost'].prefix, False, True)[0]
             if spec['synapsetool'].satisfies("+sonata"):
-                ld_flags += ' ' + find_libraries('libsonata', spec['libsonata'].prefix, False, True).ld_flags
+                ld_flags += ' ' + find_libraries('libsonata', spec['libsonata'].prefix, False, True)[0]
         return ld_flags
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus/package.py
@@ -30,19 +30,24 @@ from contextlib import contextmanager
 
 
 class Neurodamus(NeurodamusBase):
-
-    """Package used for building special from NeurodamusBase package"""
-
+    """Package used for building special from NeurodamusBase package
+    """
     variant('coreneuron', default=True, description="Enable CoreNEURON Support")
     variant('profile', default=False, description="Enable profiling using Tau")
-    variant('syntool', default=True, description="Enable Synapsetool reader")
     variant('python', default=False, description="Enable Python Neurodamus")
+    variant('syntool', default=True, description="Enable Synapsetool reader")
+    variant('sonata', default=False, description="Enable Synapsetool with Sonata")
 
-    depends_on("hdf5")
-    depends_on("mpi")
-    depends_on("neuron")
+    depends_on('mpi')
+    depends_on('hdf5+mpi')
+    depends_on('neuron')
     depends_on('reportinglib')
-    depends_on("zlib")
+    depends_on('synapsetool+mpi', when='+syntool~sonata')
+    depends_on('synapsetool+mpi+sonata', when='+syntool+sonata')
+    # Indirect deps, req'ed if we use static libs
+    depends_on('zlib')
+    depends_on('boost@1.55:', when="+syntool")
+    depends_on('libsonata+mpi', when='+sonata')
 
     depends_on('coreneuron', when='+coreneuron')
     depends_on('coreneuron+profile', when='+profile')
@@ -52,17 +57,16 @@ class Neurodamus(NeurodamusBase):
     depends_on('neurodamus-base@hippocampus', when='@hippocampus')
     depends_on('neurodamus-base@plasticity', when='@plasticity')
 
-    depends_on("neuron+profile", when='+profile')
+    depends_on('neuron+profile', when='+profile')
     depends_on('reportinglib+profile', when='+profile')
-    depends_on('synapsetool', when='+syntool')
     depends_on('tau', when='+profile')
 
-    depends_on("python@2.7:",      type=('build', 'run'), when='+python')
-    depends_on("py-setuptools",    type=('build', 'run'), when='+python')
-    depends_on("py-h5py",          type=('build', 'run'), when='+python')
-    depends_on("py-numpy",         type=('build', 'run'), when='+python')
+    depends_on('python@2.7:',      type=('build', 'run'), when='+python')
+    depends_on('py-setuptools',    type=('build', 'run'), when='+python')
+    depends_on('py-h5py',          type=('build', 'run'), when='+python')
+    depends_on('py-numpy',         type=('build', 'run'), when='+python')
     depends_on('py-enum34',        type=('build', 'run'), when='^python@2.4:2.7.999,3.1:3.3.999')
-    depends_on("py-lazy-property", type=('build', 'run'), when='+python')
+    depends_on('py-lazy-property', type=('build', 'run'), when='+python')
 
     # coreneuron support is available for plasticity model
     # and requires python support in neuron
@@ -85,27 +89,25 @@ class Neurodamus(NeurodamusBase):
         """
         profile_flag = '-DENABLE_TAU_PROFILER' if '+profile' in spec else ''
         include_flag = ''
-        link_flag = ''
+        link_flag = '-Wl,--as-needed'  # Allow deps to not recurs bring their deps
         env['MAKEFLAGS'] = '-j{0}'.format(make_jobs)
 
         if '+syntool' in spec:
             include_flag += ' -DENABLE_SYNTOOL -I ' + spec['synapsetool'].prefix.include
-            link_flag += spec['synapsetool'].libs.rpath_flags
-            link_flag += ' ' + spec['synapsetool'].libs.ld_flags
 
         if '+coreneuron' in spec:
             include_flag += ' -DENABLE_CORENEURON -I%s' % (spec['coreneuron'].prefix.include)
-            link_flag += ' ' + spec['coreneuron'].libs.rpath_flags
-            link_flag += ' ' + spec['coreneuron'].libs.ld_flags
 
         include_flag += ' -I%s -I%s %s' % (spec['reportinglib'].prefix.include,
                                            spec['hdf5'].prefix.include,
                                            profile_flag)
-        link_flag += ' %s %s -L%s -lhdf5 -L%s -lz' % (
-                     spec['reportinglib'].libs.rpath_flags,
-                     spec['reportinglib'].libs.ld_flags,
-                     spec['hdf5'].prefix.lib,
-                     spec['zlib'].prefix.lib)
+        # Handle dependencies. If shared use -rpath, -L, -l, otherwise lib path
+        for dep in ['reportinglib', 'hdf5', 'synapsetool']:
+            if spec[dep].satisfies('+shared'):
+                link_flag += " %s %s" % (spec[dep].libs.rpath_flags,
+                                         spec[dep].libs.ld_flags)
+            else:
+                link_flag += " " + " ".join(spec[dep].libs)
 
         nrnivmodl = which('nrnivmodl')
         with profiling_wrapper_on():

--- a/var/spack/repos/builtin/packages/neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus/package.py
@@ -102,12 +102,16 @@ class Neurodamus(NeurodamusBase):
                                            spec['hdf5'].prefix.include,
                                            profile_flag)
         # Handle dependencies. If shared use -rpath, -L, -l, otherwise lib path
-        for dep in ['reportinglib', 'hdf5', 'synapsetool']:
+        dep_libs = ['reportinglib', 'hdf5',  'zlib']
+        if spec.satisfies('+syntool'):
+            dep_libs.append('synapsetool')
+        for dep in dep_libs:
             if spec[dep].satisfies('+shared'):
-                link_flag += " %s %s" % (spec[dep].libs.rpath_flags,
-                                         spec[dep].libs.ld_flags)
+                link_flag += " %s %s" % (spec[dep].libs.rpath_flags, spec[dep].libs.ld_flags)
             else:
-                link_flag += " " + " ".join(spec[dep].libs)
+                link_flag += " " + spec[dep].libs.joined()
+        if spec.satisfies('^synapsetool~shared'):
+            link_flag += ' ' + spec['synapsetool'].package.dependency_libs(spec).joined()
 
         nrnivmodl = which('nrnivmodl')
         with profiling_wrapper_on():


### PR DESCRIPTION
Building synapsetool statically is used to avoid relying to LD_LIBRARY_PATH (no RPATH in neurodamus)
We then introduce the two synapsetool dependencies directly in neurodamus.

In this patch two aspects were taken into account:
 - Explicitly marking these dependencies `when(~shared)` to prepare for an eventual compat with shared libs in the future
 - We dont rely on synapsetool spec.libs since it was creating problems using external pakcages