### PR TITLE
deployment: generate module for boost

### DIFF
--- a/deploy/packages/serial-libraries.yaml
+++ b/deploy/packages/serial-libraries.yaml
@@ -43,3 +43,12 @@ packages:
     specs:
       - python@2.7.15
       - python@3.6.5
+
+  gnu-stable-serial:
+    target_matrix:
+      - gnu-stable
+    requires:
+      - architecture
+      - compiler
+    specs:
+      - boost


### PR DESCRIPTION
In #222, module are only generated for specified software packages. Add
boost to the list of installed packages to generate a module.