### PR TITLE
Simulation Stack - December Release

### DIFF
--- a/deploy/packages/parallel-libraries.yaml
+++ b/deploy/packages/parallel-libraries.yaml
@@ -85,7 +85,8 @@ packages:
       - mpi
       - python
     specs:
+      - neuron
       - neuron@7.6.8
-      - neuron+debug@7.6.8
+      - neuron+debug
       - py-h5py
       - py-mpi4py

--- a/var/spack/repos/builtin/packages/highfive/package.py
+++ b/var/spack/repos/builtin/packages/highfive/package.py
@@ -25,9 +25,9 @@ class Highfive(CMakePackage):
     # This is a header-only lib so dependencies shall be specified in the
     # target project directly and never specified here since they get truncated
     # when installed as external packages (which makes sense to improve reuse)
-    variant('boost', default=True, description='Support Boost')
-    variant('mpi', default=True, description='Support MPI')
-    variant('eigen', default=False, description='Support Eigen')
+    variant('boost',   default=True,  description='Support Boost')
+    variant('mpi',     default=True,  description='Support MPI')
+    variant('eigen',   default=False, description='Support Eigen')
     variant('xtensor', default=False, description='Support xtensor')
 
     # Develop builds tests which require boost
@@ -48,4 +48,5 @@ class Highfive(CMakePackage):
             '-DHIGHFIVE_EXAMPLES:Bool={0}'.format(self.spec.satisfies('@develop')),
             '-DHIGHFIVE_UNIT_TESTS:Bool={0}'.format(self.spec.satisfies('@develop')),
             '-DHIGHFIVE_TEST_SINGLE_INCLUDES:Bool={0}'.format(self.spec.satisfies('@develop')),
+            '-DHDF5_NO_FIND_PACKAGE_CONFIG_FILE=1',  # Dont use targets
         ]

--- a/var/spack/repos/builtin/packages/mvdtool/package.py
+++ b/var/spack/repos/builtin/packages/mvdtool/package.py
@@ -18,6 +18,7 @@ class Mvdtool(CMakePackage):
     git      = "https://github.com/BlueBrain/MVDTool.git"
 
     version('develop', clean=False, submodules=True)
+    version('2.3.1', tag='v2.3.1', clean=False)
     version('2.3.0', tag='v2.3.0', clean=False)
     version('2.2.1', tag='v2.2.1', clean=False)
     version('2.2.0', tag='v2.2.0', clean=False)

--- a/var/spack/repos/builtin/packages/mvdtool/package.py
+++ b/var/spack/repos/builtin/packages/mvdtool/package.py
@@ -18,6 +18,7 @@ class Mvdtool(CMakePackage):
     git      = "https://github.com/BlueBrain/MVDTool.git"
 
     version('develop', clean=False, submodules=True)
+    version('2.3.2', tag='v2.3.2', clean=False)
     version('2.3.1', tag='v2.3.1', clean=False)
     version('2.3.0', tag='v2.3.0', clean=False)
     version('2.2.1', tag='v2.2.1', clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -11,6 +11,8 @@ class NeurodamusHippocampus(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
     git      = "ssh://bbpcode.epfl.ch/sim/models/hippocampus"
 
+    mech_name = "hippocampus"
+
     version('develop', branch='master', submodules=True, clean=False)
     version('0.4', tag='0.4-1', submodules=True, clean=False)
     version('0.3', tag='0.3', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -11,6 +11,8 @@ class NeurodamusMousify(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/mousify"
     git      = "ssh://bbpcode.epfl.ch/sim/models/mousify"
 
+    mech_name = "mousify"
+
     version('develop', branch='master', submodules=True, clean=False)
     version('0.3', git=git, tag='0.3-1', submodules=True, clean=False)
     version('0.2', git=git, tag='0.2', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -11,6 +11,8 @@ class NeurodamusThalamus(NeurodamusModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/models/thalamus"
     git      = "ssh://bbpcode.epfl.ch/sim/models/thalamus"
 
+    mech_name = "thalamus"
+
     version('develop', branch='master', submodules=True, clean=False)
     version('0.3', tag='0.3-1', submodules=True, clean=False)
     version('0.2', tag='0.2', submodules=True, clean=False)

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -27,8 +27,7 @@ class Neuron(Package):
     patch('revert_Import3d_numerical_format.patch', when='@7.8.0:')
 
     version('develop', branch='master')
-    version('7.8.1a',  commit='92a208b', preferred=True)
-    version('7.8.0',   tag='7.8.0')
+    version('7.8.0a',  commit='92a208b')
     version('7.6.8',   tag='7.6.8')
     version('7.6.6',   tag='7.6.6')
     version('2018-10', commit='b3097b7')

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -23,9 +23,13 @@ class Neuron(Package):
     url      = "http://www.neuron.yale.edu/ftp/neuron/versions/v7.5/nrn-7.5.tar.gz"
     git      = "https://github.com/nrnhines/nrn.git"
 
+    # Patch which reverts 81a7a39 for numerical compat
+    patch('revert_Import3d_numerical_format.patch', when='@7.8.0:')
+
     version('develop', branch='master')
+    version('7.8.1a',  commit='92a208b', preferred=True)
     version('7.8.0',   tag='7.8.0')
-    version('7.6.8',   tag='7.6.8', preferred=True)
+    version('7.6.8',   tag='7.6.8')
     version('7.6.6',   tag='7.6.6')
     version('2018-10', commit='b3097b7')
     # versions from url, with checksum

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -27,7 +27,7 @@ class Neuron(Package):
     patch('revert_Import3d_numerical_format.patch', when='@7.8.0:')
 
     version('develop', branch='master')
-    version('7.8.0a',  commit='92a208b')
+    version('7.8.0a',  commit='92a208b', preferred=True)
     version('7.6.8',   tag='7.6.8')
     version('7.6.6',   tag='7.6.6')
     version('2018-10', commit='b3097b7')

--- a/var/spack/repos/builtin/packages/neuron/revert_Import3d_numerical_format.patch
+++ b/var/spack/repos/builtin/packages/neuron/revert_Import3d_numerical_format.patch
@@ -1,0 +1,22 @@
+diff --git a/share/lib/hoc/import3d/import3d_gui.hoc b/share/lib/hoc/import3d/import3d_gui.hoc
+index 79cb5fe0..b1664327 100755
+--- a/share/lib/hoc/import3d/import3d_gui.hoc
++++ b/share/lib/hoc/import3d/import3d_gui.hoc
+@@ -1056,7 +1056,7 @@ proc instantiate() {local i, j, min, haspy, ispycontext  localobj sec, xx, yy, z
+ 		    if (ispycontext) {
+ 		        pyobj.neuron._pt3dstyle_in_obj($o1, tstr, sec.raw.x[0][0], sec.raw.x[1][0], sec.raw.x[2][0])
+ 		    } else {
+-			    sprint(tstr1, "%s { pt3dstyle(1, %.8g, %.8g, %.8g) }", tstr, sec.raw.x[0][0], sec.raw.x[1][0], sec.raw.x[2][0])
++			    sprint(tstr1, "%s { pt3dstyle(1, %g, %g, %g) }", tstr, sec.raw.x[0][0], sec.raw.x[1][0], sec.raw.x[2][0])
+ 			    execute(tstr1, $o1)
+             }
+ 		}
+@@ -1078,7 +1078,7 @@ proc instantiate() {local i, j, min, haspy, ispycontext  localobj sec, xx, yy, z
+ 		    if (ispycontext) {
+ 		        pyobj.neuron._pt3dadd_in_obj($o1, tstr, xx.x[j], yy.x[j], zz.x[j], dd.x[j])
+ 		    } else {
+-			    sprint(tstr1, "%s { pt3dadd(%.8g, %.8g, %.8g, %.8g) }",\
++			    sprint(tstr1, "%s { pt3dadd(%g, %g, %g, %g) }",\
+ 			      tstr,xx.x[j], yy.x[j], zz.x[j], dd.x[j])
+ 			    execute(tstr1, $o1)
+             }

--- a/var/spack/repos/builtin/packages/psp-validation/package.py
+++ b/var/spack/repos/builtin/packages/psp-validation/package.py
@@ -30,4 +30,4 @@ class PspValidation(PythonPackage):
     depends_on('py-bluepy@0.13.3:', type='run')
     depends_on('py-efel@3.0.39:', type='run')
 
-    depends_on('py-mock@3.0.5', type='build')
+    depends_on('py-mock@3.0.5', type='build')  # remove in 2020

--- a/var/spack/repos/builtin/packages/py-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-mock/package.py
@@ -14,6 +14,7 @@ class PyMock(PythonPackage):
     homepage = "https://github.com/testing-cabal/mock"
     url      = "https://pypi.io/packages/source/m/mock/mock-1.3.0.tar.gz"
 
+    version('3.0.5', 'd834a46d9a129be3e76fdcc99751e82c')
     version('2.0.0', '0febfafd14330c9dcaa40de2d82d40ad')
     version('1.3.0', '73ee8a4afb3ff4da1b4afa287f39fdeb')
 

--- a/var/spack/repos/builtin/packages/py-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-mock/package.py
@@ -15,8 +15,7 @@ class PyMock(PythonPackage):
     url      = "https://pypi.io/packages/source/m/mock/mock-1.3.0.tar.gz"
 
     version('3.0.5', 'd834a46d9a129be3e76fdcc99751e82c')
-    # Warning: tensorflow depends on it. Mind bumping mock version
-    version('2.0.0', '0febfafd14330c9dcaa40de2d82d40ad', preferred=True)
+    version('2.0.0', '0febfafd14330c9dcaa40de2d82d40ad')
     version('1.3.0', '73ee8a4afb3ff4da1b4afa287f39fdeb')
 
     depends_on('py-pbr@0.11:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-mock/package.py
@@ -15,7 +15,8 @@ class PyMock(PythonPackage):
     url      = "https://pypi.io/packages/source/m/mock/mock-1.3.0.tar.gz"
 
     version('3.0.5', 'd834a46d9a129be3e76fdcc99751e82c')
-    version('2.0.0', '0febfafd14330c9dcaa40de2d82d40ad')
+    # Warning: tensorflow depends on it. Mind bumping mock version
+    version('2.0.0', '0febfafd14330c9dcaa40de2d82d40ad', preferred=True)
     version('1.3.0', '73ee8a4afb3ff4da1b4afa287f39fdeb')
 
     depends_on('py-pbr@0.11:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-mvdtool/package.py
+++ b/var/spack/repos/builtin/packages/py-mvdtool/package.py
@@ -15,6 +15,8 @@ class PyMvdtool(PythonPackage):
     git      = "https://github.com/BlueBrain/MVDTool.git"
 
     version('develop', branch='master', submodules=True, clean=False)
+    version('2.3.2', tag='v2.3.2', submodules=True, clean=False)
+    version('2.3.1', tag='v2.3.1', submodules=True, clean=False)
     version('2.3.0', tag='v2.3.0', submodules=True, clean=False)
     version('2.2.1', tag='v2.2.1', submodules=True, clean=False)
 

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -10,7 +10,7 @@ class PyNeurodamus(PythonPackage):
     """
 
     homepage = "https://bbpteam.epfl.ch/project/spaces/display/BGLIB/Neurodamus"
-    git      = "ssh://leite@bbpcode.epfl.ch/sim/neurodamus-py"
+    git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
     version('0.7.1',   tag='0.7.1')

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class PyNeurodamus(PythonPackage):
+    """The BBP simulation control suite, Python API
+    """
+
+    homepage = "https://bbpteam.epfl.ch/project/spaces/display/BGLIB/Neurodamus"
+    git      = "ssh://leite@bbpcode.epfl.ch/sim/neurodamus-py"
+
+    version('develop', branch='master')
+    version('0.7.1',   tag='0.7.1')
+
+    # We depend on Neurodamus but let the user decide which one
+    depends_on('python@3.4:',      type=('build', 'run'))
+    depends_on('py-setuptools',    type=('build', 'run'))
+    depends_on('py-h5py',          type='run')
+    depends_on('py-numpy',         type='run')
+    depends_on('py-lazy-property', type='run')
+    depends_on('py-docopt',        type='run')

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -71,7 +71,8 @@ class SimModel(Package):
         include_flag += ' -I%s' % (spec['coreneuron'].prefix.include)
         nrnivmodl_params = ['-i', include_flag,
                             '-l', link_flag,
-                            '-n', self.mech_name]
+                            '-n', self.mech_name,
+                            mods_location]
         which('nrnivmodl-core')(*nrnivmodl_params)
         output_dir = os.path.basename(self.neuron_archdir)
         expected_name = "libcorenrnmech" + ('_' + self.mech_name if self.mech_name else '')

--- a/var/spack/repos/builtin/packages/tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/tensorflow/package.py
@@ -46,7 +46,7 @@ class Tensorflow(Package):
     depends_on('py-protobuf@3.0.0b2',           type=('build', 'run'), when='@:1.2.0')
 
     depends_on('py-wheel',                      type=('build', 'run'))
-    depends_on('py-mock@2.0.0:',                type=('build', 'run'))
+    depends_on('py-mock@2.0.0',                 type=('build', 'run'))
 
     depends_on('py-enum34@1.1.6:',              type=('build', 'run'), when='@1.5.0:^python@:3.3.99')
     depends_on('py-absl-py@0.1.6',              type=('build', 'run'), when='@1.5.0:')


### PR DESCRIPTION
New package versions:
 * Neuron 7.8.0a
 * mvdtool v2.3.2 - for the fix with par builds and cxx stds

Recipe improvements:
 * neuron from 7.8.0 is automatically applied a patch to revert commit 81a7a39 for bin compat
 * Fix to neurodamus coreneuron mechanisms
 * HighFive to work with recent hdf5 which bring package-config
