### PR TITLE
New package for HPE-MPI using relocatable rpms

### DIFF
--- a/var/spack/repos/builtin/packages/hpe-mpi/package.py
+++ b/var/spack/repos/builtin/packages/hpe-mpi/package.py
@@ -35,6 +35,7 @@ class HpeMpi(Package):
 
     version('2.21', '2dd6c53a82993c4df929fdf898ac3d19',
         url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.21.tar.xz')
+    version('2.16', '0123456789abcdef0123456789abcdef', preferred=True)
 
     provides('mpi')
 

--- a/var/spack/repos/builtin/packages/hpe-mpi/package.py
+++ b/var/spack/repos/builtin/packages/hpe-mpi/package.py
@@ -1,3 +1,30 @@
+##############################################################################
+# Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Created by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://github.com/spack/spack
+# Please also see the NOTICE and LICENSE files for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License (as
+# published by the Free Software Foundation) version 2.1, February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from tempfile import TemporaryFile
+
+from llnl.util.filesystem import find
 from spack import *
 
 class HpeMpi(Package):
@@ -6,12 +33,33 @@ class HpeMpi(Package):
     homepage = "http://www.example.com"
     url      = "http://www.example.com/hpempi-1.0.tar.gz"
 
-    version('2.16', '0123456789abcdef0123456789abcdef')
+    version('2.21', '2dd6c53a82993c4df929fdf898ac3d19',
+        url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.21.tar.xz')
 
     provides('mpi')
 
-    def do_fetch(self, mirror_only=False):
-        raise RuntimeError('HPE MPI should be configured as external package')
+
+    @run_before('install')
+    def unpack(self):
+        rpm2cpio = spack.util.executable.which('rpm2cpio')
+        cpio = spack.util.executable.which('cpio')
+
+        for rpm_filename in find(self.stage.source_path, '*.rpm'):
+            with TemporaryFile() as tmpf:
+                rpm2cpio(rpm_filename, output=tmpf)
+                tmpf.seek(0) 
+                cpio('-dium',input=tmpf)
+
+
+    def install(self, spec, prefix):
+        for mpic in find(self.stage.source_path, 'mpic*'):
+          filter_file(r'-I(.*mpiroot)', r'-isystem\1', mpic)
+        
+        install_tree(
+            join_path(self.stage.source_path, 'opt/hpe/hpc/mpt/mpt-' + str(self.spec.version)),
+            prefix
+        )
+
 
     def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
         bindir = self.prefix.bin
@@ -23,6 +71,7 @@ class HpeMpi(Package):
         spack_env.set('MPICC_CC', spack_cc)
         spack_env.set('MPICXX_CXX', spack_cxx)
         spack_env.set('MPIF90_F90', spack_fc)
+
 
     def setup_dependent_package(self, module, dep_spec):
         bindir = self.prefix.bin


### PR DESCRIPTION
- Unpacks the archive and copies all files into prefix
- patches mpi compiler wrapper scripts to use `-isystem` rather than `-I` for include paths.