### PR TITLE
Added version printing in neurodamus

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -713,9 +713,8 @@ class GitFetchStrategy(VCSFetchStrategy):
         super(GitFetchStrategy, self).archive(destination, exclude='.git')
 
     def get_commit_hash(self):
-        git_exe = self.git.name
-        git_commit = subprocess.check_output([git_exe, 'rev-parse', 'HEAD']).split()
-        return git_commit
+        git_commit = self.git('rev-parse', 'HEAD', output=str)
+        return git_commit.strip()
 
     @_needs_stage
     def reset(self):

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -40,7 +40,6 @@ from spack.util.executable import which
 from spack.util.string import comma_and, quote
 from spack.version import Version, ver
 from spack.util.compression import decompressor_for, extension
-import subprocess
 
 #: List of all fetch strategies, created by FetchStrategy metaclass.
 all_strategies = []

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -40,7 +40,7 @@ from spack.util.executable import which
 from spack.util.string import comma_and, quote
 from spack.version import Version, ver
 from spack.util.compression import decompressor_for, extension
-
+import subprocess
 
 #: List of all fetch strategies, created by FetchStrategy metaclass.
 all_strategies = []
@@ -711,6 +711,11 @@ class GitFetchStrategy(VCSFetchStrategy):
 
     def archive(self, destination):
         super(GitFetchStrategy, self).archive(destination, exclude='.git')
+
+    def get_commit_hash(self):
+        git_exe = self.git.name
+        git_commit = subprocess.check_output([git_exe, 'rev-parse', 'HEAD']).split()
+        return git_commit
 
     @_needs_stage
     def reset(self):

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -711,9 +711,8 @@ class GitFetchStrategy(VCSFetchStrategy):
     def archive(self, destination):
         super(GitFetchStrategy, self).archive(destination, exclude='.git')
 
-    def get_commit_hash(self):
-        git_commit = self.git('rev-parse', 'HEAD', output=str)
-        return git_commit.strip()
+    def get_commit(self):
+        return self.git('rev-parse', 'HEAD', output=str).strip()
 
     @_needs_stage
     def reset(self):

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -38,7 +38,8 @@ class NeurodamusCore(Package):
     depends_on('py-lazy-property', type=('run'), when='+python')
 
     def get_git_fetcher(self):
-        return next((fetcher for fetcher in self.fetcher if (isinstance(fetcher, GitFetchStrategy) and fetcher.url == self.git)), None)
+        root_fetcher = self.fetcher[0]
+        return root_fetcher if isinstance(root_fetcher, GitFetchStrategy) else None
 
     def install(self, spec, prefix):
         shutil.copytree('hoc', prefix.hoc)

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -12,7 +12,8 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master', clean=False)
-    version('2.3.3', git=git, tag='2.3.3', preferred=True, clean=False)
+    version('2.3.4', git=git, tag='2.3.4', clean=False, preferred=True)
+    version('2.3.3', git=git, tag='2.3.3', clean=False)
     version('2.2.1', git=git, tag='2.2.1', clean=False)
 
     variant('python', default=False, description="Enable Python Neurodamus")

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -12,6 +12,7 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master', clean=False)
+    version('test', git=git, branch='master', clean=False)
     version('2.3.3', git=git, tag='2.3.3', preferred=True, clean=False)
     version('2.2.1', git=git, tag='2.2.1', clean=False)
 
@@ -36,11 +37,6 @@ class NeurodamusCore(Package):
     depends_on('py-enum34',        type=('run',), when='^python@2.4:2.7.999,3.1:3.3.999')
     depends_on('py-lazy-property', type=('run'), when='+python')
 
-    def get_commit_hash(self):
-        fetcher = self.fetcher[0]
-        git_commit = fetcher.get_commit_hash()
-        return git_commit
-
     def install(self, spec, prefix):
         shutil.copytree('hoc', prefix.hoc)
         shutil.copytree('mod', prefix.mod)
@@ -50,9 +46,9 @@ class NeurodamusCore(Package):
             copy_all('resources/common/hoc', prefix.hoc)
             copy_all('resources/common/mod', prefix.mod)
 
-        filter_file(r'UNKNOWN_CORE_VERSION', r'%s' % spec.version, prefix.hoc.join('init.hoc'))
-        git_commit_hash = self.get_commit_hash()
-        filter_file(r'UNKNOWN_CORE_HASH', r'%s' % git_commit_hash, prefix.hoc.join('init.hoc'))
+        filter_file(r'UNKNOWN_CORE_VERSION', r'%s' % spec.version, prefix.hoc.join('defvar.hoc'))
+        git_commit_hash = self.fetcher[0].get_commit_hash()
+        filter_file(r'UNKNOWN_CORE_HASH', r'%s' % git_commit_hash, prefix.hoc.join('defvar.hoc'))
 
 def setup_environment(self, spack_env, run_env):
         run_env.set('HOC_LIBRARY_PATH', self.prefix.hoc)

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -11,9 +11,9 @@ class NeurodamusCore(Package):
     homepage = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
-    version('develop', git=git, branch='master')
-    version('2.3.3', git=git, tag='2.3.3', preferred=True)
-    version('2.2.1', git=git, tag='2.2.1')
+    version('develop', git=git, branch='master', clean=False)
+    version('2.3.3', git=git, tag='2.3.3', preferred=True, clean=False)
+    version('2.2.1', git=git, tag='2.2.1', clean=False)
 
     variant('python', default=False, description="Enable Python Neurodamus")
     variant('common', default=False, description="Merge in synapse mechanisms hoc & mods")
@@ -36,6 +36,11 @@ class NeurodamusCore(Package):
     depends_on('py-enum34',        type=('run',), when='^python@2.4:2.7.999,3.1:3.3.999')
     depends_on('py-lazy-property', type=('run'), when='+python')
 
+    def get_commit_hash(self):
+        fetcher = self.fetcher[0]
+        git_commit = fetcher.get_commit_hash()
+        return git_commit
+
     def install(self, spec, prefix):
         shutil.copytree('hoc', prefix.hoc)
         shutil.copytree('mod', prefix.mod)
@@ -45,6 +50,10 @@ class NeurodamusCore(Package):
             copy_all('resources/common/hoc', prefix.hoc)
             copy_all('resources/common/mod', prefix.mod)
 
-    def setup_environment(self, spack_env, run_env):
+        filter_file(r'UNKNOWN_CORE_VERSION', r'%s' % spec.version, prefix.hoc.join('init.hoc'))
+        git_commit_hash = self.get_commit_hash()
+        filter_file(r'UNKNOWN_CORE_HASH', r'%s' % git_commit_hash, prefix.hoc.join('init.hoc'))
+
+def setup_environment(self, spack_env, run_env):
         run_env.set('HOC_LIBRARY_PATH', self.prefix.hoc)
 

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -12,7 +12,7 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master', clean=False)
-    version('2.3.4', git=git, tag='2.3.4', clean=False, preferred=True)
+    version('2.3.4', git=git, tag='2.3.4', clean=False)
     version('2.3.3', git=git, tag='2.3.3', clean=False)
     version('2.2.1', git=git, tag='2.2.1', clean=False)
 
@@ -53,7 +53,7 @@ class NeurodamusCore(Package):
         git_fetcher = self.get_git_fetcher()
         if git_fetcher is not None:
             git_commit_hash = git_fetcher.get_commit_hash()
-            filter_file(r'UNKNOWN_CORE_HASH', r'%s' % git_commit_hash, prefix.hoc.join('defvar.hoc'))
+            filter_file(r'UNKNOWN_CORE_HASH', r'\'%s\'' % git_commit_hash, prefix.hoc.join('defvar.hoc'))
 
 def setup_environment(self, spack_env, run_env):
         run_env.set('HOC_LIBRARY_PATH', self.prefix.hoc)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -11,6 +11,6 @@ class NeurodamusHippocampus(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
     git      = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
 
-    version('develop', git=git, branch='master', submodules=True)
-    version('0.2', git=git, tag='0.2', submodules=True, preferred=True)
-    version('0.1', git=git, tag='0.1', submodules=True)
+    version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('0.2', git=git, tag='0.2', submodules=True, preferred=True, clean=False)
+    version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -12,5 +12,5 @@ class NeurodamusHippocampus(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    version('0.2', git=git, tag='0.2', submodules=True, preferred=True, clean=False)
+    version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -95,7 +95,8 @@ class NeurodamusModel(SimModel):
         os.chmod(_BUILD_NEURODAMUS_FNAME, 0o770)
 
     def get_git_fetcher(self):
-        return next((fetcher for fetcher in self.fetcher if (isinstance(fetcher, GitFetchStrategy) and fetcher.url == self.git)), None)
+        root_fetcher = self.fetcher[0]
+        return root_fetcher if isinstance(root_fetcher, GitFetchStrategy) else None
 
     def install(self, spec, prefix):
         """Install phase.

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -4,7 +4,7 @@ from spack import *
 from spack.pkg.builtin.sim_model import SimModel
 import shutil
 import os
-from spack.fetch_strategy import GitFetchStrategy
+import llnl.util.tty as tty
 
 # Definitions
 _CORENRN_MODLIST_FNAME = "coreneuron_modlist.txt"
@@ -94,10 +94,6 @@ class NeurodamusModel(SimModel):
                                                  loadflags=link_flag))
         os.chmod(_BUILD_NEURODAMUS_FNAME, 0o770)
 
-    def get_git_fetcher(self):
-        root_fetcher = self.fetcher[0]
-        return root_fetcher if isinstance(root_fetcher, GitFetchStrategy) else None
-
     def install(self, spec, prefix):
         """Install phase.
 
@@ -134,10 +130,12 @@ class NeurodamusModel(SimModel):
 
         filter_file(r'UNKNOWN_NEURODAMUS_MODEL', r'%s' % spec.name, prefix.lib.hoc.join('defvar.hoc'))
         filter_file(r'UNKNOWN_NEURODAMUS_VERSION', r'%s' % spec.version, prefix.lib.hoc.join('defvar.hoc'))
-        git_fetcher = self.get_git_fetcher()
-        if git_fetcher is not None:
-            git_commit_hash = git_fetcher.get_commit_hash()
-            filter_file(r'UNKNOWN_NEURODAMUS_HASH', r'\'%s\'' % git_commit_hash, prefix.lib.hoc.join('defvar.hoc'))
+
+        try:
+            commit_hash = self.fetcher[0].get_commit()
+            filter_file(r'UNKNOWN_NEURODAMUS_HASH', r'\'%s\'' % commit_hash, prefix.lib.hoc.join('defvar.hoc'))
+        except Exception as e:
+            tty.warn(e)
 
     def setup_environment(self, spack_env, run_env):
         SimModel.setup_environment(self, spack_env, run_env)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -93,6 +93,11 @@ class NeurodamusModel(SimModel):
                                                  loadflags=link_flag))
         os.chmod(_BUILD_NEURODAMUS_FNAME, 0o770)
 
+    def get_commit_hash(self):
+        fetcher = self.fetcher[0]
+        git_commit = fetcher.get_commit_hash()
+        return git_commit
+
     def install(self, spec, prefix):
         """Install phase.
 
@@ -126,6 +131,11 @@ class NeurodamusModel(SimModel):
             force_symlink('../../lib', py_dst.lib)
             for name in ('neurodamus', 'init.py', '_debug.py'):
                 force_symlink(py_src.join(name), py_dst.join(name))
+
+        filter_file(r'UNKNOWN_NEURODAMUS_MODEL', r'%s' % spec.name, prefix.lib.hoc.join('init.hoc'))
+        filter_file(r'UNKNOWN_NEURODAMUS_VERSION', r'%s' % spec.version, prefix.lib.hoc.join('init.hoc'))
+        git_commit_hash = self.get_commit_hash()
+        filter_file(r'UNKNOWN_NEURODAMUS_HASH', r'%s' % git_commit_hash, prefix.lib.hoc.join('init.hoc'))
 
     def setup_environment(self, spack_env, run_env):
         SimModel.setup_environment(self, spack_env, run_env)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -136,7 +136,7 @@ class NeurodamusModel(SimModel):
         git_fetcher = self.get_git_fetcher()
         if git_fetcher is not None:
             git_commit_hash = git_fetcher.get_commit_hash()
-            filter_file(r'UNKNOWN_NEURODAMUS_HASH', r'%s' % git_commit_hash, prefix.lib.hoc.join('defvar.hoc'))
+            filter_file(r'UNKNOWN_NEURODAMUS_HASH', r'\'%s\'' % git_commit_hash, prefix.lib.hoc.join('defvar.hoc'))
 
     def setup_environment(self, spack_env, run_env):
         SimModel.setup_environment(self, spack_env, run_env)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -93,11 +93,6 @@ class NeurodamusModel(SimModel):
                                                  loadflags=link_flag))
         os.chmod(_BUILD_NEURODAMUS_FNAME, 0o770)
 
-    def get_commit_hash(self):
-        fetcher = self.fetcher[0]
-        git_commit = fetcher.get_commit_hash()
-        return git_commit
-
     def install(self, spec, prefix):
         """Install phase.
 
@@ -132,10 +127,10 @@ class NeurodamusModel(SimModel):
             for name in ('neurodamus', 'init.py', '_debug.py'):
                 force_symlink(py_src.join(name), py_dst.join(name))
 
-        filter_file(r'UNKNOWN_NEURODAMUS_MODEL', r'%s' % spec.name, prefix.lib.hoc.join('init.hoc'))
-        filter_file(r'UNKNOWN_NEURODAMUS_VERSION', r'%s' % spec.version, prefix.lib.hoc.join('init.hoc'))
-        git_commit_hash = self.get_commit_hash()
-        filter_file(r'UNKNOWN_NEURODAMUS_HASH', r'%s' % git_commit_hash, prefix.lib.hoc.join('init.hoc'))
+        filter_file(r'UNKNOWN_NEURODAMUS_MODEL', r'%s' % spec.name, prefix.lib.hoc.join('defvar.hoc'))
+        filter_file(r'UNKNOWN_NEURODAMUS_VERSION', r'%s' % spec.version, prefix.lib.hoc.join('defvar.hoc'))
+        git_commit_hash = self.fetcher[0].get_commit_hash()
+        filter_file(r'UNKNOWN_NEURODAMUS_HASH', r'%s' % git_commit_hash, prefix.lib.hoc.join('defvar.hoc'))
 
     def setup_environment(self, spack_env, run_env):
         SimModel.setup_environment(self, spack_env, run_env)

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -11,5 +11,5 @@ class NeurodamusMousify(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/mousify"
     git      = "ssh://bbpcode.epfl.ch/sim/models/mousify"
 
-    version('develop', git=git, branch='master', submodules=True)
-    version('0.1', git=git, tag='0.1', submodules=True, preferred=True)
+    version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('0.1', git=git, tag='0.1', submodules=True, preferred=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -12,4 +12,4 @@ class NeurodamusMousify(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/mousify"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    version('0.1', git=git, tag='0.1', submodules=True, preferred=True, clean=False)
+    version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -11,8 +11,8 @@ class NeurodamusNeocortex(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
     git      = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
 
-    version('develop', git=git, branch='master', submodules=True)
-    version('0.1', git=git, tag='0.1', submodules=True, preferred=True)
+    version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('0.1', git=git, tag='0.1', submodules=True, preferred=True, clean=False)
 
     variant('v5', default=True, description='Enable support for previous v5 circuits')
     variant('plasticity', default=False, description="Use optimized ProbAMPANMDA_EMS and ProbGABAAB_EMS")

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -12,7 +12,7 @@ class NeurodamusNeocortex(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    version('0.1', git=git, tag='0.1', submodules=True, preferred=True, clean=False)
+    version('0.1', git=git, tag='0.1', submodules=True, clean=False)
 
     variant('v5', default=True, description='Enable support for previous v5 circuits')
     variant('plasticity', default=False, description="Use optimized ProbAMPANMDA_EMS and ProbGABAAB_EMS")

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -12,4 +12,4 @@ class NeurodamusThalamus(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/thalamus"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    version('0.1', git=git, tag='0.1', submodules=True, preferred=True, clean=False)
+    version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -11,5 +11,5 @@ class NeurodamusThalamus(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/thalamus"
     git      = "ssh://bbpcode.epfl.ch/sim/models/thalamus"
 
-    version('develop', git=git, branch='master', submodules=True)
-    version('0.1', git=git, tag='0.1', submodules=True, preferred=True)
+    version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('0.1', git=git, tag='0.1', submodules=True, preferred=True, clean=False)


### PR DESCRIPTION
- This PR goes in pair with https://bbpcode.epfl.ch/code/#/c/45205/
- Filter init.hoc to replace the UNKNOWN variables with the correct
  values
- Added clean=False to all versions of Neurodamus to keep the .git
  folder in the archive made by spack
- Added method get_commit_hash() in fetch_strategy.py to return the
  commit hash
- Added method get_commit_hash() in neurodamus-core and
  neurodamus-model to get the commit hash of those packages