### PR TITLE
touchdetector: add 5.1.0

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -54,6 +54,7 @@ packages:
       - synapsetool@0.4.1
       - touchdetector@4.4.2
       - touchdetector@5.0.1
+      - touchdetector@5.1.0
       - brayns@0.8.0 +opendeck +brion ^ospray@1.7.3
   gnu-stable-parallel-python:
     target_matrix:

--- a/var/spack/repos/builtin/packages/touchdetector/package.py
+++ b/var/spack/repos/builtin/packages/touchdetector/package.py
@@ -32,6 +32,7 @@ class Touchdetector(CMakePackage):
     url      = "ssh://bbpcode.epfl.ch/building/TouchDetector"
 
     version('develop', git=url, submodules=True)
+    version('5.1.0', tag='5.1.0', git=url, submodules=True)
     version('5.0.1', tag='5.0.1', git=url, submodules=True)
     version('5.0.0', tag='5.0.0', git=url, submodules=True)
     version('4.4.2', tag='4.4.2', git=url, submodules=True)


### PR DESCRIPTION
Since the default touchspace has been modified, keep the older version
around for a little bit.