### PR TITLE
boost: bump deployment build.

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -126,6 +126,8 @@ class Boost(Package):
             description='Generate position-independent code (PIC), useful '
                         'for building static libraries')
 
+    variant('deployment_build', default='1',  description='Build number for re-builds')
+
     depends_on('icu4c', when='+icu')
     depends_on('python', when='+python')
     depends_on('mpi', when='+mpi')


### PR DESCRIPTION
Attempt to fix this:

    ldd $(spack location --install-dir boost%gcc@6.4.0)/lib/libboost_iostreams.so.1.68.0|grep bz2
            libbz2.so.1.0 => not found

As reported by @ppodhajski.  Curiously, dropping the version suffix
results in `libbz2` being resolved.