### PR TITLE
 touchdetector: use external Catch2.

### DIFF
--- a/var/spack/repos/builtin/packages/catch/package.py
+++ b/var/spack/repos/builtin/packages/catch/package.py
@@ -20,6 +20,7 @@ class Catch(CMakePackage):
     # - CMake config package was added in 2.1.2
     conflicts('~single_header', when='@:1.6.1')
 
+    version('2.6.0', sha256='4c94a685557328eb1b0ed1017ca37c3a378742dc03b558cf02267b6ba8579577')
     version('2.5.0', sha256='720c84d18f4dc9eb23379941df2054e7bcd5ff9c215e4d620f8533a130d128ae')
     version('2.4.0', sha256='ab176de36b886a33aa745fcf34642eac853bf677bda518a88655dc750c72d756')
     version('2.3.0', sha256='aaf6bbf81ce8522131bae2ea4d013a77b003bbb2017614f5872d5787687f8f5f')

--- a/var/spack/repos/builtin/packages/catch/package.py
+++ b/var/spack/repos/builtin/packages/catch/package.py
@@ -20,6 +20,7 @@ class Catch(CMakePackage):
     # - CMake config package was added in 2.1.2
     conflicts('~single_header', when='@:1.6.1')
 
+    version('2.8.0', sha256='b567c37446cd22c8550bfeb7e2fe3f981b8f3ab8b2148499a522e7f61b8a481d')
     version('2.6.1', sha256='b57c2d3362102a77955d3cd0181b792c496520349bfefee8379b9d35b8819f80')
     version('2.6.0', sha256='4c94a685557328eb1b0ed1017ca37c3a378742dc03b558cf02267b6ba8579577')
     version('2.5.0', sha256='720c84d18f4dc9eb23379941df2054e7bcd5ff9c215e4d620f8533a130d128ae')

--- a/var/spack/repos/builtin/packages/catch/package.py
+++ b/var/spack/repos/builtin/packages/catch/package.py
@@ -20,6 +20,7 @@ class Catch(CMakePackage):
     # - CMake config package was added in 2.1.2
     conflicts('~single_header', when='@:1.6.1')
 
+    version('2.6.1', sha256='b57c2d3362102a77955d3cd0181b792c496520349bfefee8379b9d35b8819f80')
     version('2.6.0', sha256='4c94a685557328eb1b0ed1017ca37c3a378742dc03b558cf02267b6ba8579577')
     version('2.5.0', sha256='720c84d18f4dc9eb23379941df2054e7bcd5ff9c215e4d620f8533a130d128ae')
     version('2.4.0', sha256='ab176de36b886a33aa745fcf34642eac853bf677bda518a88655dc750c72d756')

--- a/var/spack/repos/builtin/packages/catch/package.py
+++ b/var/spack/repos/builtin/packages/catch/package.py
@@ -20,6 +20,7 @@ class Catch(CMakePackage):
     # - CMake config package was added in 2.1.2
     conflicts('~single_header', when='@:1.6.1')
 
+    version('2.5.0', sha256='720c84d18f4dc9eb23379941df2054e7bcd5ff9c215e4d620f8533a130d128ae')
     version('2.4.0', sha256='ab176de36b886a33aa745fcf34642eac853bf677bda518a88655dc750c72d756')
     version('2.3.0', sha256='aaf6bbf81ce8522131bae2ea4d013a77b003bbb2017614f5872d5787687f8f5f')
     # releases 2.3.0+ changed to "catch2/catch.hpp" header

--- a/var/spack/repos/builtin/packages/catch/package.py
+++ b/var/spack/repos/builtin/packages/catch/package.py
@@ -67,6 +67,9 @@ class Catch(CMakePackage):
     @when('+single_header')
     def install(self, spec, prefix):
         mkdirp(prefix.include)
-        install(join_path('single_include', 'catch.hpp'), prefix.include)
+        if spec.satisfies('@2.3.0:'):
+            install_tree('single_include', prefix.include)
+        else:
+            install(join_path('single_include', 'catch.hpp'), prefix.include)
         # fakes out spack so it installs a module file
         mkdirp(join_path(prefix, 'bin'))

--- a/var/spack/repos/builtin/packages/touchdetector/package.py
+++ b/var/spack/repos/builtin/packages/touchdetector/package.py
@@ -42,6 +42,7 @@ class Touchdetector(CMakePackage):
 
     depends_on('cmake', type='build')
     depends_on('boost@1.50:')
+    depends_on('catch~single_header', when='@5.0.2:')
     depends_on('eigen', when='@4.5:')
     depends_on('fmt', when='@4.5:')
     depends_on('hdf5@1.8:')


### PR DESCRIPTION
Allows to use some CMake libraries that would be awkward to include via
a subproject.