### PR TITLE
Reverting py packages from depending on parallel neuron

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -92,7 +92,7 @@ packages:
       - py-bluepymm@0.6.38 ^neuron~mpi
       - py-bluepyopt@1.6.56 ^neuron~mpi
       - py-efel@3.0.22
-      - py-bglibpy
+      - py-bglibpy ^neuron~mpi
 
 
   #### cellular ####

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -89,8 +89,8 @@ packages:
       # - lapack
       - python
     specs:
-      - py-bluepymm@0.6.38
-      - py-bluepyopt@1.6.56
+      - py-bluepymm@0.6.38 ^neuron~mpi
+      - py-bluepyopt@1.6.56 ^neuron~mpi
       - py-efel@3.0.22
       - py-bglibpy
 

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -16,7 +16,7 @@ class PyBglibpy(PythonPackage):
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('neuron+python', type='run')
+    depends_on('neuron+python~mpi', type='run')
     depends_on('py-h5py~mpi@2.3:', type='run')
 
     depends_on('py-bluepy@0.13.2:', type='run')


### PR DESCRIPTION
Revert 2758f82 - Remove ~mpi for py-bglibpy
Revert 46debf3 - remobe neuron~mpi for bluepy*