### PR TITLE
Fixing special patching

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -97,11 +97,8 @@ class NeurodamusModel(SimModel):
         python/ If neurodamus-core comes with python, create links
         """
         # base dest dirs already created by model install
-        arch = arch = spec.architecture.target
-        dst_libname = 'libnrnmech{}.so'.format(self._lib_suffix)
-        shutil.move(join_path(arch, 'special'), prefix.bin.join('special'))
-        shutil.move(arch + "/.libs/libnrnmech.so", prefix.lib.join(dst_libname))
-        self._patch_special(prefix, dst_libname)
+        # We install binaries normally, except lib has a suffix
+        self._install_binaries(lib_suffix=self._lib_suffix)
 
         if spec.satisfies('+coreneuron'):
             install = which('nrnivmech_install.sh', path=".")
@@ -124,6 +121,7 @@ class NeurodamusModel(SimModel):
         run_env.set('HOC_LIBRARY_PATH', self.prefix.lib.hoc)
         run_env.set('NEURON_INIT_MPI', "1")  # Always Init MPI (support python)
 
+	# TODO: This is very fragile. The vars only exist if we compiled.
         if hasattr(self, '_incflags'):
             run_env.set('ND_INCFLAGS', self._incflags)
             run_env.set('ND_LOADFLAGS', self._loadflags)

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -118,9 +118,10 @@ class SimModel(Package):
     def _patch_special(prefix, libname='libnrnmech.so'):
         """Patch bash-based special to point to nrnmech lib inside lib/
         """
-        which('sed')('-i',
+        which('sed')('-i.bak',
                      's#-dll .*#-dll %s "$@"#' % prefix.lib.join(libname),
                      prefix.bin.special)
+        os.remove(prefix.bin.join('special.bak'))
 
     def _install_src(self, prefix):
         """Copy original and translated c mods

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -103,7 +103,7 @@ class SimModel(Package):
         mkdirp(prefix.share.modc)
 
         self._install_binaries()
-       
+
         if spec.satisfies('+coreneuron'):
             install = which('nrnivmech_install.sh', path=".")
             install(prefix)
@@ -117,8 +117,8 @@ class SimModel(Package):
         prefix = self.prefix
         shutil.copy(join_path(arch, 'special'), prefix.bin)
 
-        # Install libnrnmech - might have several links. 
-        for f in find(arch + "/.libs", 'libnrnmech*.so', recursive=False):
+        # Install libnrnmech - might have several links.
+        for f in find(arch + "/.libs", 'libnrnmech*.so*', recursive=False):
             if not os.path.islink(f):
                 bname = os.path.basename(f)
                 lib_dst = prefix.lib.join(bname[:bname.find(".")] + lib_suffix + ".so")


### PR DESCRIPTION
**Problem 1**
Special patching was not working under OSX since sed -i option requires
an argument

**Problem 2**
The libraries were not being correctly copied. nrnmech libs included some symlinks which had to be skipped.

**Problem 3** : Linking mess
OSX has a quite different linking system. The corenrnmech libs had invalid LC_ID_DYLIB and would not support rapth. [CoreNeuron/pull/177 ](https://github.com/BlueBrain/CoreNeuron/pull/177) fixes the naming issue while from spack side it looks ok

**Problem 4** : readline
OSX Mojave is incompat with bare readline, so even though linking is ok, neuron startup fails with `Symbol not found: _rl_event_hook`. The builtin readline works well and we can drop the dependency.