### PR TITLE
Add python packages required to use hpc-coding-conventions

### DIFF
--- a/var/spack/repos/builtin/packages/py-aspy-yaml/package.py
+++ b/var/spack/repos/builtin/packages/py-aspy-yaml/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyAspyYaml(PythonPackage):
+    """Some extensions to pyyaml"""
+
+    homepage = "https://github.com/asottile/aspy.yaml"
+    url      = "https://files.pythonhosted.org/packages/23/53/e80eea1877989d7ea6cd055be5a0addd4b60223a9340c7b82017d1401f0a/aspy.yaml-1.1.2.tar.gz"
+
+    version('1.1.2', sha256='5eaaacd0886e8b581f0e4ff383fb6504720bb2b3c7be17307724246261a41adf')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-pyyaml', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-cfgv/package.py
+++ b/var/spack/repos/builtin/packages/py-cfgv/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyCfgv(PythonPackage):
+    """Validate configuration and produce human readable error messages."""
+
+    homepage = "https://github.com/asottile/cfgv"
+    url      = "https://files.pythonhosted.org/packages/84/7a/84fe8269f1bafb906b660917820d329c863b845b73b2e150de8900837470/cfgv-1.4.0.tar.gz"
+
+    version('1.4.0', sha256='39d9055c47e3932908fe25abd5807e21dc002630db01c7a5f05738d027e2b706')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-six',        type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-cmake-format/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake-format/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyCmakeFormat(PythonPackage):
+    """Source code formatter for cmake listfiles."""
+
+    homepage = "https://github.com/cheshirekow/cmake_format"
+    url      = "https://files.pythonhosted.org/packages/d8/3f/14e1a63402eeb664b35392b33450f27f0a7f8d00d8b0c26e8e108d9cef24/cmake_format-0.4.5.tar.gz"
+
+    version('0.4.5', sha256='16602408c774cd989ecfa25883de4c2dbac937e3890b735be4aab76f9647875a')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-contextlib2/package.py
+++ b/var/spack/repos/builtin/packages/py-contextlib2/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyContextlib2(PythonPackage):
+    """Backports and enhancements for the contextlib module"""
+
+    homepage = "http://contextlib2.readthedocs.org/"
+    url      = "https://files.pythonhosted.org/packages/6e/db/41233498c210b03ab8b072c8ee49b1cd63b3b0c76f8ea0a0e5d02df06898/contextlib2-0.5.5.tar.gz"
+
+    version('0.5.5', sha256='509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48')

--- a/var/spack/repos/builtin/packages/py-identify/package.py
+++ b/var/spack/repos/builtin/packages/py-identify/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyIdentify(PythonPackage):
+    """File identification library for Python"""
+
+    homepage = "https://github.com/chriskuehl/identify"
+    url      = "https://files.pythonhosted.org/packages/6d/10/888a9535d6dd93d8ade00ca52edc682ed16131b3db69efbb7aa4a7bf4f8e/identify-1.2.2.tar.gz"
+
+    version('1.2.2', sha256='d3ddec4436e043c3398392b4ba8936b4ab52fa262284e767eb6c351d9b3ab5b7')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyImportlibMetadata(PythonPackage):
+    """Read metadata from Python packages"""
+
+    homepage = "https://importlib-metadata.readthedocs.io/en/latest/"
+    url      = "https://files.pythonhosted.org/packages/af/6a/ef5cac9b429b974df7189bc35c974251b91c38bc9c7b74a0ed56cf0baf9a/importlib_metadata-0.8.tar.gz"
+
+    version('0.8', sha256='b50191ead8c70adfa12495fba19ce6d75f2e0275c14c5a7beb653d6799b512bd')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-configparser', type=('build', 'run'), when="^python@:3")
+    depends_on('py-contextlib2', type=('build', 'run'), when="^python@:3")
+    depends_on('py-pathlib2', type=('build', 'run'), when="^python@:3")
+    depends_on('py-typing', type=('build', 'run'), when="^python@:3.5")
+    depends_on('py-zipp@0.3.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-importlib-resources/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-resources/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyImportlibResources(PythonPackage):
+    """Provides for access to resources in Python packages"""
+
+    homepage = "https://importlib-resources.readthedocs.io/en/latest/"
+    url      = "https://files.pythonhosted.org/packages/83/a4/ce09af12e1a91b5b77cefc893ef5054619553734c5b42f143d93ed581744/importlib_resources-1.0.2.tar.gz"
+
+    version('1.0.2', sha256='d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-pathlib2', type=('build', 'run'), when='^python@:3')
+    depends_on('py-typing', type=('build', 'run'), when='^python@:3.5')

--- a/var/spack/repos/builtin/packages/py-nodeenv/package.py
+++ b/var/spack/repos/builtin/packages/py-nodeenv/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyNodeenv(PythonPackage):
+    """Node.js virtual environment builder"""
+
+    homepage = "https://github.com/ekalinin/nodeenv"
+    url      = "https://files.pythonhosted.org/packages/00/6e/ed417bd1ed417ab3feada52d0c89ab0ed87d150f91590badf84273e047c9/nodeenv-1.3.3.tar.gz"
+
+    version('1.3.3', sha256='ad8259494cf1c9034539f6cced78a1da4840a4b157e23640bc4a0c0546b0cb7a')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-pre-commit/package.py
+++ b/var/spack/repos/builtin/packages/py-pre-commit/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPreCommit(PythonPackage):
+    """A framework for managing and maintaining multi-language pre-commit hooks."""
+
+    homepage = "https://github.com/pre-commit/pre-commit"
+    url      = "https://files.pythonhosted.org/packages/95/f1/dd0c0161dafa5ae8f73eef423a9898130db10d986a47a27e66625fe81178/pre_commit-1.14.4.tar.gz"
+
+    version('1.14.4', sha256='d3d69c63ae7b7584c4b51446b0b583d454548f9df92575b2fe93a68ec800c4d3')
+
+    depends_on('py-setuptools',  type='build')
+    depends_on('py-aspy-yaml', type=('build', 'run'))
+    depends_on('py-cfgv@1.4.0:', type=('build', 'run'))
+    depends_on('py-futures', type=('build', 'run'), when='^python@2.7.0:2.7.999')
+    depends_on('py-identify', type=('build', 'run'))
+    depends_on('py-importlib-metadata', type=('build', 'run'))
+    depends_on('py-importlib-resources', type=('build', 'run'), when='^python@:3.7')
+    depends_on('py-nodeenv@0.11.1:', type=('build', 'run'))
+    depends_on('py-pyyaml', type=('build', 'run'))
+    depends_on('py-six', type=('build', 'run'))
+    depends_on('py-toml', type=('build', 'run'))
+    depends_on('py-virtualenv@15.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-zipp/package.py
+++ b/var/spack/repos/builtin/packages/py-zipp/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyZipp(PythonPackage):
+    """Pathlib-compatible object wrapper for zip files"""
+
+    homepage = "https://github.com/jaraco/zipp"
+    url      = "https://files.pythonhosted.org/packages/0f/f4/930f91b0527d9701623d4895a978ec0abd6b8904ef272a2701190fdbf9f8/zipp-0.3.3.tar.gz"
+
+    version('0.3.3', sha256='55ca87266c38af6658b84db8cfb7343cdb0bf275f93c7afaea0d8e7a209c7478')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
This pull-request provides Spack packages for `cmake-format` and `pre-commit`, along with all the missing dependent packages.