### PR TITLE
hpe-mpi: add libraries into LD_LIBRARY_PATH

### DIFF
--- a/var/spack/repos/builtin/packages/hpe-mpi/package.py
+++ b/var/spack/repos/builtin/packages/hpe-mpi/package.py
@@ -24,6 +24,9 @@ class HpeMpi(Package):
         spack_env.set('MPICXX_CXX', spack_cxx)
         spack_env.set('MPIF90_F90', spack_fc)
 
+        libdir = self.prefix.lib
+        spack_env.prepend_path('LD_LIBRARY_PATH', libdir)
+
     def setup_dependent_package(self, module, dep_spec):
         bindir = self.prefix.bin
         self.spec.mpicc = join_path(bindir, 'mpicc')


### PR DESCRIPTION
This is needed to make MPI calls work on BlueBrain5 when running with
`spack install --test=root…`.

@pramodk this fixes issues with BlueBrain/zee#41 et al for me locally.