### PR TITLE
Deploying steps 3.5.0a, required by Dan

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -91,6 +91,7 @@ packages:
       - python
     specs:
       - steps@3.4.1+petsc
+      - steps@3.5.0a+petsc
 
   gnu-stable-lapack-parallel:
     target_matrix:

--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -13,6 +13,7 @@ class Steps(CMakePackage):
     git      = "git@github.com:CNS-OIST/HBP_STEPS.git"
 
     version("develop", branch="master", submodules=True)
+    version("3.5.0a",  commit="1c8a5b0" submodules=True)
     version("3.4.1", submodules=True)
     version("3.3.0", submodules=True)
     version("3.2.0", submodules=True)

--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -13,7 +13,7 @@ class Steps(CMakePackage):
     git      = "git@github.com:CNS-OIST/HBP_STEPS.git"
 
     version("develop", branch="master", submodules=True)
-    version("3.5.0a",  commit="1c8a5b0" submodules=True)
+    version("3.5.0a",  commit="1c8a5b0", submodules=True)
     version("3.4.1", submodules=True)
     version("3.3.0", submodules=True)
     version("3.2.0", submodules=True)

--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -13,7 +13,7 @@ class Steps(CMakePackage):
     git      = "git@github.com:CNS-OIST/HBP_STEPS.git"
 
     version("develop", branch="master", submodules=True)
-    version("3.5.0a",  commit="1c8a5b0", submodules=True)
+    version("3.5.0a",  commit="30eb779", submodules=True)
     version("3.4.1", submodules=True)
     version("3.3.0", submodules=True)
     version("3.2.0", submodules=True)


### PR DESCRIPTION
Dan requires this version which implements intersection.
Previously I deployed it in a separate tree in proj40 but in the meantime the main functionality was merged to master featuring a lot of improvements.
Since there hasn't been a recent Steps in some time, and I'm not an authority there to create a tag, I believe an interim 3.5.0a will do (I know I know, debatable version name but... well, better options?)