### PR TITLE
Update synapsetool to 0.5.1

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -57,7 +57,7 @@ packages:
     specs:
       - functionalizer@3.12.2
       - parquet-converters@0.4.1
-      - synapsetool@0.5.0
+      - synapsetool@0.5.1
       - touchdetector@4.4.2
       - touchdetector@5.1.0
       - touchdetector@5.2.0

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -34,7 +34,7 @@ class Synapsetool(CMakePackage):
     git      = "ssh://bbpcode.epfl.ch/hpc/synapse-tool"
 
     version('develop', submodules=True)
-    version('0.5.0', tag='v0.5.0', submodules=True)
+    version('0.5.1', tag='v0.5.1', submodules=True)
     version('0.4.1', tag='v0.4.1', submodules=True)
     version('0.3.3', tag='v0.3.3', submodules=True)
     version('0.2.5', tag='v0.2.5', submodules=True)


### PR DESCRIPTION
Bring synapsetool 0.5.1 for the Sonata fixes
- Better detection. Now it can even detect .h5 sonatas / syn2 (inspect contents)
- Fixed several warnings
- Fixed syn2 / sonata tests