### PR TITLE
Remove unset LC_ALL

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -244,7 +244,6 @@ class Neuron(Package):
         filter_file(env['CXX'], self.compiler.cxx, nrnmakefile, **kwargs)
 
     def setup_environment(self, spack_env, run_env):
-        spack_env.unset('LC_ALL')
         neuron_archdir = self.get_neuron_archdir()
         run_env.prepend_path('PATH', join_path(neuron_archdir, 'bin'))
         run_env.prepend_path('LD_LIBRARY_PATH', join_path(neuron_archdir, 'lib'))

--- a/var/spack/repos/builtin/packages/reportinglib/package.py
+++ b/var/spack/repos/builtin/packages/reportinglib/package.py
@@ -87,5 +87,3 @@ class Reportinglib(CMakePackage):
                 return libs
         return None
 
-    def setup_environment(self, spack_env, run_env):
-        spack_env.unset('LC_ALL')


### PR DESCRIPTION
- Removed the unset(LC_ALL) from neuron and reportinglib
- Enough to keep it on neurodamus-model