### PR TITLE
Deploy new version of neurodamus-core

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -12,7 +12,7 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master')
-    version('2.3.1', git=git, tag='2.3.1', preferred=True)
+    version('2.3.3', git=git, tag='2.3.3', preferred=True)
     version('2.2.1', git=git, tag='2.2.1')
 
     variant('python', default=False, description="Enable Python Neurodamus")


### PR DESCRIPTION
After fixing parallel spike writing model, which had a bug in its
intermediate buffer allocation where the buffer size could be 0 when it
should be at least 1 to fit the \0 termination.