### PR TITLE
Piz-Daint configuration update

### DIFF
--- a/sysconfig/daint/modules.yaml
+++ b/sysconfig/daint/modules.yaml
@@ -32,6 +32,8 @@ modules:
     hash_length: 0
     whitelist:
       - 'neurodamus'
+      - 'neurodamus-neocortex'
+      - 'neurodamus-hippocampus'
       - 'neuron'
     blacklist:
       - '%gcc'

--- a/sysconfig/daint/packages.yaml
+++ b/sysconfig/daint/packages.yaml
@@ -44,14 +44,20 @@ packages:
             cmake@3.8.1: /apps/common/UES/jenkins/SLES12/easybuild/software/CMake/3.8.1
         buildable: False
         version: [3.8.1]
+    boost:
+        modules:
+            boost@1.67.0: Boost/1.67.0-CrayGNU-18.08
+        buildable: False
+        version: [1.67.0]
     ncurses:
         paths:
             ncurses@6.0: /apps/daint/UES/jenkins/6.0.UP07/mc/easybuild/software/ncurses/6.1-CrayGNU-18.08
         buildable: False
         version: [6.1]
     hdf5:
-        modules:
-            hdf5@1.8.16 arch=cray-cnl6-haswell: cray-hdf5/1.8.16
+        paths:
+            hdf5@1.8.16~mpi arch=cray-cnl6-haswell: /opt/cray/pe/hdf5/1.8.16/GNU/5.1
+            hdf5@1.8.16+mpi arch=cray-cnl6-haswell: /opt/cray/pe/hdf5-parallel/1.8.16/GNU/5.1
         buildable: False
         version: [1.8.16]
     zlib:

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -113,7 +113,7 @@ class SimModel(Package):
 
     def _install_binaries(self, lib_suffix=''):
         # Install special
-        arch = self.spec.architecture.target
+        arch = os.path.basename(self.neuron_archdir)
         prefix = self.prefix
         shutil.copy(join_path(arch, 'special'), prefix.bin)
 
@@ -136,7 +136,7 @@ class SimModel(Package):
     def _install_src(self, prefix):
         """Copy original and translated c mods
         """
-        arch = self.spec.architecture.target
+        arch = os.path.basename(self.neuron_archdir)
         copy_all('mod', prefix.lib.mod)
         copy_all('hoc', prefix.lib.hoc)
 

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -85,6 +85,7 @@ class Synapsetool(CMakePackage):
                 '-DSYNTOOL_WITH_MPI:BOOL=ON',
                 '-DSYNTOOL_UNIT_TESTS=OFF'
             ])
+
         if spec.satisfies('~shared'):
             args.append('-DCOMPILE_LIBRARY_TYPE=STATIC')
 


### PR DESCRIPTION
  - spec.architecture.target is cpu arch on cray (e.g. haswell)
  - add parallel hdf5 and boost for syntool
  - whitelist neurodamus modules