### PR TITLE
Adding neurodamus-core 2.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -12,7 +12,7 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master')
-    version('2.1.0', git=git, tag='2.1.0', preferred=True)
+    version('2.2.1', git=git, tag='2.2.1', preferred=True)
 
     variant('python', default=False, description="Enable Python Neurodamus")
 


### PR DESCRIPTION
This tag includes several fixes and improvements:

- Use python dict to loat METypeInfo
- Better clear up mem before launching corenrn
- Write sim.conf inside outputRoot