### PR TITLE
highfive: new variants for eigen and xtensor / bump xtensor and eigen versions

### DIFF
--- a/var/spack/repos/builtin/packages/highfive/package.py
+++ b/var/spack/repos/builtin/packages/highfive/package.py
@@ -47,4 +47,5 @@ class Highfive(CMakePackage):
             '-DHIGHFIVE_PARALLEL_HDF5:Bool={0}'.format('+mpi' in self.spec),
             '-DHIGHFIVE_EXAMPLES:Bool={0}'.format(self.spec.satisfies('@develop')),
             '-DHIGHFIVE_UNIT_TESTS:Bool={0}'.format(self.spec.satisfies('@develop')),
+            '-DHIGHFIVE_TEST_SINGLE_INCLUDES:Bool={0}'.format(self.spec.satisfies('@develop')),
         ]

--- a/var/spack/repos/builtin/packages/highfive/package.py
+++ b/var/spack/repos/builtin/packages/highfive/package.py
@@ -27,6 +27,8 @@ class Highfive(CMakePackage):
     # when installed as external packages (which makes sense to improve reuse)
     variant('boost', default=True, description='Support Boost')
     variant('mpi', default=True, description='Support MPI')
+    variant('eigen', default=False, description='Support Eigen')
+    variant('xtensor', default=False, description='Support xtensor')
 
     # Develop builds tests which require boost
     conflicts('~boost', when='@develop')
@@ -34,11 +36,15 @@ class Highfive(CMakePackage):
     depends_on('boost @1.41:', when='+boost')
     depends_on('hdf5 ~mpi', when='~mpi')
     depends_on('hdf5 +mpi', when='+mpi')
+    depends_on('eigen', when='+eigen')
+    depends_on('xtensor', when='+xtensor')
 
     def cmake_args(self):
         return [
+            '-DUSE_EIGEN:Bool=' + ('TRUE' if '+eigen' in self.spec else 'FALSE'),
+            '-DUSE_XTENSOR:Bool=' + ('TRUE' if '+xtensor' in self.spec else 'FALSE'),
             '-DUSE_BOOST:Bool={0}'.format('+boost' in self.spec),
             '-DHIGHFIVE_PARALLEL_HDF5:Bool={0}'.format('+mpi' in self.spec),
-            '-DHIGHFIVE_EXAMPLES:Bool=false',
-            '-DHIGHFIVE_UNIT_TESTS:Bool={0}'.format(self.spec.satisfies('@develop'))
+            '-DHIGHFIVE_EXAMPLES:Bool={0}'.format(self.spec.satisfies('@develop')),
+            '-DHIGHFIVE_UNIT_TESTS:Bool={0}'.format(self.spec.satisfies('@develop')),
         ]

--- a/var/spack/repos/builtin/packages/xtensor/package.py
+++ b/var/spack/repos/builtin/packages/xtensor/package.py
@@ -16,6 +16,7 @@ class Xtensor(CMakePackage):
     maintainers = ['ax3l']
 
     version('develop', branch='master')
+    version('0.21.0', sha256='62c9acd6a12fbd50f1379e6c60ffdceb317838d1d79a691d441bebaf7174aa12')
     version('0.15.1', 'c24ecc406003bd1ac22291f1f7cac29a')
     version('0.13.1', '80e7e33f05066d17552bf0f8b582dcc5')
 
@@ -23,7 +24,8 @@ class Xtensor(CMakePackage):
             description='Enable SIMD intrinsics')
 
     depends_on('xtl')
-    depends_on('xtl@0.4.0:0.4.99', when='@0.15.1:')
+    depends_on('xtl@0.6.9', when='@0.21.0:')
+    depends_on('xtl@0.4.0:0.4.99', when='@0.15.1:0.20.99')
     depends_on('xtl@0.3.3:0.3.99', when='@0.13.1')
     depends_on('xsimd@4.0.0', when='@0.15.1 +xsimd')
     depends_on('xsimd@3.1.0', when='@0.13.1 +xsimd')

--- a/var/spack/repos/builtin/packages/xtl/package.py
+++ b/var/spack/repos/builtin/packages/xtl/package.py
@@ -16,6 +16,7 @@ class Xtl(CMakePackage):
     maintainers = ['ax3l']
 
     version('develop', branch='master')
+    version('0.6.9', sha256='c348fcf53dd2b355d143ad28e77f1ede7e1d5e6a196d2d5b9c478b1c005dedd0')
     version('0.4.0', '48c76b63ab12e497a53fb147c41ae747')
     version('0.3.4', 'b76548a55f1e171a9c849e5ed543e8b3')
     version('0.3.3', '09b6d9611e460d9280bf1156bcca20f5')


### PR DESCRIPTION
* xtensor: add 0.21.0
* xtl: add 0.6.9
* highfive:
  * add variants to support eigen and/or xtensor
  * build examples when @develop