### PR TITLE
Update neurodamus family

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -114,10 +114,10 @@ packages:
       - python
     specs:
       - py-bluepy
-      - py-bluepymm@0.6.38 ^neuron~mpi
-      - py-bluepyopt@1.6.56 ^neuron~mpi
+      - py-bluepymm@0.6.38
+      - py-bluepyopt@1.6.56
       - py-efel@3.0.22
-      - py-bglibpy@4.1.4 ^neuron~mpi
+      - py-bglibpy@4.1.4
 
 
   #### cellular ####

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -114,10 +114,10 @@ packages:
       - python
     specs:
       - py-bluepy
-      - py-bluepymm@0.6.38
-      - py-bluepyopt@1.6.56
+      - py-bluepymm@0.6.38 ^neuron~mpi
+      - py-bluepyopt@1.6.56 ^neuron~mpi
       - py-efel@3.0.22
-      - py-bglibpy@4.1.4
+      - py-bglibpy@4.1.4 ^neuron~mpi
 
 
   #### cellular ####

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -129,7 +129,7 @@ packages:
       - architecture
       - compiler
     specs:
-      - neurodamus-core+common@2.6.0
+      - neurodamus-core+common@2.7.0
 
   intel-stable-parallel:
     target_matrix:
@@ -150,10 +150,10 @@ packages:
       - mpi
       - python
     specs:
-      - neurodamus-neocortex+coreneuron@0.2-1
-      - neurodamus-hippocampus+coreneuron@0.3-1
-      - neurodamus-thalamus+coreneuron@0.2-1
-      - neurodamus-mousify+coreneuron@0.2-1
-      - neurodamus-neocortex+coreneuron@0.2-1^coreneuron+knl
-      - neurodamus-thalamus+coreneuron@0.2-1^coreneuron+knl
-      - neurodamus-hippocampus+coreneuron@0.3-1^coreneuron+knl
+      - neurodamus-neocortex+coreneuron@0.3
+      - neurodamus-hippocampus+coreneuron@0.4
+      - neurodamus-thalamus+coreneuron@0.3
+      - neurodamus-mousify+coreneuron@0.3
+      - neurodamus-neocortex+coreneuron@0.3^coreneuron+knl
+      - neurodamus-hippocampus+coreneuron@0.4^coreneuron+knl
+      - neurodamus-thalamus+coreneuron@0.3^coreneuron+knl

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -57,7 +57,7 @@ packages:
     specs:
       - functionalizer@3.12.2
       - parquet-converters@0.4.1
-      - synapsetool@0.5.1
+      - synapsetool@0.5.2
       - touchdetector@4.4.2
       - touchdetector@5.1.0
       - touchdetector@5.2.0

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -129,7 +129,7 @@ packages:
       - architecture
       - compiler
     specs:
-      - neurodamus-core+common@2.5.0
+      - neurodamus-core+common@2.6.0
 
   intel-stable-parallel:
     target_matrix:

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -150,10 +150,10 @@ packages:
       - mpi
       - python
     specs:
-      - neurodamus-neocortex+coreneuron@0.2
-      - neurodamus-hippocampus+coreneuron@0.3
-      - neurodamus-thalamus+coreneuron@0.2
-      - neurodamus-mousify+coreneuron@0.2
-      - neurodamus-neocortex+coreneuron@0.2^coreneuron+knl
-      - neurodamus-thalamus+coreneuron@0.2^coreneuron+knl
-      - neurodamus-hippocampus+coreneuron@0.3^coreneuron+knl
+      - neurodamus-neocortex+coreneuron@0.2.1
+      - neurodamus-hippocampus+coreneuron@0.3.1
+      - neurodamus-thalamus+coreneuron@0.2.1
+      - neurodamus-mousify+coreneuron@0.2.1
+      - neurodamus-neocortex+coreneuron@0.2.1^coreneuron+knl
+      - neurodamus-thalamus+coreneuron@0.2.1^coreneuron+knl
+      - neurodamus-hippocampus+coreneuron@0.3.1^coreneuron+knl

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -150,10 +150,10 @@ packages:
       - mpi
       - python
     specs:
-      - neurodamus-neocortex+coreneuron@0.2.1
-      - neurodamus-hippocampus+coreneuron@0.3.1
-      - neurodamus-thalamus+coreneuron@0.2.1
-      - neurodamus-mousify+coreneuron@0.2.1
-      - neurodamus-neocortex+coreneuron@0.2.1^coreneuron+knl
-      - neurodamus-thalamus+coreneuron@0.2.1^coreneuron+knl
-      - neurodamus-hippocampus+coreneuron@0.3.1^coreneuron+knl
+      - neurodamus-neocortex+coreneuron@0.2-1
+      - neurodamus-hippocampus+coreneuron@0.3-1
+      - neurodamus-thalamus+coreneuron@0.2-1
+      - neurodamus-mousify+coreneuron@0.2-1
+      - neurodamus-neocortex+coreneuron@0.2-1^coreneuron+knl
+      - neurodamus-thalamus+coreneuron@0.2-1^coreneuron+knl
+      - neurodamus-hippocampus+coreneuron@0.3-1^coreneuron+knl

--- a/deploy/packages/parallel-libraries.yaml
+++ b/deploy/packages/parallel-libraries.yaml
@@ -86,5 +86,5 @@ packages:
       - mpi
       - python
     specs:
-      - neuron@7.6.6
-      - neuron+debug@7.6.6
+      - neuron@7.6.8
+      - neuron+debug@7.6.8

--- a/deploy/packages/serial-libraries.yaml
+++ b/deploy/packages/serial-libraries.yaml
@@ -22,7 +22,7 @@ packages:
     specs:
       - arrow+parquet+python@0.11.0
       - boost@1.65.0+python
-      - neuron~mpi@7.6.6
+      - neuron~mpi@7.6.8
 
   gnu-stable-serial-python3:
     target_matrix:

--- a/var/spack/repos/builtin/packages/asciitoh5/package.py
+++ b/var/spack/repos/builtin/packages/asciitoh5/package.py
@@ -14,7 +14,7 @@ class Asciitoh5(Package):
     version('develop', git=git, branch='master')
     version('1.0', git=git, tag='1.0')
 
-    depends_on('neuron')
+    depends_on('neuron~mpi')
     depends_on('hdf5~mpi')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/asciitoh5/package.py
+++ b/var/spack/repos/builtin/packages/asciitoh5/package.py
@@ -14,7 +14,7 @@ class Asciitoh5(Package):
     version('develop', git=git, branch='master')
     version('1.0', git=git, tag='1.0')
 
-    depends_on('neuron~mpi')
+    depends_on('neuron')
     depends_on('hdf5~mpi')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/asciitoh5/package.py
+++ b/var/spack/repos/builtin/packages/asciitoh5/package.py
@@ -14,7 +14,7 @@ class Asciitoh5(Package):
     version('develop', git=git, branch='master')
     version('1.0', git=git, tag='1.0')
 
-    depends_on('neuron~mpi')
+    depends_on('neuron')
     depends_on('hdf5~mpi')
 
     def install(self, spec, prefix):
@@ -32,3 +32,5 @@ class Asciitoh5(Package):
 
     def setup_environment(self, spack_env, run_env):
         run_env.set('HOC_LIBRARY_PATH', self.prefix.lib.hoc)
+        run_env.set('NEURON_INIT_MPI', "0")
+        run_env.unset('PMI_RANK')

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -37,7 +37,8 @@ class Coreneuron(CMakePackage):
     url      = "https://github.com/BlueBrain/CoreNeuron"
 
     version('develop', git=url, submodules=True)
-    version('0.14.1', git=url, submodules=True, preferred=True)
+    version('0.15', git=url, tag='0.15', submodules=True)
+    version('0.14', git=url, tag='0.14', submodules=True)
 
     variant('debug', default=False, description='Build debug with O0')
     variant('gpu', default=False, description="Enable GPU build")

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -24,7 +24,7 @@ class NeurodamusCore(Package):
     variant('common', default=False, description="Merge in synapse mechanisms hoc & mods")
 
     # Attempt to support building
-    depends_on('neuron~binary+python', when='+common')
+    depends_on('neuron~binary+python~mpi', when='+common')
 
     # Neurodamus py is currently an extension to core
     resource(name='pydamus',
@@ -92,5 +92,6 @@ class NeurodamusCore(Package):
                 bindir = open(bindir_info, 'r').readline()
                 mechlib = find_libraries('libnrnmech', join_path(self.prefix, bindir, '.libs'))[0]
                 run_env.set('NRNMECH_LIB_PATH', mechlib)
+                run_env.set('BGLIBPY_MOD_LIBRARY_PATH', mechlib)
             else:
                 tty.warn("No .bindir info file found. NRNMECH_LIB_PATH env var wont be set")

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -13,6 +13,7 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master', clean=False)
+    version('2.7.0', git=git, tag='2.7.0', clean=False)
     version('2.6.0', git=git, tag='2.6.0', clean=False)
     version('2.5.0', git=git, tag='2.5.0', clean=False)
     version('2.4.3', git=git, tag='2.4.3', clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -26,7 +26,7 @@ class NeurodamusCore(Package):
     variant('common', default=False, description="Merge in synapse mechanisms hoc & mods")
 
     # Attempt to support building
-    depends_on('neuron~binary+python~mpi', when='+common')
+    depends_on('neuron~binary+python', when='+common')
 
     # Neurodamus py is currently an extension to core
     resource(name='pydamus',

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -24,7 +24,7 @@ class NeurodamusCore(Package):
     variant('common', default=False, description="Merge in synapse mechanisms hoc & mods")
 
     # Attempt to support building
-    depends_on('neuron~binary+python~mpi', when='+common')
+    depends_on('neuron~binary+python', when='+common')
 
     # Neurodamus py is currently an extension to core
     resource(name='pydamus',

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -13,6 +13,7 @@ class NeurodamusCore(Package):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', git=git, branch='master', clean=False)
+    version('2.6.0', git=git, tag='2.6.0', clean=False)
     version('2.5.0', git=git, tag='2.5.0', clean=False)
     version('2.4.3', git=git, tag='2.4.3', clean=False)
     version('2.4.1', git=git, tag='2.4.1', clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -11,7 +11,7 @@ class NeurodamusHippocampus(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
     git      = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
 
-    version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('develop', branch='master', submodules=True, clean=False)
     version('0.4', tag='0.4', submodules=True, clean=False)
     version('0.3', tag='0.3', submodules=True, clean=False)
     version('0.2', tag='0.2', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -12,7 +12,7 @@ class NeurodamusHippocampus(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
 
     version('develop', branch='master', submodules=True, clean=False)
-    version('0.4', tag='0.4', submodules=True, clean=False)
+    version('0.4', tag='0.4-1', submodules=True, clean=False)
     version('0.3', tag='0.3', submodules=True, clean=False)
     version('0.2', tag='0.2', submodules=True, clean=False)
     version('0.1', tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -12,7 +12,7 @@ class NeurodamusHippocampus(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
-    version('0.3-1', git=git, tag='0.3', submodules=True, clean=False)
-    version('0.2', git=git, tag='0.2', submodules=True, clean=False)
-    version('0.1', git=git, tag='0.1', submodules=True, clean=False)
+    version('0.4', tag='0.4', submodules=True, clean=False)
+    version('0.3', tag='0.3', submodules=True, clean=False)
+    version('0.2', tag='0.2', submodules=True, clean=False)
+    version('0.1', tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -12,6 +12,7 @@ class NeurodamusHippocampus(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('0.3.1', git=git, tag='0.3', submodules=True, clean=False)
     version('0.3', git=git, tag='0.3', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -15,7 +15,3 @@ class NeurodamusHippocampus(NeurodamusModel):
     version('0.3', git=git, tag='0.3', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)
-
-    # NEURODAMUS-HIPPOCAMPUS <=0.3
-    depends_on('neurodamus-core@2.5.0', when='@:0.3')
-    depends_on('neurodamus-core+python@2.5.0', when='+python@:0.3')

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -14,6 +14,5 @@ class NeurodamusHippocampus(NeurodamusModel):
     version('develop', git=git, branch='master', submodules=True, clean=False)
     # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
     version('0.3-1', git=git, tag='0.3', submodules=True, clean=False)
-    version('0.3', git=git, tag='0.3', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -15,3 +15,7 @@ class NeurodamusHippocampus(NeurodamusModel):
     version('0.3', git=git, tag='0.3', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)
+
+    # NEURODAMUS-HIPPOCAMPUS <=0.3
+    depends_on('neurodamus-core@2.5.0', when='@:0.3')
+    depends_on('neurodamus-core+python@2.5.0', when='+python@:0.3')

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -12,7 +12,8 @@ class NeurodamusHippocampus(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    version('0.3.1', git=git, tag='0.3', submodules=True, clean=False)
+    # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
+    version('0.3-1', git=git, tag='0.3', submodules=True, clean=False)
     version('0.3', git=git, tag='0.3', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -22,9 +22,11 @@ class NeurodamusModel(SimModel):
     variant('python',      default=False, description="Install neurodamus-python alongside")
     variant('common_mods', default='',    description="Source of common mods. '': no change,"
                                                       " other string: alternate path")
-
-    depends_on('neurodamus-core')
-    depends_on('neurodamus-core+python', when='+python')
+    # NEURODAMUS-CORE 2.5.0
+    depends_on('reportinglib@2.5.1', when='^neurodamus-core@2.5.0')
+    depends_on('reportinglib+profile@2.5.1', when='+profile ^neurodamus-core@2.5.0')
+    depends_on('synapsetool+mpi@0.5.1', when='+synapsetool~sonata ^neurodamus-core@2.5.0')
+    depends_on('synapsetool+mpi+sonata@0.5.1', when='+synapsetool+sonata ^neurodamus-core@2.5.0')
 
     depends_on("mpi")
     depends_on("hdf5+mpi")

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -22,11 +22,9 @@ class NeurodamusModel(SimModel):
     variant('python',      default=False, description="Install neurodamus-python alongside")
     variant('common_mods', default='',    description="Source of common mods. '': no change,"
                                                       " other string: alternate path")
-    # NEURODAMUS-CORE 2.5.0
-    depends_on('reportinglib@2.5.1', when='^neurodamus-core@2.5.0')
-    depends_on('reportinglib+profile@2.5.1', when='+profile ^neurodamus-core@2.5.0')
-    depends_on('synapsetool+mpi@0.5.1', when='+synapsetool~sonata ^neurodamus-core@2.5.0')
-    depends_on('synapsetool+mpi+sonata@0.5.1', when='+synapsetool+sonata ^neurodamus-core@2.5.0')
+
+    depends_on('neurodamus-core')
+    depends_on('neurodamus-core+python', when='+python')
 
     depends_on("mpi")
     depends_on("hdf5+mpi")

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -11,7 +11,7 @@ class NeurodamusMousify(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/mousify"
     git      = "ssh://bbpcode.epfl.ch/sim/models/mousify"
 
-    version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('develop', branch='master', submodules=True, clean=False)
     version('0.3', git=git, tag='0.3', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -12,6 +12,6 @@ class NeurodamusMousify(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/mousify"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
-    version('0.2-1', git=git, tag='0.2', submodules=True, clean=False)
+    version('0.3', git=git, tag='0.3', submodules=True, clean=False)
+    version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -12,6 +12,6 @@ class NeurodamusMousify(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/mousify"
 
     version('develop', branch='master', submodules=True, clean=False)
-    version('0.3', git=git, tag='0.3', submodules=True, clean=False)
+    version('0.3', git=git, tag='0.3-1', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -12,6 +12,7 @@ class NeurodamusMousify(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/mousify"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    version('0.2.1', git=git, tag='0.2', submodules=True, clean=False)
+    # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
+    version('0.2-1', git=git, tag='0.2', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -12,5 +12,6 @@ class NeurodamusMousify(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/mousify"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('0.2.1', git=git, tag='0.2', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -14,5 +14,4 @@ class NeurodamusMousify(NeurodamusModel):
     version('develop', git=git, branch='master', submodules=True, clean=False)
     # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
     version('0.2-1', git=git, tag='0.2', submodules=True, clean=False)
-    version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -14,7 +14,3 @@ class NeurodamusMousify(NeurodamusModel):
     version('develop', git=git, branch='master', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)
-
-    # NEURODAMUS-MOUSIFY <=0.2
-    depends_on('neurodamus-core@2.5.0', when='@:0.2')
-    depends_on('neurodamus-core+python@2.5.0', when='+python@:0.2')

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -14,3 +14,7 @@ class NeurodamusMousify(NeurodamusModel):
     version('develop', git=git, branch='master', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)
+
+    # NEURODAMUS-MOUSIFY <=0.2
+    depends_on('neurodamus-core@2.5.0', when='@:0.2')
+    depends_on('neurodamus-core+python@2.5.0', when='+python@:0.2')

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -12,7 +12,7 @@ class NeurodamusNeocortex(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
 
     version('develop', branch='master', submodules=True, clean=False)
-    version('0.3', tag='0.3', submodules=True, clean=False)
+    version('0.3', tag='0.3-1', submodules=True, clean=False)
     version('0.2', tag='0.2', submodules=True, clean=False)
     version('0.1', tag='0.1', submodules=True, clean=False)
 

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -12,9 +12,9 @@ class NeurodamusNeocortex(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
-    version('0.2-1', git=git, tag='0.2', submodules=True, clean=False)
-    version('0.1', git=git, tag='0.1', submodules=True, clean=False)
+    version('0.3', tag='0.3', submodules=True, clean=False)
+    version('0.2', tag='0.2', submodules=True, clean=False)
+    version('0.1', tag='0.1', submodules=True, clean=False)
 
     variant('v5', default=True, description='Enable support for previous v5 circuits')
     variant('plasticity', default=False, description="Use optimized ProbAMPANMDA_EMS and ProbGABAAB_EMS")

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -11,7 +11,7 @@ class NeurodamusNeocortex(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
     git      = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
 
-    version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('develop', branch='master', submodules=True, clean=False)
     version('0.3', tag='0.3', submodules=True, clean=False)
     version('0.2', tag='0.2', submodules=True, clean=False)
     version('0.1', tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -14,7 +14,6 @@ class NeurodamusNeocortex(NeurodamusModel):
     version('develop', git=git, branch='master', submodules=True, clean=False)
     # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
     version('0.2-1', git=git, tag='0.2', submodules=True, clean=False)
-    version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)
 
     variant('v5', default=True, description='Enable support for previous v5 circuits')

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -12,7 +12,8 @@ class NeurodamusNeocortex(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    version('0.2.1', git=git, tag='0.2', submodules=True, clean=False)
+    # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
+    version('0.2-1', git=git, tag='0.2', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)
 

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -18,10 +18,6 @@ class NeurodamusNeocortex(NeurodamusModel):
     variant('v5', default=True, description='Enable support for previous v5 circuits')
     variant('plasticity', default=False, description="Use optimized ProbAMPANMDA_EMS and ProbGABAAB_EMS")
 
-    # NEURODAMUS-NEOCORTEX <=0.2
-    depends_on('neurodamus-core@2.5.0', when='@:0.2')
-    depends_on('neurodamus-core+python@2.5.0', when='+python@:0.2')
-
     mech_name = "neocortex"
 
     @run_before('build_model')

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -12,6 +12,7 @@ class NeurodamusNeocortex(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('0.2.1', git=git, tag='0.2', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)
 

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -18,6 +18,10 @@ class NeurodamusNeocortex(NeurodamusModel):
     variant('v5', default=True, description='Enable support for previous v5 circuits')
     variant('plasticity', default=False, description="Use optimized ProbAMPANMDA_EMS and ProbGABAAB_EMS")
 
+    # NEURODAMUS-NEOCORTEX <=0.2
+    depends_on('neurodamus-core@2.5.0', when='@:0.2')
+    depends_on('neurodamus-core+python@2.5.0', when='+python@:0.2')
+
     mech_name = "neocortex"
 
     @run_before('build_model')

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -11,7 +11,7 @@ class NeurodamusThalamus(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/thalamus"
     git      = "ssh://bbpcode.epfl.ch/sim/models/thalamus"
 
-    version('develop', git=git, branch='master', submodules=True, clean=False)
-    # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
-    version('0.2-1', git=git, tag='0.2', submodules=True, clean=False)
-    version('0.1', git=git, tag='0.1', submodules=True, clean=False)
+    version('develop', branch='master', submodules=True, clean=False)
+    version('0.3', tag='0.3', submodules=True, clean=False)
+    version('0.2', tag='0.2', submodules=True, clean=False)
+    version('0.1', tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -12,6 +12,6 @@ class NeurodamusThalamus(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/thalamus"
 
     version('develop', branch='master', submodules=True, clean=False)
-    version('0.3', tag='0.3', submodules=True, clean=False)
+    version('0.3', tag='0.3-1', submodules=True, clean=False)
     version('0.2', tag='0.2', submodules=True, clean=False)
     version('0.1', tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -14,3 +14,7 @@ class NeurodamusThalamus(NeurodamusModel):
     version('develop', git=git, branch='master', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)
+
+    # NEURODAMUS-THALAMUS <=0.2
+    depends_on('neurodamus-core@2.5.0', when='@:0.2')
+    depends_on('neurodamus-core+python@2.5.0', when='+python@:0.2')

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -14,5 +14,4 @@ class NeurodamusThalamus(NeurodamusModel):
     version('develop', git=git, branch='master', submodules=True, clean=False)
     # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
     version('0.2-1', git=git, tag='0.2', submodules=True, clean=False)
-    version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -12,5 +12,6 @@ class NeurodamusThalamus(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/thalamus"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
+    version('0.2.1', git=git, tag='0.2', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -12,6 +12,7 @@ class NeurodamusThalamus(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/thalamus"
 
     version('develop', git=git, branch='master', submodules=True, clean=False)
-    version('0.2.1', git=git, tag='0.2', submodules=True, clean=False)
+    # Updated CoreNeuron to 0.15 and neurodamus-core to 2.6.0
+    version('0.2-1', git=git, tag='0.2', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -14,7 +14,3 @@ class NeurodamusThalamus(NeurodamusModel):
     version('develop', git=git, branch='master', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)
     version('0.1', git=git, tag='0.1', submodules=True, clean=False)
-
-    # NEURODAMUS-THALAMUS <=0.2
-    depends_on('neurodamus-core@2.5.0', when='@:0.2')
-    depends_on('neurodamus-core+python@2.5.0', when='+python@:0.2')

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -272,11 +272,12 @@ class Neuron(Package):
         filter_file(env['CC'],  cxx_compiler, libtool_makefile, **kwargs)
         filter_file(env['CXX'], cxx_compiler, libtool_makefile, **kwargs)
 
-        filter_file(env['CC'],  cc_compiler, nrnmech_makefile, **kwargs)
-        filter_file(env['CXX'], cxx_compiler, nrnmech_makefile, **kwargs)
+        if self.spec.satisfies('+mpi'):
+            filter_file(env['CC'],  cc_compiler, nrnmech_makefile, **kwargs)
+            filter_file(env['CXX'], cxx_compiler, nrnmech_makefile, **kwargs)
 
-        filter_file(env['CC'],  cc_compiler, nrniv_makefile, **kwargs)
-        filter_file(env['CXX'], cxx_compiler, nrniv_makefile, **kwargs)
+            filter_file(env['CC'],  cc_compiler, nrniv_makefile, **kwargs)
+            filter_file(env['CXX'], cxx_compiler, nrniv_makefile, **kwargs)
 
 
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -82,7 +82,7 @@ class Neuron(Package):
         '+mpi+multisend': ['--with-multisend'],
         '~rx3d':      ['--disable-rx3d'],
         '~mpi':       ['--without-paranrn'],
-        '+mpi':       ['--with-paranrn'],
+        '+mpi':       ['--with-paranrn=dynamic'],
         '~shared':    ['--disable-shared'],
         '+binary':    ['linux_nrnmech=no'],
     }

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -24,7 +24,9 @@ class Neuron(Package):
     git      = "https://github.com/nrnhines/nrn.git"
 
     version('develop', branch='master')
-    version('7.6.6',   tag='7.6.6', preferred=True)
+    # TODO : temporary until tag is created
+    version('7.6.8',   commit='3316022db691c5518347670784889823a5f0e52f', preferred=True)
+    version('7.6.6',   tag='7.6.6')
     version('2018-10', commit='b3097b7')
     # versions from url, with checksum
     version('7.5', 'fb72c841374dfacbb6c2168ff57bfae9')

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -269,15 +269,17 @@ class Neuron(Package):
         }
 
         # hpe-mpi requires linking to libmpi++ and hence needs to use cxx wrapper
-        filter_file(env['CC'],  cxx_compiler, libtool_makefile, **kwargs)
+        if self.spec.satisfies('+mpi'):
+            filter_file(env['CC'],  cxx_compiler, libtool_makefile, **kwargs)
+        else:
+            filter_file(env['CC'],  cc_compiler, libtool_makefile, **kwargs)
         filter_file(env['CXX'], cxx_compiler, libtool_makefile, **kwargs)
 
-        if self.spec.satisfies('+mpi'):
-            filter_file(env['CC'],  cc_compiler, nrnmech_makefile, **kwargs)
-            filter_file(env['CXX'], cxx_compiler, nrnmech_makefile, **kwargs)
+        filter_file(env['CC'],  cc_compiler, nrnmech_makefile, **kwargs)
+        filter_file(env['CXX'], cxx_compiler, nrnmech_makefile, **kwargs)
 
-            filter_file(env['CC'],  cc_compiler, nrniv_makefile, **kwargs)
-            filter_file(env['CXX'], cxx_compiler, nrniv_makefile, **kwargs)
+        filter_file(env['CC'],  cc_compiler, nrniv_makefile, **kwargs)
+        filter_file(env['CXX'], cxx_compiler, nrniv_makefile, **kwargs)
 
 
     def setup_environment(self, spack_env, run_env):

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -17,7 +17,7 @@ class PyBglibpy(PythonPackage):
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('neuron+python~mpi', type='run')
+    depends_on('neuron+python', type='run')
     depends_on('py-h5py~mpi@2.3:', type='run')
     depends_on('py-bluepy@0.13.2:', type='run')
     depends_on('py-libsonata', type='run')

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -21,3 +21,6 @@ class PyBglibpy(PythonPackage):
     depends_on('py-h5py~mpi@2.3:', type='run')
     depends_on('py-bluepy@0.13.2:', type='run')
     depends_on('py-libsonata', type='run')
+
+    def setup_environment(self, spack_env, run_env):
+        run_env.set('NEURON_INIT_MPI', "0")

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -17,10 +17,11 @@ class PyBglibpy(PythonPackage):
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('neuron+python~mpi', type='run')
+    depends_on('neuron+python', type='run')
     depends_on('py-h5py~mpi@2.3:', type='run')
     depends_on('py-bluepy@0.13.2:', type='run')
     depends_on('py-libsonata', type='run')
 
     def setup_environment(self, spack_env, run_env):
         run_env.set('NEURON_INIT_MPI', "0")
+        run_env.unset('PMI_RANK')

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -17,7 +17,7 @@ class PyBglibpy(PythonPackage):
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('neuron+python', type='run')
+    depends_on('neuron+python~mpi', type='run')
     depends_on('py-h5py~mpi@2.3:', type='run')
     depends_on('py-bluepy@0.13.2:', type='run')
     depends_on('py-libsonata', type='run')

--- a/var/spack/repos/builtin/packages/py-bluepymm/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepymm/package.py
@@ -44,3 +44,6 @@ class PyBluepymm(PythonPackage):
     depends_on('py-lxml', type='run')
     depends_on('py-sh', type='run')
     depends_on('neuron', type='run')
+
+    def setup_environment(self, spack_env, run_env):
+        run_env.set('NEURON_INIT_MPI', "0")

--- a/var/spack/repos/builtin/packages/py-bluepymm/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepymm/package.py
@@ -46,4 +46,5 @@ class PyBluepymm(PythonPackage):
     depends_on('neuron', type='run')
 
     def setup_environment(self, spack_env, run_env):
+        run_env.unset('PMI_RANK')
         run_env.set('NEURON_INIT_MPI', "0")

--- a/var/spack/repos/builtin/packages/py-bluepyopt/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepyopt/package.py
@@ -47,4 +47,5 @@ class PyBluepyopt(PythonPackage):
     depends_on('neuron', type='run', when='+neuron')
 
     def setup_environment(self, spack_env, run_env):
+        run_env.unset('PMI_RANK')
         run_env.set('NEURON_INIT_MPI', "0")

--- a/var/spack/repos/builtin/packages/py-bluepyopt/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepyopt/package.py
@@ -32,7 +32,7 @@ class PyBluepyopt(PythonPackage):
     url = "https://pypi.io/packages/source/b/bluepyopt/bluepyopt-1.6.56.tar.gz"
 
     version('1.6.56', sha256='1c57c91465ca4b947fe157692e7004a3e6df02e4151e3dc77a8831382a8f1ab9')
-    
+
     variant('neuron', default=True, description="Use BluePyOpt together with NEURON")
 
     depends_on('py-setuptools', type='build')
@@ -45,3 +45,6 @@ class PyBluepyopt(PythonPackage):
     depends_on('py-future', type='run')
     depends_on('py-jinja2', type='run')
     depends_on('neuron', type='run', when='+neuron')
+
+    def setup_environment(self, spack_env, run_env):
+        run_env.set('NEURON_INIT_MPI', "0")

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -116,7 +116,7 @@ class SimModel(Package):
         arch = os.path.basename(self.neuron_archdir)
         prefix = self.prefix
         shutil.copy(join_path(arch, 'special'), prefix.bin)
-        
+
         if self.spec.satisfies('^neuron~binary'):
             # Install libnrnmech - might have several links.
             for f in find(arch + "/.libs", 'libnrnmech*.so*', recursive=False):
@@ -133,7 +133,7 @@ class SimModel(Package):
                          's#-dll .*#-dll %s "$@"#' % lib_dst,
                          prefix.bin.special)
             os.remove(prefix.bin.join('special.bak'))
-        
+
     def _install_src(self, prefix):
         """Copy original and translated c mods
         """

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -28,12 +28,6 @@ class SimModel(Package):
     variant('coreneuron',  default=False, description="Enable CoreNEURON Support")
     variant('profile',     default=False, description="Enable profiling using Tau")
 
-    # NEURODAMUS-CORE 2.5.0
-    depends_on('neuron+mpi@7.6.6', type=('build', 'link', 'run'), when='^neurodamus-core@2.5.0')
-    depends_on('coreneuron@0.15', when='+coreneuron ^neurodamus-core@2.5.0', type=('build', 'link', 'run'))
-    depends_on('coreneuron+profile@0.15', when='+coreneuron+profile ^neurodamus-core@2.5.0')
-    depends_on('neuron+profile@7.6.6', when='+profile ^neurodamus-core@2.5.0')
-
     depends_on('neuron+mpi', type=('build', 'link', 'run'))
     depends_on('coreneuron', when='+coreneuron', type=('build', 'link', 'run'))
     depends_on('coreneuron+profile', when='+coreneuron+profile')

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -28,6 +28,12 @@ class SimModel(Package):
     variant('coreneuron',  default=False, description="Enable CoreNEURON Support")
     variant('profile',     default=False, description="Enable profiling using Tau")
 
+    # NEURODAMUS-CORE 2.5.0
+    depends_on('neuron+mpi@7.6.6', type=('build', 'link', 'run'), when='^neurodamus-core@2.5.0')
+    depends_on('coreneuron@0.15', when='+coreneuron ^neurodamus-core@2.5.0', type=('build', 'link', 'run'))
+    depends_on('coreneuron+profile@0.15', when='+coreneuron+profile ^neurodamus-core@2.5.0')
+    depends_on('neuron+profile@7.6.6', when='+profile ^neurodamus-core@2.5.0')
+
     depends_on('neuron+mpi', type=('build', 'link', 'run'))
     depends_on('coreneuron', when='+coreneuron', type=('build', 'link', 'run'))
     depends_on('coreneuron+profile', when='+coreneuron+profile')

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -34,6 +34,7 @@ class Synapsetool(CMakePackage):
     git      = "ssh://bbpcode.epfl.ch/hpc/synapse-tool"
 
     version('develop', submodules=True)
+    version('0.5.2', tag='v0.5.2', submodules=True)
     version('0.5.1', tag='v0.5.1', submodules=True)
     version('0.4.1', tag='v0.4.1', submodules=True)
     version('0.3.3', tag='v0.3.3', submodules=True)


### PR DESCRIPTION
With neurodamus-core 2.6.0 comes the following:

- Quit when there is a duplicate target
- BinReportHelper: Ctor dont return value
- Print correct number of target cells and subtargets
- nrnPath can be a file (or a dir: deprecated)
- Attempt finding start.target initially in circuitpath
- Better detection / precedence of connectivity: 1. Sonata, 2. syn2, 3. Nrn
- Improved Deprecation and Error messages

With neurodamusc-core 2.7.0, common mods 1.3, synapsetool 0.5.2 comes

 - population ids to seed synapse RNGs
 - Better support for sonata, with verbose mode 