### PR TITLE
environment modifications: use better before environment

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -401,7 +401,21 @@ class EnvironmentModifications(object):
         dump_cmd = 'import os, json; print(json.dumps(dict(os.environ)))'
         dump_environment = 'python -c "{0}"'.format(dump_cmd)
 
+        def grab_environment(command):
+            # Try to source the file
+            proc = subprocess.Popen(
+                command, stdout=subprocess.PIPE, env=os.environ)
+            proc.wait()
+
+            if proc.returncode != 0:
+                msg = 'Sourcing file {0} returned a non-zero exit code'.format(
+                    filename)
+                raise RuntimeError(msg)
+
+            return ''.join([line.decode('utf-8') for line in proc.stdout])
+
         # Construct the command that will be executed
+        reference = [shell, shell_options, dump_environment]
         command = [
             shell,
             shell_options,
@@ -411,22 +425,10 @@ class EnvironmentModifications(object):
             ]),
         ]
 
-        # Try to source the file
-        proc = subprocess.Popen(
-            command, stdout=subprocess.PIPE, env=os.environ)
-        proc.wait()
-
-        if proc.returncode != 0:
-            msg = 'Sourcing file {0} returned a non-zero exit code'.format(
-                filename)
-            raise RuntimeError(msg)
-
-        output = ''.join([line.decode('utf-8') for line in proc.stdout])
-
         # Construct dictionaries of the environment before and after
         # sourcing the file, so that we can diff them.
-        env_before = dict(os.environ)
-        env_after = json.loads(output)
+        env_before = json.loads(grab_environment(reference))
+        env_after = json.loads(grab_environment(command))
 
         # If we're in python2, convert to str objects instead of unicode
         # like json gives us.  We can't put unicode in os.environ anyway.


### PR DESCRIPTION
Replace os.environ by bash reference environment to catch modifications
done by the profile/rc files.