### PR TITLE
Revert "zee: add depends on fmt (#626)"

### DIFF
--- a/var/spack/repos/builtin/packages/zee/package.py
+++ b/var/spack/repos/builtin/packages/zee/package.py
@@ -43,7 +43,6 @@ class Zee(CMakePackage):
     depends_on('gmsh@4: +metis~mpi+oce+openmp+shared')
     depends_on('mpi')
     depends_on('omega-h')
-    depends_on('fmt')
 
     depends_on('metis+int64')
     depends_on('petsc +int64', when='+petsc')


### PR DESCRIPTION
This reverts commit 5a7b7a195f586c64cd17eb8186063b25cd204041.