### PR TITLE
Adding neurodamus core 2.6.0

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -129,7 +129,7 @@ packages:
       - architecture
       - compiler
     specs:
-      - neurodamus-core+common@2.5.0
+      - neurodamus-core+common@2.6.0
 
   intel-stable-parallel:
     target_matrix:

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -13,6 +13,7 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master', clean=False)
+    version('2.6.0', git=git, tag='2.6.0', clean=False)
     version('2.5.0', git=git, tag='2.5.0', clean=False)
     version('2.4.3', git=git, tag='2.4.3', clean=False)
     version('2.4.1', git=git, tag='2.4.1', clean=False)


### PR DESCRIPTION
Among the new features:
 - Quit when there is a duplicate target
 - BinReportHelper: Ctor dont return value
 - Print correct number of target cells and subtargets
 - nrnPath can be a file (or a dir: deprecated)
 - Attempt finding start.target initially in circuitpath
 - Better detection / precedence of connectivity: 1. Sonata, 2. syn2, 3. Nrn
 - Improved Deprecation and Error messages