### PR TITLE
Bug fix with MODULEPATH

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -279,7 +279,7 @@ _sp_multi_pathadd() {
         setopt sh_word_split
     fi
     for pth in "$2"; do
-        _spack_pathadd "$1" "$pth"
+        _spack_pathadd "$1" "$pth/$_sp_sys_type"
     done
 }
 _sp_multi_pathadd MODULEPATH "$_sp_tcl_roots"


### PR DESCRIPTION
6ec7bac5cfc627 removed arch from MODULEPATH resulting in module
avail showing

```
$ echo $MODULEPATH
/Users/kumbhar/workarena/software/sources/spack/share/spack/modules
$ module av
darwin-sierra-x86_64/boost-1.58-clang-9.0.0-apple
```
This commit adds arch back to modulepath:

```
$ echo $MODULEPATH
/Users/kumbhar/workarena/software/sources/spack/share/spack/modules/darwin-sierra-x86_64
$ module av
boost-1.58-clang-9.0.0-apple
```

@ferdonline  : this is why we were experiencing issues.