### PR TITLE
Fixed PYTHONPATH for nest

### DIFF
--- a/var/spack/repos/builtin/packages/nest/package.py
+++ b/var/spack/repos/builtin/packages/nest/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 from spack import *
 
 
@@ -151,3 +152,9 @@ class Nest(CMakePackage):
 
     def setup_environment(self, spack_env, run_env):
         run_env.set("NEST_INSTALL_DIR", self.spec.prefix)
+        if self.spec.satisfies('+python'):
+            eggs = find(self.prefix, 'PyNEST*egg*')
+            if eggs:
+                site_packages = os.path.dirname(find(self.prefix, 'PyNEST*egg*')[0])
+                run_env.prepend_path('PYTHONPATH', site_packages)
+


### PR DESCRIPTION
Simple addition to support custom `PYTHONPATH` for `nest`.