### PR TITLE
zee: use gmsh 4 / omega-h: bump to 9.29.2

### DIFF
--- a/deploy/packages/external-libraries.yaml
+++ b/deploy/packages/external-libraries.yaml
@@ -27,7 +27,7 @@ packages:
       - cudnn@7.3
       - freeimage@3.18.0
       - glew
-      - gmsh+oce~mpi@3.0.6
+      - gmsh~mpi+oce+openmp+shared@4.4.1
       - hdf5~mpi@1.10.4
       - highfive~mpi@2.0
       - intel-mkl@2018.1.163

--- a/deploy/packages/parallel-libraries.yaml
+++ b/deploy/packages/parallel-libraries.yaml
@@ -47,7 +47,7 @@ packages:
       - lapack
     specs:
       - hypre@2.14.0
-      - omega-h+trilinos@9.29.0
+      - omega-h+trilinos@9.29.2
       - superlu-dist@5.4.0
       - trilinos@xsdk-0.4.0-rc1
 

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -19,6 +19,7 @@ class Gmsh(CMakePackage):
     homepage = 'http://gmsh.info'
     url = 'http://gmsh.info/src/gmsh-2.11.0-source.tgz'
 
+    version('4.4.1', sha256='853c6438fc4e4b765206e66a514b09182c56377bb4b73f1d0d26eda7eb8af0dc')
     version('4.2.2', sha256='e9ee9f5c606bbec5f2adbb8c3d6023c4e2577f487fa4e4ecfcfc94a241cc8dcc')
     version('4.0.0',  'fb0c8afa37425c6f4315ab3b3124e9e102fcf270a35198423a4002796f04155f')
     version('3.0.6',  '9700bcc440d7a6b16a49cbfcdcdc31db33efe60e1f5113774316b6fa4186987b')

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -18,7 +18,7 @@ class OmegaH(CMakePackage):
     git      = "https://github.com/SNLComputation/omega_h.git"
 
     version('develop', branch='master')
-    version('9.29.0', sha256='b41964b018909ffe9cea91c23a0509b259bfbcf56874fcdf6bd9f6a179938014')
+    version('9.29.2', sha256='8eea6da0ebde44176a6d19fb858f89f872611cbad08cad65700757e096058465')
     version('9.28.0', sha256='681588974116025c6c1c535972386c23fe354502319fcbbbdc5b9d373429c08e')
     version('9.27.3', sha256='7c0b0c9c00cda97763be1287d3bf8b931bcdd07bf4971fc7258a3892d628cf20')
     version('9.26.6', sha256='5022bf3f9be1a27668fd2ec396d66f6b0124dc4a3adeedb20a580a701d37d893')
@@ -46,7 +46,7 @@ class OmegaH(CMakePackage):
     depends_on('zlib', when='+zlib')
 
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86610
-    conflicts('%gcc@8:')
+    conflicts('%gcc@8:8.2.99', when='@:9.22.1')
 
     def _bob_options(self):
         cmake_var_prefix = 'Omega_h_CXX_'

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -19,6 +19,7 @@ class OmegaH(CMakePackage):
 
     version('develop', branch='master')
     version('9.29.2', sha256='8eea6da0ebde44176a6d19fb858f89f872611cbad08cad65700757e096058465')
+    version('9.29.0', sha256='b41964b018909ffe9cea91c23a0509b259bfbcf56874fcdf6bd9f6a179938014')
     version('9.28.0', sha256='681588974116025c6c1c535972386c23fe354502319fcbbbdc5b9d373429c08e')
     version('9.27.3', sha256='7c0b0c9c00cda97763be1287d3bf8b931bcdd07bf4971fc7258a3892d628cf20')
     version('9.26.6', sha256='5022bf3f9be1a27668fd2ec396d66f6b0124dc4a3adeedb20a580a701d37d893')

--- a/var/spack/repos/builtin/packages/zee/package.py
+++ b/var/spack/repos/builtin/packages/zee/package.py
@@ -36,7 +36,7 @@ class Zee(CMakePackage):
     depends_on('py-pre-commit', type='build', when='+codechecks')
     depends_on('py-pyyaml', type='build', when='+codechecks')
     depends_on('python@3:', type='build', when='+codechecks')
-    depends_on('gmsh@4: +oce')
+    depends_on('gmsh@4: ~mpi+oce+openmp+shared')
     depends_on('mpi')
     depends_on('omega-h+trilinos')
     depends_on('petsc +int64', when='+petsc')

--- a/var/spack/repos/builtin/packages/zee/package.py
+++ b/var/spack/repos/builtin/packages/zee/package.py
@@ -36,7 +36,7 @@ class Zee(CMakePackage):
     depends_on('py-pre-commit', type='build', when='+codechecks')
     depends_on('py-pyyaml', type='build', when='+codechecks')
     depends_on('python@3:', type='build', when='+codechecks')
-    depends_on('gmsh@:3 +oce -mpi %gcc')
+    depends_on('gmsh@4: +oce')
     depends_on('mpi')
     depends_on('omega-h+trilinos')
     depends_on('petsc +int64', when='+petsc')


### PR DESCRIPTION
@smelchio needs to use the distributed mesh C++ API available in gmsh 4.
