### PR TITLE
Add variants that we want to keep in export

### DIFF
--- a/lib/spack/spack/cmd/export.py
+++ b/lib/spack/spack/cmd/export.py
@@ -110,6 +110,10 @@ def export(parser, args):
 
     pymods = {}
 
+    # variants that needs to be propogated to packages.yaml even if they
+    # have default value (workaround for external packages)
+    variants_to_keep = ['mpi', 'python']
+
     # Dump per package, make sure that none are forgotten
     for pkg, pkg_specs in pkgs.items():
         paths = syaml_dict()
@@ -127,7 +131,7 @@ def export(parser, args):
                 default = None
                 if k in spec.package.variants:
                     default = spec.package.variants[k].default
-                if v.value != default:
+                if v.value != default or v.name in variants_to_keep:
                     if v.value in (True, False):
                         bflags.append(v)
                     elif v.name != 'patches':

--- a/var/spack/repos/builtin/packages/neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus/package.py
@@ -39,7 +39,7 @@ class Neurodamus(NeurodamusBase):
     variant('python', default=False, description="Enable Python Neurodamus")
 
     depends_on("boost", when="+syntool")
-    depends_on("hdf5")
+    depends_on("hdf5+mpi")
     depends_on("mpi")
     depends_on("neuron")
     depends_on('reportinglib')


### PR DESCRIPTION
Update neurodamus package

@matz-e  : this PR is `workaround` (we can discuss). Not sure better way to handle. Wonder if we should dump all variants.