### PR TITLE
Add latest PGI@18.10 for OpenACC

### DIFF
--- a/deploy/packages/compilers.yaml
+++ b/deploy/packages/compilers.yaml
@@ -36,3 +36,4 @@ packages:
       - intel@18.0.3
       - llvm@7.0.0
       - pgi+network+nvidia+mpi@18.4
+      - pgi+network+nvidia+mpi@18.10

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -20,6 +20,7 @@ class Pgi(Package):
 
     homepage = "http://www.pgroup.com/"
 
+    version('18.10',  '0e1598c05aa8faeb84e351c0f68274c3')
     version('18.4',  'e11423ba43b26a9cd5bf21832f6b1df9')
     version('17.10', '33e407eea9600997914b2535a36b4d92')
     version('17.4',  'a311d2756ddda657860bad8e5725597b')


### PR DESCRIPTION
Update : we need to fix license issue for 18.10 prior to merge as existing license is valid for 18.4