### PR TITLE
Fix dependency check with +syntool directly

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus/package.py
@@ -109,7 +109,7 @@ class Neurodamus(NeurodamusBase):
                 link_flag += " %s %s" % (spec[dep].libs.rpath_flags, spec[dep].libs.ld_flags)
             else:
                 link_flag += " " + spec[dep].libs.joined()
-        if spec.satisfies('^synapsetool~shared'):
+        if spec.satisfies('+syntool') and spec.satisfies('^synapsetool~shared'):
             link_flag += ' ' + spec['synapsetool'].package.dependency_libs(spec).joined()
 
         nrnivmodl = which('nrnivmodl')


### PR DESCRIPTION
Tests currently fail since spack considers that `spec.satisfies('^synapsetool~shared')` is true, even when synapsetool is not a dependency, hence `spec['synapsetool']...` is executed
This patch tests for the dependency on synapsetool by checking the variant in the first place