### PR TITLE
deployment: ipy* considered harmful.

### DIFF
--- a/deploy/configs/serial-libraries/modules.yaml
+++ b/deploy/configs/serial-libraries/modules.yaml
@@ -31,6 +31,7 @@ modules:
       - gmsh
       - hdf5~mpi
       - highfive~mpi
+      - py-ipyparallel
       - neuron
       - python-dev
       - 'tensorflow@1.12.0'

--- a/var/spack/repos/builtin/packages/python-dev/package.py
+++ b/var/spack/repos/builtin/packages/python-dev/package.py
@@ -13,7 +13,7 @@ class PythonDev(Package):
     homepage = "http://www.dummy.org/"
     url      = "https://www.dummy.org/source/dummy-0.2.zip"
 
-    version('0.2')
+    version('0.3')
 
     depends_on('python', type=('build', 'run'))
     depends_on('py-beautifulsoup4', type=('build', 'run'))
@@ -21,9 +21,6 @@ class PythonDev(Package):
     depends_on('py-clustershell', type=('build', 'run'))
     depends_on('py-cython', type=('build', 'run'))
     depends_on('py-h5py~mpi', type=('build', 'run'))
-    depends_on('py-ipykernel', type=('build', 'run'))
-    depends_on('py-ipyparallel', type=('build', 'run'))
-    depends_on('py-ipython', type=('build', 'run'))
     depends_on('py-jinja2', type=('build', 'run'))
     depends_on('py-jinja2-cli', type=('build', 'run'))
     depends_on('py-lazy-property', type=('build', 'run'))
@@ -54,7 +51,6 @@ class PythonDev(Package):
         open(os.path.join(prefix, 'success.txt'), 'w').close()
 
     def setup_environment(self, spack_env, run_env):
-        deps = ['py-pip', 'py-ipython', 'py-virtualenv', 'py-wheel', 'py-cython', 'py-pyspark',
-                'py-ipyparallel']
+        deps = ['py-pip', 'py-virtualenv', 'py-wheel', 'py-cython', 'py-pyspark']
         for dep in deps:
             run_env.prepend_path('PATH', self.spec[dep].prefix.bin)


### PR DESCRIPTION
These packages are best installed by the user. Providing them centrally
makes local upgrades painful.