### PR TITLE
Neuron: Bring readline back

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -60,6 +60,7 @@ class Neuron(Package):
     depends_on('mpi',         when='+mpi')
     depends_on('ncurses',     when='~cross-compile')
     depends_on('python@2.6:', when='+python', type=('build', 'link', 'run'))
+    depends_on('py-numpy',    when='+python', type='run')
     depends_on('tau',         when='+profile')
 
     conflicts('~shared',  when='+python')
@@ -217,6 +218,8 @@ class Neuron(Package):
         if 'readline' in spec:
             options.append('--with-readline=' + spec['readline'].prefix)
             ld_flags += ' -L{0.prefix.lib} {0.libs.rpath_flags}'.format(spec['readline'])
+        else:
+            options.append('--with-readline=no')
 
         # To support prompt (not cross-compile) use readline + ncurses
         if 'ncurses' in spec:

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -60,7 +60,8 @@ class Neuron(Package):
     depends_on('mpi',         when='+mpi')
     depends_on('ncurses',     when='~cross-compile')
     depends_on('python@2.6:', when='+python', type=('build', 'link', 'run'))
-    depends_on('py-numpy',    when='+python', type='run')
+    # Numpy is required for Vector.as_numpy()
+    # depends_on('py-numpy',    when='+python', type='run')
     depends_on('tau',         when='+profile')
 
     conflicts('~shared',  when='+python')

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import platform
+import sys
 from spack import *
 from contextlib import contextmanager
 
@@ -53,8 +53,7 @@ class Neuron(Package):
 
     # Readline became incompatible with Mac so we use neuron internal readline.
     # HOWEVER, with the internal version there is a bug which makes Vector.as_numpy() not work!
-    if platform.system() != "Darwin":
-        depends_on('readline')
+    depends_on('readline', when=sys.platform != 'darwin')
 
     depends_on('mpi',         when='+mpi')
     depends_on('ncurses',     when='~cross-compile')

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -51,9 +51,8 @@ class Neuron(Package):
     depends_on('libtool',    type='build')
     depends_on('pkgconfig',  type='build')
 
-    # Preferably we should NOT depend on readline because it became incompatible with Mac and
-    # there is a neuron internal readline. HOWEVER without it Vector.as_numpy() doesnt work!
-    # TODO: Drop again when fixed in neuron
+    # Readline became incompatible with Mac so we use neuron internal readline.
+    # HOWEVER, with the internal version there is a bug which makes Vector.as_numpy() not work!
     if platform.system() != "Darwin":
         depends_on('readline')
 
@@ -215,8 +214,8 @@ class Neuron(Package):
         options.extend(self.get_compilation_options(spec))
 
         ld_flags = 'LDFLAGS='
-        # TODO: Drop this when neuron as_numpy() fixed
         if 'readline' in spec:
+            # Except in Mac we always depend on readline, which is anyway a python dependency
             options.append('--with-readline=' + spec['readline'].prefix)
             ld_flags += ' -L{0.prefix.lib} {0.libs.rpath_flags}'.format(spec['readline'])
         else:

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -44,6 +44,8 @@ class Neuron(Package):
     variant('pysetup',       default=True,  description="Build Python module with setup.py")
     variant('rx3d',          default=False, description="Enable cython translated 3-d rxd. Depends on pysetup")
 
+    variant('deployment_build', default='1',  description='Build number for re-builds')
+
     depends_on('autoconf',   type='build')
     depends_on('automake',   type='build')
     depends_on('bison',      type='build')


### PR DESCRIPTION
**Neuron+Readline tale** 
Neuron uses readline internally for a prompt, and can use any readline, including a self provided one.

HOWEVER, when using the system provided one, or even completely disabling it, hoc.so (python extension) will still link with the original library (or fail to use it). Stuff that depends on it will fail (e.g. Vector.as_numpy.
A fix has been proposed in https://github.com/neuronsimulator/nrn/pull/223, but has been merged early and then killed... So we don't want to wait for it.

Anyway it is a good thing to link with the system provided one so that no conflicts will occur in Python mode. 

For the moment in MAC Mojave we to use the internal one, and due to those problems Vector.as_numpy *Wont work* there. 