### PR TITLE
hadoop: update versions.

### DIFF
--- a/var/spack/repos/builtin/packages/hadoop/package.py
+++ b/var/spack/repos/builtin/packages/hadoop/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -15,8 +15,8 @@ class Hadoop(Package):
     homepage = "http://hadoop.apache.org/"
     url      = "http://mirrors.ocf.berkeley.edu/apache/hadoop/common/hadoop-3.1.1/hadoop-3.1.1.tar.gz"
 
-    version('3.1.1', '0b6ab06b59ae75f433de387783f19011')
-    version('2.9.0', 'b443ead81aa2bd5086f99e62e66a8f64')
+    version('3.1.2', '4394af12a81424dc225fe4f2dd02f274')
+    version('2.9.2', '82db6a62febd8c2976d75b8bd5513315')
 
     depends_on('java', type='run')
 


### PR DESCRIPTION
The folks at the Apache mirrors were so nice to purge old versions. File copied from upstream.