### PR TITLE
Adding spatial index 0.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/spatial-index/package.py
+++ b/var/spack/repos/builtin/packages/spatial-index/package.py
@@ -16,6 +16,7 @@ class SpatialIndex(PythonPackage):
     depends_on("cmake")
     depends_on("boost")
 
+    version('0.2.0', tag='0.2.0', submodules=True)
     version('0.1.0', tag='0.1.0', submodules=True)
 
 

--- a/var/spack/repos/builtin/packages/spatial-index/package.py
+++ b/var/spack/repos/builtin/packages/spatial-index/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
 
-
 class SpatialIndex(PythonPackage):
     """Spatial indexer for geometries and morphologies"""
 
@@ -16,7 +15,9 @@ class SpatialIndex(PythonPackage):
     depends_on("cmake")
     depends_on("boost")
 
-    version('0.2.0', tag='0.2.0', submodules=True)
+    version('0.2.1', tag='0.2.1', submodules=True)
     version('0.1.0', tag='0.1.0', submodules=True)
 
-
+    @run_after('install')
+    def install_headers(self):
+        install_tree('include', self.prefix.include)


### PR DESCRIPTION
Deploying Spatial Index 0.2.1 after Weina's additions.
 - SPIND-82: Query window for Spatial Index
 - SPIND-84: Spatial Index Point API
- Add `has_Soma` flag (default=true) in `add_neuron` to allow the API to add segments only (compat with data from MorphIO)
 - Add `add_soma` function in MorphIndex API
 - Add `__str__` in the Python API