### PR TITLE
Update Jureca configurations :

### DIFF
--- a/sysconfig/jureca-booster/compilers.yaml
+++ b/sysconfig/jureca-booster/compilers.yaml
@@ -29,9 +29,7 @@ compilers:
     environment: {}
     extra_rpaths: []
     flags: {}
-    modules:
-    - Architecture/KNL
-    - Intel
+    modules: []
     operating_system: centos7
     paths:
       cc: /usr/local/software/jurecabooster/Stages/2018a/software/icc/2018.2.199-GCC-5.5.0/compilers_and_libraries_2018.2.199/linux/bin/intel64/icc

--- a/sysconfig/jureca-booster/modules.yaml
+++ b/sysconfig/jureca-booster/modules.yaml
@@ -22,6 +22,7 @@ modules:
       - CMAKE_PREFIX_PATH
   tcl:
     all:
+      autoload: 'all'
       suffixes:
           '+profile': 'profile'
           '^coreneuron+knl': 'knl'
@@ -32,6 +33,8 @@ modules:
     whitelist:
       - 'neurodamus'
       - 'neuron'
+      - 'python'
+      - 'py-bluepyopt'
     blacklist:
       - '%gcc'
       - '%intel'

--- a/sysconfig/jureca-booster/packages.yaml
+++ b/sysconfig/jureca-booster/packages.yaml
@@ -35,21 +35,25 @@ packages:
             intel-mpi-external@5.5.0: /usr/local/software/jurecabooster/Stages/2018a/software/impi/2018.2.199-iccifort-2018.2.199-GCC-5.5.0/intel64
         version: [5.5.0]
         buildable: False
+    intel-mkl:
+        paths:
+            intel-mkl@2018.2.199: /usr/local/software/jurecabooster/Stages/2018a/software/imkl/2018.2.199-ipsmpi-2018a/
+        version: [2018.2.199]
+        buildable: False
     m4:
         paths:
             m4@1.4.16: /usr
         buildable: False
         version: [1.4.16]
+    openssl:
+        paths:
+            openssl@system: /usr
     pkg-config:
         paths:
             pkg-config@0.29.1: /usr
-        buildable: False
         version: [0.29.1]
     python:
-        paths:
-            python@2.7.14: /usr/local/software/jurecabooster/Stages/2018a/software/Python/2.7.14-GCCcore-5.5.0
-        version: [2.7.14]
-        buildable: False
+        version: [2.7.15]
     zlib:
         version: [1.2.8]
     all:

--- a/sysconfig/jureca-cluster/compilers.yaml
+++ b/sysconfig/jureca-cluster/compilers.yaml
@@ -3,21 +3,6 @@ compilers:
     environment: {}
     extra_rpaths: []
     flags: {}
-    modules:
-    - Architecture/Haswell
-    - GCC/5.5.0
-    operating_system: centos7
-    paths:
-      cc: /usr/local/software/jureca/Stages/2018a/software/GCCcore/5.5.0/bin/gcc
-      cxx: /usr/local/software/jureca/Stages/2018a/software/GCCcore/5.5.0/bin/g++
-      f77: /usr/local/software/jureca/Stages/2018a/software/GCCcore/5.5.0/bin/gfortran
-      fc: /usr/local/software/jureca/Stages/2018a/software/GCCcore/5.5.0/bin/gfortran
-    spec: gcc@5.5.0
-    target: x86_64
-- compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
     modules: []
     operating_system: centos7
     paths:
@@ -31,9 +16,7 @@ compilers:
     environment: {}
     extra_rpaths: []
     flags: {}
-    modules:
-    - Architecture/Haswell
-    - Intel
+    modules: []
     operating_system: centos7
     paths:
       cc: /usr/local/software/jureca/Stages/2018a/software/icc/2018.2.199-GCC-5.5.0/compilers_and_libraries_2018.2.199/linux/bin/intel64/icc

--- a/sysconfig/jureca-cluster/modules.yaml
+++ b/sysconfig/jureca-cluster/modules.yaml
@@ -22,6 +22,7 @@ modules:
       - CMAKE_PREFIX_PATH
   tcl:
     all:
+      autoload: 'all'
       suffixes:
           '+profile': 'profile'
           '^coreneuron+knl': 'knl'
@@ -32,6 +33,8 @@ modules:
     whitelist:
       - 'neurodamus'
       - 'neuron'
+      - 'python'
+      - 'py-bluepyopt'
     blacklist:
       - '%gcc'
       - '%intel'

--- a/sysconfig/jureca-cluster/packages.yaml
+++ b/sysconfig/jureca-cluster/packages.yaml
@@ -32,6 +32,11 @@ packages:
             intel-mpi-external@5.5.0: /usr/local/software/jureca/Stages/2018a/software/impi/2018.2.199-iccifort-2018.2.199-GCC-5.5.0/intel64
         version: [5.5.0]
         buildable: False
+    intel-mkl:
+        paths:
+            intel-mkl@2018.2.199: /usr/local/software/jurecabooster/Stages/2018a/software/imkl/2018.2.199-ipsmpi-2018a
+        version: [2018.2.199]
+        buildable: False
     m4:
         paths:
             m4@1.4.16: /usr
@@ -43,13 +48,9 @@ packages:
     pkg-config:
         paths:
             pkg-config@0.29.1: /usr
-        buildable: False
         version: [0.29.1]
     python:
-        paths:
-            python@2.7.14: /usr/local/software/jureca/Stages/2018a/software/Python/2.7.14-GCCcore-5.5.0
-        version: [2.7.14]
-        buildable: False
+        version: [2.7.15]
     zlib:
         version: [1.2.8]
     all:


### PR DESCRIPTION
   - use 2018 stack because intel mpi 2019 causes deadlock on booster
   - install python 2.7.15 from source for bluepyopt and cython
   - use intel-mkl for numpy installation
   - remove some buildable false for concretiser