### PR TITLE
bzip2: Add 1.0.8 (#12017)

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -13,13 +13,12 @@ class Bzip2(Package):
     compressors), whilst being around twice as fast at compression
     and six times faster at decompression."""
 
-    # FIXME: The bzip.org domain has expired:
-    # https://lwn.net/Articles/762264/
-    # This package will need to be updated when a new home is found.
     homepage = "https://sourceware.org/bzip2/"
-    url      = "https://fossies.org/linux/misc/bzip2-1.0.6.tar.gz"
+    url      = "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
 
-    version('1.0.6', '00b516f4704d4a7cb50a1d97e6e8e15b')
+    version('1.0.8', 'ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269')
+    version('1.0.7', 'e768a87c5b1a79511499beb41500bcc4caf203726fff46a6f5f9ad27fe08ab2b')
+    version('1.0.6', '00b516f4704d4a7cb50a1d97e6e8e15b', preferred=True)
 
     variant('shared', default=True, description='Enables the build of shared libraries.')
 


### PR DESCRIPTION
Update URLs to official ones.

Commit cherry-picked from master spack branch.
Fossies.org has only the last version.