### PR TITLE
Enable modules for synapsetool and reportinglib

### DIFF
--- a/sysconfig/bb5/users/modules.yaml
+++ b/sysconfig/bb5/users/modules.yaml
@@ -38,8 +38,10 @@ modules:
       - neurodamus
       - parquet-converters
       - python
+      - reportinglib
       - spykfunc
       - steps
+      - synapsetool
       - touchdetector
     blacklist:
       - '%gcc'


### PR DESCRIPTION
Adding modules to bbp software. Needed also for tests in blueconfigs