### PR TITLE
Adding user modules for new neurodamus (hip & tha)

### DIFF
--- a/sysconfig/bb5/users/modules.yaml
+++ b/sysconfig/bb5/users/modules.yaml
@@ -37,6 +37,8 @@ modules:
       - neuron
       - neurodamus
       - neurodamus-neocortex
+      - neurodamus-hippocampus
+      - neurodamus-thalamus
       - parquet-converters
       - python
       - reportinglib


### PR DESCRIPTION
neurodamus-hippocampus is  [passing the tests](https://bbpcode.epfl.ch/ci/blue/organizations/jenkins/hpc.SimulationStack/detail/hpc.SimulationStack/261/pipeline). Before it wouldn't due to core using Random123 by default).
neurodamus-thalamus recipe seems to be building well, so allowing module to be created as well. Eventual bugs are not expected from spack side.