### PR TITLE
Adding new neurodamus minor tag 2.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -12,7 +12,8 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master')
-    version('2.2.1', git=git, tag='2.2.1', preferred=True)
+    version('2.3.0', git=git, tag='2.3.0', preferred=True)
+    version('2.2.1', git=git, tag='2.2.1')
 
     variant('python', default=False, description="Enable Python Neurodamus")
 


### PR DESCRIPTION
For merging neurodamus-core change 44420 results were updated.
However new version will only become effective after tagging and changing the default installed version. 

(To think about... maybe these tests should run on "devel" versions)