### PR TITLE
Fix neurodamus build on OS X : gnu specific linker flag

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus/package.py
@@ -26,6 +26,7 @@ from spack import *
 from spack.pkg.builtin.neurodamus_base import NeurodamusBase
 import os
 import shutil
+import sys
 from contextlib import contextmanager
 
 
@@ -92,7 +93,8 @@ class Neurodamus(NeurodamusBase):
         env['MAKEFLAGS'] = '-j{0}'.format(make_jobs)
         profile_flag = '-DENABLE_TAU_PROFILER' if '+profile' in spec else ''
 
-        link_flag = '-Wl,--as-needed'  # Allow deps to not recurs bring their deps
+        # Allow deps to not recurs bring their deps
+        link_flag = '-Wl,--as-needed' if sys.platform != 'darwin' else ''
         include_flag = ' -I%s -I%s %s' % (spec['reportinglib'].prefix.include,
                                           spec['hdf5'].prefix.include,
                                           profile_flag)


### PR DESCRIPTION
@ferdonline  : While building on OS X with Clang/LLVM

```
libtool: link: /usr/local/Cellar/mpich/3.2.1_2/bin/mpic++ -O2 -g -D_THREAD_SAFE -Wl,--as-needed -Wl,-rpath -Wl,/Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/reportinglib-develop-z5kwrtnxto2fec4iu3yl6eztpuaakwh2/lib64 -Wl,-rpath -Wl,/usr/local/Cellar/hdf5/1.10.2_1/lib -Wl,-rpath -Wl,/usr/local/lib -Wl,-rpath -Wl,/Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/synapsetool-0.3.2-7h37yixwjrn5z6n4q6b4jl473x3rywyz/lib64 -Wl,-rpath -Wl,/Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/coreneuron-plasticity-ogwx2zxo5cekrlypsxex2cdyjbeukwrc/lib64 -headerpad_max_install_names -o special /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/nrnmain.o /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/ivocmain.o /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/nvkludge.o ALU.o ASCIIrecord.o BK.o BinReportHelper.o BinReports.o Ca.o CaDynamics_DC0.o CaDynamics_DC0_hip.o CaDynamics_DC1.o CaDynamics_DC2.o CaDynamics_DC_hip.o CaDynamics_E.o CaDynamics_E2.o CaDynamics_E3.o Ca_HVA.o Ca_HVA2.o Ca_LVA.o Ca_LVAs.o Ca_LVAst.o CoreConfig.o DetAMPANMDA.o DetGABAAB.o GluSynapse.o HCN1_0061.o HCN2_0062.o HCN3_0063.o HCN4_0064.o HDF5reader.o HDF5record.o HHK.o HHK1.o HHK2.o HHK3.o HHK_MC.o IM2.o ISynAMPAEx.o ISynNMDAEx.o Ih.o Im.o KCa1.o KCa2.o KCa3.o K_P.o K_Ps.o K_Pst.o K_T.o K_Ts.o K_Tst.o KahpM95_hip.o Kd.o KdShu2007.o Kfast.o Kfast10oct07.o Kfast_E.o Kfast_S.o Kslow.o Kslow10oct07.o Kslow_E.o Kslow_S.o Kv1_1.o Kv1_2.o Kv1_3.o Kv1_4.o Kv1_5.o Kv1_6.o Kv2_1.o Kv2_2.o Kv3_1.o Kv3_3.o Kv3_4.o MemUsage.o Na.o Na10oct07.o NaTa_t.o NaTaxon.o NaTg.o NaTg2.o NaTs.o NaTs2_t.o Na_E.o Na_S.o Nap.o Nap_E.o Nap_Et2.o Nav1_6.o ProbAMPA.o ProbAMPANMDA.o ProbAMPANMDA_EMS.o ProbGABAA.o ProbGABAAB_EMS.o ProbGABAA_EMS.o ProbNMDA.o ProfileHelper.o SK_E.o SK_E2.o SK_S.o SKv3_1.o SKv3_1t.o SpikeWriter.o StdpWADoublet.o StdpWATriplet.o StochKv.o StochKv2.o StochKv3.o SynapseReader.o TTXDynamicsSwitch.o VecStim.o _CSA.o _CSK.o _GNoise.o _calcium.o _calcium2.o _calciumc_concentration.o _iAHP.o _iM.o _outside_calcium_concentration.o cacum_hip.o cagk_hip.o cahva_hip.o cal_hip.o calcium_dynamics.o calcium_shaul.o calva_hip.o can_hip.o cat_hip.o epsp.o gap.o h_hip.o hcn3.o hd2_hip.o hd_hip.o hdf5.o hdf5new.o kad2_hip.o kad_hip.o kap2_hip.o kap_hip.o kdr2_hip.o kdr_hip.o km1.o km2_hip.o km_hip.o lookupTableV2.o memoryaccess.o na2.o na3_hip.o na4_hip.o na_hip.o nax_hip.o netstim_inhpoisson.o new_calcium_channels.o pump.o sk2_hip.o sk_hip.o tmgExSyn.o tmgInhSyn.o traub.o utility.o xtra.o mod_func.o  -L/Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/reportinglib-develop-z5kwrtnxto2fec4iu3yl6eztpuaakwh2/lib64 -lreportinglib -L/usr/local/Cellar/hdf5/1.10.2_1/lib -L/usr/local/lib -lhdf5 -L/Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/synapsetool-0.3.2-7h37yixwjrn5z6n4q6b4jl473x3rywyz/lib64 -lsyn2 -L/Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/coreneuron-plasticity-ogwx2zxo5cekrlypsxex2cdyjbeukwrc/lib64 -lcoreneuron -L/Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libnrnoc.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libnrniv.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libivoc.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/liboc.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libneuron_gnu.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libscopmath.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libsparse13.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libsundials.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libnrnmpi.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libmemacs.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libmeschach.dylib /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libivos.dylib -lreadline -lncurses /Users/kumbhar/workarena/software/sources/spack/opt/spack/darwin-sierra-x86_64/clang-9.0.0-apple/neuron-2018-10-hmof6dku5i7ove25ezus7lbk5lnog2wb/x86_64/lib/libnrnpython.dylib -L/System/Library/Frameworks/Python.framework/Versions/2.7/lib -lpython2.7 -ldl -framework CoreFoundation
ld: unknown option: --as-needed
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [special] Error 1
==> Error: AssertionError:

/Users/kumbhar/workarena/software/sources/spack/var/spack/repos/builtin/packages/neurodamus/package.py:119, in build:
        116        with profiling_wrapper_on():
        117            nrnivmodl('-incflags', include_flag, '-loadflags', link_flag, 'm')
        118        special = os.path.join(os.path.basename(self.neuron_archdir), 'special')
  >>    119        assert os.path.isfile(special)
```