### PR TITLE
intel-mkl: fix usage of openmp_libs and tbb_libs (#9863)

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -693,7 +693,7 @@ class IntelPackage(PackageBase):
             gcc = Executable(self.compiler.cc)
             omp_lib_path = gcc(
                 '--print-file-name', 'libgomp.%s' % dso_suffix, output=str)
-            omp_libs = LibraryList(omp_lib_path)
+            omp_libs = LibraryList(omp_lib_path.strip())
 
         if len(omp_libs) < 1:
             raise_lib_error('Cannot locate OpenMP libraries:', omp_libnames)
@@ -760,10 +760,10 @@ class IntelPackage(PackageBase):
                 mkl_threading = 'libmkl_intel_thread'
             elif '%gcc' in self.spec:
                 mkl_threading = 'libmkl_gnu_thread'
-            threading_engine_libs = self.openmp_libs()
+            threading_engine_libs = self.openmp_libs
         elif self.spec.satisfies('threads=tbb'):
             mkl_threading = 'libmkl_tbb_thread'
-            threading_engine_libs = self.tbb_libs()
+            threading_engine_libs = self.tbb_libs
         elif self.spec.satisfies('threads=none'):
             mkl_threading = 'libmkl_sequential'
             threading_engine_libs = LibraryList([])


### PR DESCRIPTION
* intel-mkl: fix usage of openmp_libs and tbb_libs
* intel-mkl: remove trailing whitespace from openmp lib