### PR TITLE
Keep branch commits and tags in case clean=False

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -671,7 +671,8 @@ class GitFetchStrategy(VCSFetchStrategy):
             with working_dir(self.stage.path):
                 cloned = False
                 # Yet more efficiency, only download a 1-commit deep tree
-                if self.git_version >= ver('1.7.1'):
+                # If clean=False don't optimize, we may need tags
+                if self.git_version >= ver('1.7.1') and self.clean:
                     try:
                         git(*(args + ['--depth', '1', self.url]))
                         cloned = True


### PR DESCRIPTION
Some packages rely on recent tags to build their version number.

This patch changes the behavior of the git fetcher so that it doesnt use `depth=1` when clean=False, allowing users to see the full branch commits and tags when required.

With this patch it becomes possible to use `git describe`