### PR TITLE
deployment: fix module naming to avoid conflicts.

### DIFF
--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -54,9 +54,9 @@ modules:
     all:
       autoload: 'all'
       suffixes:
+        '^coreneuron+knl': '/knl'
         '^python@:2.99': '/python2'
         '^python@3:': '/python3'
-        '^coreneuron+knl': '/knl'
         '+mpi': '/parallel'
       environment:
         set:


### PR DESCRIPTION
Moving `/knl` up in the hierarchy should resolve issues with `python3` the module file and `python3` the directory to contain `knl` the module file.