### PR TITLE
deployment: keep specifying spack branch.

### DIFF
--- a/deploy/Jenkinsfile
+++ b/deploy/Jenkinsfile
@@ -98,7 +98,7 @@ pipeline {
             // license files are available to Spack
             steps {
                 dir("${DEPLOYMENT_ROOT}/spack") {
-                    git(url: "https://github.com/BlueBrain/spack.git")
+                    git(url: "https://github.com/BlueBrain/spack.git", branch: "develop")
                 }
                 dir("${DEPLOYMENT_ROOT}/spack/etc/spack/licenses") {
                     git(url: "ssh://bbpcode.epfl.ch/user/kumbhar/spack-licenses")

--- a/deploy/configs/external-libraries/modules.yaml
+++ b/deploy/configs/external-libraries/modules.yaml
@@ -28,6 +28,7 @@ modules:
     hash_length: 0
     whitelist:
       - cuda
+      - spark
     blacklist:
       - '%gcc'
       - '%intel'

--- a/deploy/configs/serial-libraries/modules.yaml
+++ b/deploy/configs/serial-libraries/modules.yaml
@@ -34,7 +34,6 @@ modules:
       - neuron
       - 'python-dev'
       - 'python%gcc'
-      - spark
     blacklist:
       - '%gcc'
       - '%intel'


### PR DESCRIPTION
@pramodk seems like dropping the branch did not do the right thing (it always succeeds in PRs, though, due to a different setup logic). This adds an explicit reference to `develop`.