### PR TITLE
Fixes for cray deployment

### DIFF
--- a/sysconfig/daint/packages.yaml
+++ b/sysconfig/daint/packages.yaml
@@ -41,12 +41,12 @@ packages:
         version: [system]
     cmake:
         paths:
-            cmake@3.8.1: /apps/common/UES/jenkins/SLES12/easybuild/software/CMake/3.8.1
+            cmake@3.12.4: /apps/daint/UES/jenkins/6.0.UP07/mc/easybuild/software/CMake/3.12.4
         buildable: False
-        version: [3.8.1]
+        version: [3.12.4]
     boost:
-        modules:
-            boost@1.67.0: Boost/1.67.0-CrayGNU-18.08
+        paths:
+            boost@1.67.0: /apps/daint/UES/jenkins/6.0.UP07/mc/easybuild/software/Boost/1.67.0-CrayGNU-18.08
         buildable: False
         version: [1.67.0]
     ncurses:

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -126,7 +126,7 @@ class Coreneuron(CMakePackage):
                    '-DDISABLE_NRN_TIMEOUT=ON'
                    ]
 
-        if spec.satisfies('~shared') or spec.satisfies('+gpu'):
+        if spec.satisfies('~shared') or spec.satisfies('+gpu') or 'cray' in spec.architecture:
             options.append('-DCOMPILE_LIBRARY_TYPE=STATIC')
 
         if 'bgq' in spec.architecture and '%xl' in spec:
@@ -174,7 +174,8 @@ class Coreneuron(CMakePackage):
         """
         search_paths = [[self.prefix.lib, False], [self.prefix.lib64, False]]
         spec = self.spec
-        is_shared = spec.satisfies('+shared') and spec.satisfies('~gpu')
+        # opposite of how static linkage is used
+        is_shared = not (spec.satisfies('~shared') or spec.satisfies('+gpu') or 'cray' in spec.architecture)
         for path, recursive in search_paths:
             libs = find_libraries(['libcoreneuron', 'libcorenrnmech'], root=path,
                                   shared=is_shared, recursive=False)

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -4,7 +4,6 @@ from spack import *
 from contextlib import contextmanager
 import os, shutil
 
-
 class SimModel(Package):
     """The abstract base package for simulation models.
 
@@ -73,7 +72,7 @@ class SimModel(Package):
         which('nrnivmodl-core')(
             '-i', include_flag, '-l', link_flag, '-n', self.mech_name,
             '-v', str(spec.version), '-c', mods_location)
-        output_dir = spec.architecture.target
+        output_dir = os.path.basename(self.neuron_archdir)
         expected_name = "libcorenrnmech" + ('_' + self.mech_name if self.mech_name else '')
         mechlib = find_libraries(expected_name + '*', output_dir)
         assert len(mechlib.names) == 1, "Error creating corenrnmech lib."


### PR DESCRIPTION
  - spec.architecture.target provides cpu arch (e.g. haswell) and not x86_64
  - boost dependency of synapsetool requires newer cmake (BSD-44)
  - use newest cmake on piz daint