### PR TITLE
Adding neuron+debug to the deployments for the CI

### DIFF
--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -44,7 +44,7 @@ modules:
       - neurodamus-thalamus
       - neurodamus-mousify
       #- 'neuron+mpi%intel'
-      - neuron@7.6.6~debug
+      - neuron~debug
       - parquet-converters
       - placement-algorithm
       - psp-validation

--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -44,7 +44,7 @@ modules:
       - neurodamus-thalamus
       - neurodamus-mousify
       #- 'neuron+mpi%intel'
-      - neuron@7.6.6
+      - neuron@7.6.6~debug
       - parquet-converters
       - placement-algorithm
       - psp-validation

--- a/deploy/packages/parallel-libraries.yaml
+++ b/deploy/packages/parallel-libraries.yaml
@@ -87,3 +87,4 @@ packages:
       - python
     specs:
       - neuron@7.6.6
+      - neuron+debug@7.6.6


### PR DESCRIPTION
With this change we expect to get rid of an extra upstream (in proj12/jenkins/devel_builds) and simplify a lot the blueconfigs CI scripts.