### PR TITLE
Improv/neurodamus rebuild

### DIFF
--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -65,6 +65,7 @@ modules:
         '^python@:2.99': '/python2'
         '^python@3:': '/python3'
         '+mpi': '/parallel'
+        '~mpi': '/serial'
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -89,8 +89,8 @@ packages:
       # - lapack
       - python
     specs:
-      - py-bluepymm@0.6.38 ^neuron~mpi
-      - py-bluepyopt@1.6.56 ^neuron~mpi
+      - py-bluepymm@0.6.38
+      - py-bluepyopt@1.6.56
       - py-efel@3.0.22
       - py-bglibpy
 

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -12,7 +12,7 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master')
-    version('2.3.0', git=git, tag='2.3.0', preferred=True)
+    version('2.3.1', git=git, tag='2.3.1', preferred=True)
     version('2.2.1', git=git, tag='2.2.1')
 
     variant('python', default=False, description="Enable Python Neurodamus")

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -145,7 +145,7 @@ set -e
 if [ "$#" -eq 0 ]; then
     echo "******* Neurodamus builder *******"
     echo "Syntax:"
-    echo "$0 <mods_dir> [add_include_flags] [add_link_flags]"
+    echo "$(basename $0) <mods_dir> [add_include_flags] [add_link_flags]"
     echo
     echo "NOTE: mods_dir is literally passed to nrnivmodl. If you only have the mechanism mods"
     echo " and wish to build neurodamus you need to include the neurodamus-specific mods."

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -5,25 +5,10 @@ from spack.pkg.builtin.sim_model import SimModel
 import shutil
 import os
 
-
-_REBUILD_NEURODAMUS_TPL = """#!/bin/sh
-set -e
-if [ "$#" -eq 0 ]; then
-    echo "******* Neurodamus builder *******"
-    echo "Syntax:"
-    echo "$0 <mods_dir> [add_include_flags] [add_link_flags]"
-    echo
-    echo "NOTE: mods_dir is literally passed to nrnivmodl. If you only have the mechanism mods"
-    echo " and wish to build neurodamus you need to include the neurodamus-specific mods."
-    echo " Under \$NEURODAMUS_ROOT/share you'll find the whole set of original mod files, as"
-    echo " well as the neurodamus-specific mods alone. You may copy/link them into your directory."
-    exit 1
-fi
-
-# run with nrnivmodl in path
-set -x
-'{nrnivmodl}' -incflags '{incflags} '"$2" -loadflags '{loadflags} '"$3" "$1"
-"""
+# Definitions
+_CORENRN_MODLIST_FNAME = "coreneuron_modlist.txt"
+_BUILD_NEURODAMUS_FNAME = "build_neurodamus.sh"
+_LIB_SUFFIX = "_nd"
 
 
 class NeurodamusModel(SimModel):
@@ -53,9 +38,6 @@ class NeurodamusModel(SimModel):
 
     phases = ['build_model', 'merge_hoc_mod', 'build', 'install']
 
-    _corenrn_modlist = "coreneuron_modlist.txt"
-    _lib_suffix = "_nd"
-
     def build_model(self, spec, prefix):
         """Build and install the bare model.
         """
@@ -74,7 +56,7 @@ class NeurodamusModel(SimModel):
         # If we shall build mods for coreneuron, only bring from core those specified
         if spec.satisfies("+coreneuron"):
             shutil.copytree('mod', 'mod_core', True)
-            with open(core_prefix.mod.join(self._corenrn_modlist)) as core_mods:
+            with open(core_prefix.mod.join(_CORENRN_MODLIST_FNAME)) as core_mods:
                 for aux_mod in core_mods:
                     shutil.copy(core_prefix.mod.join(aux_mod.strip()), 'mod_core')
 
@@ -101,15 +83,15 @@ class NeurodamusModel(SimModel):
             link_flag += ' ' + spec['synapsetool'].package.dependency_libs(spec).joined()
 
         # Override mech_name in order to generate a library with a different name
-        self.mech_name += self._lib_suffix
+        self.mech_name += _LIB_SUFFIX
         self._build_mods('mod', link_flag, include_flag, 'mod_core')
 
         # Create rebuild script
-        with open("build_neurodamus.sh", "w") as f:
-            f.write(_REBUILD_NEURODAMUS_TPL.format(nrnivmodl=str(which('nrnivmodl')),
-                                                   incflags=include_flag,
-                                                   loadflags=link_flag))
-        os.chmod("build_neurodamus.sh", 0o770)
+        with open(_BUILD_NEURODAMUS_FNAME, "w") as f:
+            f.write(_BUILD_NEURODAMUS_TPL.format(nrnivmodl=str(which('nrnivmodl')),
+                                                 incflags=include_flag,
+                                                 loadflags=link_flag))
+        os.chmod(_BUILD_NEURODAMUS_FNAME, 0o770)
 
     def install(self, spec, prefix):
         """Install phase.
@@ -121,7 +103,7 @@ class NeurodamusModel(SimModel):
         """
         # base dest dirs already created by model install
         # We install binaries normally, except lib has a suffix
-        self._install_binaries(lib_suffix=self._lib_suffix)
+        self._install_binaries(lib_suffix=_LIB_SUFFIX)
 
         if spec.satisfies('+coreneuron'):
             install = which('nrnivmech_install.sh', path=".")
@@ -129,7 +111,7 @@ class NeurodamusModel(SimModel):
 
         # Install mods/hocs, and a builder script
         self._install_src(prefix)
-        shutil.move("build_neurodamus.sh", prefix.bin)
+        shutil.move(_BUILD_NEURODAMUS_FNAME, prefix.bin)
 
         # Create mods links in share
         force_symlink(spec['neurodamus-core'].prefix.mod, prefix.share.mod_neurodamus)
@@ -156,3 +138,23 @@ class NeurodamusModel(SimModel):
                     run_env.prepend_path('PYTHONPATH', m.value)
             run_env.prepend_path('PYTHONPATH', pylib)
             run_env.set('NEURODAMUS_PYTHON', pylib)
+
+
+_BUILD_NEURODAMUS_TPL = """#!/bin/sh
+set -e
+if [ "$#" -eq 0 ]; then
+    echo "******* Neurodamus builder *******"
+    echo "Syntax:"
+    echo "$0 <mods_dir> [add_include_flags] [add_link_flags]"
+    echo
+    echo "NOTE: mods_dir is literally passed to nrnivmodl. If you only have the mechanism mods"
+    echo " and wish to build neurodamus you need to include the neurodamus-specific mods."
+    echo " Under \\$NEURODAMUS_ROOT/share you'll find the whole set of original mod files, as"
+    echo " well as the neurodamus-specific mods alone. You may copy/link them into your directory."
+    exit 1
+fi
+
+# run with nrnivmodl in path
+set -x
+'{nrnivmodl}' -incflags '{incflags} '"$2" -loadflags '{loadflags} '"$3" "$1"
+"""

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -16,7 +16,7 @@ class PyBglibpy(PythonPackage):
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('neuron+python~mpi', type='run')
+    depends_on('neuron+python', type='run')
     depends_on('py-h5py~mpi@2.3:', type='run')
 
     depends_on('py-bluepy@0.13.2:', type='run')

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -99,7 +99,7 @@ class SimModel(Package):
         share/ <- neuron & coreneuron mod.c's (modc and modc_core)
         """
         mkdirp(prefix.bin)
-        mkdirp(prefix.lib)
+        mkdirp(prefix.lib.mod, prefix.lib.hoc)
         mkdirp(prefix.share.modc)
 
         self._install_binaries()
@@ -137,9 +137,8 @@ class SimModel(Package):
         """Copy original and translated c mods
         """
         arch = self.spec.architecture.target
-        shutil.move('mod', prefix.lib.mod)
-        shutil.move('hoc', prefix.lib.hoc)
-        shutil.move('common', prefix.lib.common)
+        copy_all('mod', prefix.lib.mod)
+        copy_all('hoc', prefix.lib.hoc)
 
         for cmod in find(arch, "*.c", recursive=False):
             shutil.move(cmod, prefix.share.modc)


### PR DESCRIPTION
**Problem** The neurodamus build flags are only known after a neurodamus build. In case of spack module regen that info is lost. Further, a script is more elegant and can be expanded to handle more cases if desirable.

Neurodamus rebuild script:
```
build_neurodamus.sh
******* Neurodamus builder *******
Syntax:
build_neurodamus.sh <mods_dir> [add_include_flags] [add_link_flags]

NOTE: mods_dir is literally passed to nrnivmodl. If you only have the mechanism mods
 and wish to build neurodamus you need to include the neurodamus-specific mods.
 Under $NEURODAMUS_ROOT/share you'll find the whole set of original mod files,
 as well as the neurodamus-specific mods alone. You may copy/link them into your directory.
```
Together with this addition, hocs and mods sources are deployed by file, instead of symlinks, which was bringing a lot of hard-to-debug problems when the links get broken.

**Extras**

- added neurodamus-core version 2.3.1, for the fix to createMapping which should use local pc and cellDistrib
- Removed NEURON_INIT_MPI env var, so that parallel neuron can be used serially

