### PR TITLE
Neurodamus-core: building mods + release 2.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import llnl.util.tty as tty
 
+
 class NeurodamusCore(Package):
     """Library of channels developed by Blue Brain Project, EPFL"""
 
@@ -18,6 +19,9 @@ class NeurodamusCore(Package):
 
     variant('python', default=False, description="Enable Python Neurodamus")
     variant('common', default=False, description="Merge in synapse mechanisms hoc & mods")
+
+    # Attempt to support building
+    depends_on('neuron~binary', when='+common')
 
     # Neurodamus py is currently an extension to core
     resource(name='pydamus',
@@ -42,17 +46,44 @@ class NeurodamusCore(Package):
         shutil.copytree('mod', prefix.mod)
         if spec.satisfies('+python'):
             copy_tree('resources/neurodamus-py', prefix.python)
-        if spec.satisfies('+common'):
-            copy_all('resources/common/hoc', prefix.hoc)
-            copy_all('resources/common/mod', prefix.mod)
 
         filter_file(r'UNKNOWN_CORE_VERSION', r'%s' % spec.version, prefix.hoc.join('defvar.hoc'))
-
         try:
             commit_hash = self.fetcher[0].get_commit()
             filter_file(r'UNKNOWN_CORE_HASH', r'\'%s\'' % commit_hash, prefix.hoc.join('defvar.hoc'))
         except Exception as e:
-            tty.warn(e)
+            tty.warn(str(e))
+
+        # +Common will bring common mods and build a bare nrnmechlib
+        if spec.satisfies('+common'):
+            copy_all('resources/common/hoc', prefix.hoc)
+            copy_all('resources/common/mod', prefix.mod)
+
+            with working_dir(prefix):
+                which('nrnivmodl')('-incflags', '-DDISABLE_REPORTINGLIB', 'mod')
+
+                bindir = os.path.basename(self.neuron_archdir)
+                special = join_path(bindir, 'special')
+                open('.bindir', 'w').write(bindir)
+
+                if not os.path.isfile(special):
+                    raise Exception("Failed to build neurodamus core mods")
+
+                # Cleanup
+                for f in find(bindir, '*.lo'): os.remove(f)
+                for f in find(bindir, '*.mod'): os.remove(f)
+                for f in find(bindir + '/.libs', '*.o'): os.remove(f)
+                os.mkdir(bindir + "/mod2c")
+                for f in find(bindir, "*.c*"): shutil.move(f, bindir + "/mod2c/")
 
     def setup_environment(self, spack_env, run_env):
         run_env.set('HOC_LIBRARY_PATH', self.prefix.hoc)
+        if self.spec.satisfies('+common'):
+            run_env.set('MOD_LIBRARY_PATH', self.prefix.mod)
+            bindir_info = self.prefix.join('.bindir')
+            if os.path.isfile(bindir_info):
+                bindir = open(bindir_info, 'r').readline()
+                mechlib = find_libraries('libnrnmech', join_path(self.prefix, bindir, '.libs'))[0]
+                run_env.set('NRNMECH_LIB_PATH', mechlib)
+            else:
+                tty.warn("No .bindir info file found. NRNMECH_LIB_PATH env var wont be set")

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -13,6 +13,7 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master', clean=False)
+    version('2.4.0', git=git, tag='2.4.0', clean=False)
     version('2.3.4', git=git, tag='2.3.4', clean=False)
     version('2.3.3', git=git, tag='2.3.3', clean=False)
     version('2.2.1', git=git, tag='2.2.1', clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -73,8 +73,8 @@ class NeurodamusCore(Package):
                 for f in find(bindir, '*.lo'): os.remove(f)
                 for f in find(bindir, '*.mod'): os.remove(f)
                 for f in find(bindir + '/.libs', '*.o'): os.remove(f)
-                os.mkdir(bindir + "/mod2c")
-                for f in find(bindir, "*.c*"): shutil.move(f, bindir + "/mod2c/")
+                os.mkdir(bindir + "/modc")
+                for f in find(bindir, "*.c*"): shutil.move(f, bindir + "/modc/")
 
     def setup_environment(self, spack_env, run_env):
         run_env.set('HOC_LIBRARY_PATH', self.prefix.hoc)

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -22,7 +22,7 @@ class NeurodamusCore(Package):
     variant('common', default=False, description="Merge in synapse mechanisms hoc & mods")
 
     # Attempt to support building
-    depends_on('neuron~binary', when='+common')
+    depends_on('neuron~binary~mpi', when='+common')
 
     # Neurodamus py is currently an extension to core
     resource(name='pydamus',


### PR DESCRIPTION
According to https://bbpteam.epfl.ch/project/issues/browse/BBPBGLIB-463 people want neurodamus core to be compiled.

Even though is not intended as so, we are giving initial experimental support for that. All mods are being compiled even though more advanced features are disabled, inc reporting lib and synapsetool which belong to a full featured neurodamus.

Extra: Added neurodamus-core 2.4.0, featuring
- recalc_ptr_callback optional
- delete spike file before create
- SpontMiniRate fix in Connection blocks