### PR TITLE
py-morphio: add hdf5 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-morphio/package.py
+++ b/var/spack/repos/builtin/packages/py-morphio/package.py
@@ -19,3 +19,4 @@ class PyMorphio(PythonPackage):
 
     depends_on('cmake@3.2:', type='build')
     depends_on('py-numpy', type='run')
+    depends_on('hdf5~mpi', type=('build', 'run'))


### PR DESCRIPTION
`ldd` will show that MorphIO links to the system one otherwise.