### PR TITLE
mvdtool,libsonata: fix build dependencies.

### DIFF
--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -340,8 +340,10 @@ class BaseConfiguration(object):
         """
         suffixes = []
         for constraint, suffix in self.conf.get('suffixes', {}).items():
-            if constraint in self.spec:
-                suffixes.append(suffix)
+            for spec in self.spec.traverse(deptype=('link', 'run')):
+                if constraint in spec:
+                    suffixes.append(suffix)
+                    break
         if self.hash:
             suffixes.append(self.hash)
         return suffixes

--- a/var/spack/repos/builtin/packages/libsonata/package.py
+++ b/var/spack/repos/builtin/packages/libsonata/package.py
@@ -24,7 +24,9 @@ class Libsonata(CMakePackage):
 
     variant('mpi', default=False, description="Enable MPI backend")
 
+
     depends_on('cmake@3.3:', type='build')
+    depends_on('py-setuptools-scm', type='build', when='@0.1:')
     depends_on('fmt@4.0:')
     depends_on('highfive+mpi', when='+mpi')
     depends_on('highfive~mpi', when='~mpi')

--- a/var/spack/repos/builtin/packages/mvdtool/package.py
+++ b/var/spack/repos/builtin/packages/mvdtool/package.py
@@ -27,6 +27,7 @@ class Mvdtool(CMakePackage):
 
     depends_on('boost')
     depends_on('cmake', type='build')
+    depends_on('py-setuptools-scm', type='build', when='@2:')
 
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('hdf5~mpi', when='~mpi')


### PR DESCRIPTION
Add `py-setuptools-scm` to the build dependencies to get a version number from git. As it's marked `type=build`, no `python` module will be loaded when creating modules.