### PR TITLE
Add py-ipyparallel to $PATH

### DIFF
--- a/var/spack/repos/builtin/packages/py-bluepyopt/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepyopt/package.py
@@ -49,3 +49,4 @@ class PyBluepyopt(PythonPackage):
     def setup_environment(self, spack_env, run_env):
         run_env.unset('PMI_RANK')
         run_env.set('NEURON_INIT_MPI', "0")
+        run_env.prepend_path('PATH', self.spec['py-ipyparallel'].prefix.bin)


### PR DESCRIPTION
  - py-ipyparallel is dependency but we don't create module which
    avoids it being added to $PATH
  - in this PR we add py-ipyparallel explicitily to $PATH (instead
    of enabling module)