### PR TITLE
Build numpy, hdf5 and h5py in Intel

### DIFF
--- a/deploy/configs/parallel-libraries/modules.yaml
+++ b/deploy/configs/parallel-libraries/modules.yaml
@@ -30,7 +30,7 @@ modules:
       - hdf5+mpi
       - highfive+mpi
       - petsc
-      - py-mpi4py
+      - py-mpi4py%gcc
       - trilinos
       - neuron~debug+mpi
       - omega-h

--- a/deploy/configs/serial-libraries/modules.yaml
+++ b/deploy/configs/serial-libraries/modules.yaml
@@ -33,6 +33,8 @@ modules:
       - highfive~mpi
       - neuron
       - python-dev
+      - py-h5py
+      - py-numpy
       - py-virtualenv
       - 'tensorflow@1.12.0'
     blacklist:

--- a/deploy/configs/serial-libraries/modules.yaml
+++ b/deploy/configs/serial-libraries/modules.yaml
@@ -33,8 +33,8 @@ modules:
       - highfive~mpi
       - neuron
       - python-dev
-      - py-h5py
-      - py-numpy
+      - py-h5py%gcc
+      - py-numpy%gcc
       - py-virtualenv
       - 'tensorflow@1.12.0'
     blacklist:

--- a/deploy/packages/parallel-libraries.yaml
+++ b/deploy/packages/parallel-libraries.yaml
@@ -19,7 +19,6 @@ packages:
       - compiler
       - mpi
     specs:
-      - py-mpi4py@3.0.0
       - hdf5+mpi@1.10.4
       - highfive+mpi@2.0
       - ospray@1.7.3
@@ -88,3 +87,5 @@ packages:
     specs:
       - neuron@7.6.8
       - neuron+debug@7.6.8
+      - py-h5py@2.9.0
+      - py-mpi4py@3.0.0

--- a/deploy/packages/parallel-libraries.yaml
+++ b/deploy/packages/parallel-libraries.yaml
@@ -87,5 +87,5 @@ packages:
     specs:
       - neuron@7.6.8
       - neuron+debug@7.6.8
-      - 'py-h5py@2.9.0 ^py-numpy~blas~lapack'
+      - py-h5py@2.9.0
       - py-mpi4py@3.0.0

--- a/deploy/packages/parallel-libraries.yaml
+++ b/deploy/packages/parallel-libraries.yaml
@@ -87,5 +87,5 @@ packages:
     specs:
       - neuron@7.6.8
       - neuron+debug@7.6.8
-      - py-h5py@2.9.0
+      - 'py-h5py@2.9.0 ^py-numpy~blas~lapack'
       - py-mpi4py@3.0.0

--- a/deploy/packages/python-packages.yaml
+++ b/deploy/packages/python-packages.yaml
@@ -148,6 +148,7 @@ packages:
     requires:
       - architecture
       - compiler
+      - lapack
       - python
     specs:
-      - py-numpy~blas~lapack
+      - py-numpy

--- a/deploy/packages/python-packages.yaml
+++ b/deploy/packages/python-packages.yaml
@@ -141,3 +141,13 @@ packages:
     # - py-scikit-learn@0.19.1 ^py-numpy@1.15.1 ^py-scipy@1.1.0
     # - py-theano@1.0.2 ^py-numpy@1.15.1 ^py-scipy@1.1.0
     # - py-pytorch@0.4.0 ^py-numpy@1.15.1
+    #
+  intel-stable-serial-lapack:
+    target_matrix:
+      - intel-stable
+    requires:
+      - architecture
+      - compiler
+      - python
+    specs:
+      - py-numpy~blas~lapack

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -572,6 +572,9 @@ class Python(AutotoolsPackage):
         pythonpath = ':'.join(python_paths)
         spack_env.set('PYTHONPATH', pythonpath)
 
+        if self.spec.satisfies('%intel'):
+            spack_env.set('LDSHARED', '%s -shared' % spack_cc)
+
         # For run time environment set path for all dependent_spec
         # recursively and prepend it to PYTHONPATH
         python_paths = set()


### PR DESCRIPTION
Simulation stack is intel compiler based so we want to have these foundation modules in Intel too.
Further, we allow the gcc modules for numpy and h5py

As  direct application it would greatly help simplifying neurodamus tests and future neurodamus+mvdtool