### PR TITLE
Enable valgrind module

### DIFF
--- a/deploy/configs/tools/modules.yaml
+++ b/deploy/configs/tools/modules.yaml
@@ -46,6 +46,7 @@ modules:
       - openmpi
       - osu-micro-benchmarks
       - stat
+      - 'valgrind@3.13.0'
     blacklist:
       - '%gcc'
       - '%intel'


### PR DESCRIPTION
Currently valgrind is installed on BB5 but module is not enabled.