### PR TITLE
(WIP, Do not Merge) : Make /serial suffix applicable for neuron and hdf5

### DIFF
--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -78,7 +78,7 @@ modules:
         '^python@:2.99': '/python2'
         '^python@3:': '/python3'
         '+mpi': '/parallel'
-        '~mpi': '/serial'
+        'neuron~mpi': '/serial'
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'

--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -43,8 +43,7 @@ modules:
       - neurodamus-neocortex
       - neurodamus-thalamus
       - neurodamus-mousify
-      #- 'neuron+mpi%intel'
-      - neuron~debug
+      - neuron~debug+mpi
       - parquet-converters
       - placement-algorithm
       - psp-validation
@@ -77,7 +76,6 @@ modules:
         '^coreneuron+knl': '/knl'
         '^python@:2.99': '/python2'
         '^python@3:': '/python3'
-        '+mpi': '/parallel'
         'neuron~mpi': '/serial'
       environment:
         set:

--- a/deploy/configs/parallel-libraries/modules.yaml
+++ b/deploy/configs/parallel-libraries/modules.yaml
@@ -45,7 +45,6 @@ modules:
       suffixes:
         '^python@:2.99': '/python2'
         '^python@3:': '/python3'
-        '+mpi': '/parallel'
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'

--- a/deploy/configs/serial-libraries/modules.yaml
+++ b/deploy/configs/serial-libraries/modules.yaml
@@ -46,6 +46,7 @@ modules:
         '^python@:2.99': '/python2'
         '^python@3:': '/python3'
         'neuron~mpi': '/serial'
+        'hdf5~mpi': '/serial'
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'

--- a/deploy/configs/serial-libraries/modules.yaml
+++ b/deploy/configs/serial-libraries/modules.yaml
@@ -45,7 +45,7 @@ modules:
       suffixes:
         '^python@:2.99': '/python2'
         '^python@3:': '/python3'
-        '~mpi': '/serial'
+        'neuron~mpi': '/serial'
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'


### PR DESCRIPTION
  - #371 added /serial suffix for ~mpi variant which
    is not strict
  - we want to add serial suffix for neuron~mpi only

Didn't realise `/serial` is appended everywhere:

<img width="776" alt="image" src="https://user-images.githubusercontent.com/666852/64477885-e9dc1d00-d1a0-11e9-9463-f1519c6923fa.png">

Note : we should this PR after carefully checking module names generated in PR. I wonder if will end-up **with and without /serial** (i.e. duplicates) due to rsync.
 

 