### PR TITLE
New default v neuron 7.6

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -113,6 +113,6 @@ packages:
       - neurodamus-hippocampus
       - neurodamus-thalamus
       - neurodamus-mousify
-      - neurodamus-neocortex+coreneuron^coreneuron+knl^neuron@7.6.6
-      - neurodamus-thalamus+coreneuron^coreneuron+knl^neuron@7.6.6
-      - neurodamus-hippocampus+coreneuron^coreneuron+knl^neuron@7.6.6
+      - neurodamus-neocortex+coreneuron^coreneuron+knl
+      - neurodamus-thalamus+coreneuron^coreneuron+knl
+      - neurodamus-hippocampus+coreneuron^coreneuron+knl

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -25,7 +25,6 @@ class Neuron(Package):
     version('develop', branch='master')
     version('7.6.6',   tag='7.6.6', preferred=True)
     version('2018-10', commit='b3097b7')
-    version('7.6.2',   tag='7.6.2')
     # versions from url, with checksum
     version('7.5', 'fb72c841374dfacbb6c2168ff57bfae9')
     version('7.4', '2c0bbee8a9e55d60fa26336f4ab7acbf')

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -23,8 +23,8 @@ class Neuron(Package):
     git      = "https://github.com/nrnhines/nrn.git"
 
     version('develop', branch='master')
-    version('7.6.6',   tag='7.6.6')
-    version('2018-10', commit='b3097b7', preferred=True)
+    version('7.6.6',   tag='7.6.6', preferred=True)
+    version('2018-10', commit='b3097b7')
     version('7.6.2',   tag='7.6.2')
     # versions from url, with checksum
     version('7.5', 'fb72c841374dfacbb6c2168ff57bfae9')


### PR DESCRIPTION
Neuron 7.6.6 has some important new features.

It passes SimulationStack test suite. See https://bbpcode.epfl.ch/ci/blue/organizations/jenkins/hpc.SimulationStack/detail/hpc.SimulationStack/486/pipeline

@iomaganaris I believe there were some simplifications we could do to the deployed versions (for KNL) in case this becomes the default.