### PR TITLE
steps: new "bundle" variant to use system dependencies instead of bundled code

### DIFF
--- a/var/spack/repos/builtin/packages/easyloggingpp/package.py
+++ b/var/spack/repos/builtin/packages/easyloggingpp/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Easyloggingpp(CMakePackage):
+    """Single header C++ logging library"""
+
+    homepage = "https://github.com/zuhd-org/easyloggingpp"
+    url      = "https://github.com/zuhd-org/easyloggingpp/archive/v9.96.7.tar.gz"
+
+    version('9.96.7', sha256='237c80072b9b480a9f2942b903b4b0179f65e146e5dcc64864dc91792dedd722')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -81,6 +81,8 @@ class Petsc(Package):
             description='Activates support for SuiteSparse')
     variant('patchmpi64', default=False,
             description='Patch of MPI support of int64')
+    variant('dmplex', default=False,
+            description='Enable DMPlex support')
 
     variant('X', default=False,
             description='Activate X support')
@@ -224,6 +226,14 @@ class Petsc(Package):
             options.append('--with-x=1')
         else:
             options.append('--with-x=0')
+
+        if '+dmplex' in spec:
+            options.append('--download-ctetgen')
+            if '^int64' in spec:
+                options.extend([
+                    '--download-chaco',
+                    '--download-triangle',
+                ])
 
         if 'trilinos' in spec:
             options.append('--with-cxx-dialect=C++11')

--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -21,6 +21,7 @@ class Steps(CMakePackage):
     variant("petsc", default=False, description="Use PETSc library for parallel E-Field solver")
     variant("mpi", default=True, description="Use MPI for parallel solvers")
     variant("coverage", default=False, description="Enable code coverage")
+    variant("bundle", default=True, description="Use bundled libraries")
 
     depends_on("blas")
     depends_on("lapack", when="+lapack")
@@ -35,9 +36,18 @@ class Steps(CMakePackage):
     depends_on("py-unittest2", type=("build", "test"))
     depends_on("python")
 
+    depends_on("easyloggingpp", when="~bundle")
+    depends_on("random123", when="~bundle")
+    depends_on("sundials@:2.99.99+int64", when="~bundle")
+
     def cmake_args(self):
         args = []
         spec = self.spec
+
+        if "~bundle" in spec:
+            bundles = ["EASYLOGGINGPP", "RANDOM123", "SUNDIALS", "SUPERLU_DIST"]
+            for bundle in bundles:
+                args.append("-DUSE_BUNDLE_{}:BOOL=OFF".format(bundle))
 
         if "+native" in spec:
             args.append("-DTARGET_NATIVE_ARCH:BOOL=True")

--- a/var/spack/repos/builtin/packages/superlu-dist/0001-Fix-libdir-pkgconfig-variable.patch
+++ b/var/spack/repos/builtin/packages/superlu-dist/0001-Fix-libdir-pkgconfig-variable.patch
@@ -1,0 +1,58 @@
+From 188f8e2d55fc7c8db2d8d5eec26caa892ee829be Mon Sep 17 00:00:00 2001
+From: Tristan Carel <tristan.carel@gmail.com>
+Date: Mon, 4 Mar 2019 09:54:48 +0100
+Subject: [PATCH] Fix libdir pkgconfig variable
+
+`CMAKE_INSTALL_LIBDIR` variable can be absolute, which can lead to an invalid
+`libdir` variable in `superlu_dist.pc`, for instance for CMake 3.13.0:
+
+```bash
+$ cat superlu_dist.pc
+prefix=/home/me/stow/spack/gcc-7.3.0/superlu-dist-6.1.0-7jy53y
+libdir=/home/me/stow/spack/gcc-7.3.0/superlu-dist-6.1.0-7jy53y//home/me/stow/spack/gcc-7.3.0/superlu-dist-6.1.0-7jy53y/lib
+includedir=/home/me/stow/spack/gcc-7.3.0/superlu-dist-6.1.0-7jy53y/include
+
+Name: SuperLU_DIST
+Description: Distributed-memory direct solution of sparse systems of linear equations
+Version: 6.1.0
+URL: http://crd-legacy.lbl.gov/~xiaoye/SuperLU/
+
+Libs: -L${libdir} -lsuperlu
+Libs.private: -L/home/me/stow/spack/gcc-7.3.0/openblas-0.3.5-esdvmj/lib -lopenblas -lm
+Cflags: -I${includedir}
+```
+---
+ CMakeLists.txt     | 5 +++++
+ superlu_dist.pc.in | 2 +-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index eaf2c26..e2fcec2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -340,6 +340,11 @@ configure_file(${SuperLU_DIST_SOURCE_DIR}/SRC/superlu_dist_config.h.in ${SuperLU
+ configure_file(${SuperLU_DIST_SOURCE_DIR}/SRC/superlu_dist_config.h.in ${SuperLU_DIST_SOURCE_DIR}/SRC/superlu_dist_config.h)
+ 
+ # Add pkg-config support
++if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
++  set(pkgconfig_libdir ${CMAKE_INSTALL_LIBDIR})
++else()
++  set(pkgconfig_libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
++endif()
+ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/superlu_dist.pc.in ${CMAKE_CURRENT_BINARY_DIR}/superlu_dist.pc @ONLY)
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/superlu_dist.pc
+ 	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+diff --git a/superlu_dist.pc.in b/superlu_dist.pc.in
+index 2de05e0..0a98d31 100644
+--- a/superlu_dist.pc.in
++++ b/superlu_dist.pc.in
+@@ -1,5 +1,5 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
++libdir=@pkgconfig_libdir@
+ includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
+ 
+ Name: @CMAKE_PROJECT_NAME@
+-- 
+2.21.0
+

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -33,7 +33,8 @@ class SuperluDist(CMakePackage):
     depends_on('blas')
     depends_on('lapack')
     depends_on('parmetis')
-    depends_on('metis@5:')
+    depends_on('metis@5:~int64', when='~int64')
+    depends_on('metis@5:+int64', when='+int64')
 
     patch('0001-Fix-libdir-pkgconfig-variable.patch')
 

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -35,6 +35,8 @@ class SuperluDist(CMakePackage):
     depends_on('parmetis')
     depends_on('metis@5:')
 
+    patch('0001-Fix-libdir-pkgconfig-variable.patch')
+
     def cmake_args(self):
         spec = self.spec
         lapack_blas = spec['lapack'].libs + spec['blas'].libs


### PR DESCRIPTION
This pull-request allows to build STEPS using system dependencies instead of using code bundled in the HBP_STEPS repository like easylogging, superlu_dist, random123, and cvode.

Original requirements come from: https://github.com/CNS-OIST/STEPS/issues/15
It requires https://github.com/CNS-OIST/HBP_STEPS/pull/168