### PR TITLE
Fixes from Jureca deployment

### DIFF
--- a/sysconfig/jureca-booster/modules.yaml
+++ b/sysconfig/jureca-booster/modules.yaml
@@ -26,7 +26,7 @@ modules:
       suffixes:
           '+profile': 'profile'
           '^coreneuron+knl': 'knl'
-          '~mpi': 'serial'
+          'neuron~mpi': 'serial'
       filter:
         environment_blacklist: ['CPATH', 'LIBRARY_PATH']
     naming_scheme: '${PACKAGE}/${VERSION}'

--- a/sysconfig/jureca-booster/modules.yaml
+++ b/sysconfig/jureca-booster/modules.yaml
@@ -38,6 +38,7 @@ modules:
       - 'neuron'
       - 'py-bluepyopt'
       - 'py-bluepy'
+      - 'libxslt'
     blacklist:
       - '%gcc'
       - '%intel'

--- a/sysconfig/jureca-booster/packages.yaml
+++ b/sysconfig/jureca-booster/packages.yaml
@@ -122,11 +122,6 @@ packages:
             py-matplotlib@2.2.2: /usr/local/software/jurecabooster/Stages/2019a/software/SciPy-Stack/2019a-gcccoremkl-8.3.0-2019.3.199-Python-2.7.16
         version: [2.2.2]
         buildable: False
-    py-numpy:
-        paths:
-            py-numpy@1.14.2: /usr/local/software/jurecabooster/Stages/2019a/software/SciPy-Stack/2019a-gcccoremkl-8.3.0-2019.3.199-Python-2.7.16
-        version: [1.14.2]
-        buildable: False
     py-pandas:
         paths:
             py-pandas@0.22.0: /usr/local/software/jurecabooster/Stages/2019a/software/SciPy-Stack/2019a-gcccoremkl-8.3.0-2019.3.199-Python-2.7.16

--- a/sysconfig/jureca-cluster/modules.yaml
+++ b/sysconfig/jureca-cluster/modules.yaml
@@ -26,7 +26,7 @@ modules:
       suffixes:
           '+profile': 'profile'
           '^coreneuron+knl': 'knl'
-          '~mpi': 'serial'
+          'neuron~mpi': '/serial'
       filter:
         environment_blacklist: ['CPATH', 'LIBRARY_PATH']
     naming_scheme: '${PACKAGE}/${VERSION}'

--- a/sysconfig/jureca-cluster/packages.yaml
+++ b/sysconfig/jureca-cluster/packages.yaml
@@ -102,11 +102,6 @@ packages:
             py-matplotlib@2.2.2: /usr/local/software/jureca/Stages/2019a/software/SciPy-Stack/2019a-gcccoremkl-8.3.0-2019.3.199-Python-2.7.16
         version: [2.2.2]
         buildable: False
-    py-numpy:
-        paths:
-            py-numpy@1.14.2: /usr/local/software/jureca/Stages/2019a/software/SciPy-Stack/2019a-gcccoremkl-8.3.0-2019.3.199-Python-2.7.16
-        version: [1.14.2]
-        buildable: False
     py-pandas:
         paths:
             py-pandas@0.22.0: /usr/local/software/jureca/Stages/2019a/software/SciPy-Stack/2019a-gcccoremkl-8.3.0-2019.3.199-Python-2.7.16

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -17,7 +17,7 @@ class Bzip2(Package):
     # https://lwn.net/Articles/762264/
     # This package will need to be updated when a new home is found.
     homepage = "https://sourceware.org/bzip2/"
-    url      = "https://fossies.org/linux/misc/bzip2-1.0.6.tar.gz"
+    url      = "https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"
 
     version('1.0.6', '00b516f4704d4a7cb50a1d97e6e8e15b')
 

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -51,9 +51,11 @@ class Coreneuron(CMakePackage):
     variant('shared', default=True, description="Build shared library")
     variant('tests', default=False, description="Enable building tests")
 
+    depends_on('bison', type='build')
     depends_on('boost', when='+tests')
     depends_on('cmake@3:', type='build')
     depends_on('cuda', when='+gpu')
+    depends_on('flex', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('reportinglib', when='+report')
     depends_on('reportinglib+profile', when='+report+profile')


### PR DESCRIPTION
  - serial prefix for neuron~mpi
  - coreneuron flex/bison dependency was missing
  - install numpy explicitly to avoid bluepy building issue with python2