### PR TITLE
psp-validation: nuke py-bglibpy version pin.

### DIFF
--- a/var/spack/repos/builtin/packages/psp-validation/package.py
+++ b/var/spack/repos/builtin/packages/psp-validation/package.py
@@ -24,5 +24,5 @@ class PspValidation(PythonPackage):
     depends_on('py-numpy@1.10:', type='run')
     depends_on('py-tqdm@4.0:', type='run')
 
-    depends_on('py-bglibpy@4.0.27', type='run')
+    depends_on('py-bglibpy@4.0:', type='run')
     depends_on('py-bluepy@0.13.3:', type='run')


### PR DESCRIPTION
With frequent `py-bglibpy` version changes *and the removal of old versions*, we can't have a hard dependency like this.