### PR TITLE
Bump psp-validation to 0.2.0 and BluePy to 0.14.3

### DIFF
--- a/var/spack/repos/builtin/packages/psp-validation/package.py
+++ b/var/spack/repos/builtin/packages/psp-validation/package.py
@@ -13,6 +13,7 @@ class PspValidation(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/nse/psp-validation"
 
     version('develop', branch='master')
+    version('0.2.0', tag='psp-validation-v0.2.0')
     version('0.1.19', tag='psp-validation-v0.1.19')
     version('0.1.14', tag='psp-validation-v0.1.14')
     version('0.1.12', tag='psp-validation-v0.1.12')
@@ -27,7 +28,7 @@ class PspValidation(PythonPackage):
     depends_on('py-numpy@1.10:', type='run')
     depends_on('py-tqdm@4.0:', type='run')
     depends_on('py-bglibpy@4.0:', type='run')
-    depends_on('py-bluepy@0.14.1:', type='run')
+    depends_on('py-bluepy@0.14.3:', type='run')
     depends_on('py-efel@3.0.39:', type='run')
 
     depends_on('py-mock@3.0.5', type='build')  # remove in 2020

--- a/var/spack/repos/builtin/packages/py-bluepy/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepy/package.py
@@ -12,6 +12,7 @@ class PyBluepy(PythonPackage):
     homepage = "https://bbpcode.epfl.ch/code/#/admin/projects/nse/bluepy"
     git      = "ssh://bbpcode.epfl.ch/nse/bluepy"
 
+    version('0.14.3', tag='bluepy-v0.14.3')
     version('0.14.1', tag='bluepy-v0.14.1')
     version('0.13.5', tag='bluepy-v0.13.5')
     version('0.12.7', tag='bluepy-v0.12.7')

--- a/var/spack/repos/builtin/packages/py-efel/package.py
+++ b/var/spack/repos/builtin/packages/py-efel/package.py
@@ -26,19 +26,20 @@ from spack import *
 
 
 class PyEfel(PythonPackage):
-    """The Electrophys Feature Extract Library (eFEL) allows 
-    neuroscientists to automatically extract features from time series data 
+    """The Electrophys Feature Extract Library (eFEL) allows
+    neuroscientists to automatically extract features from time series data
     recorded from neurons (both in vitro and in silico).
-    Examples are the action potential width and amplitude in 
+    Examples are the action potential width and amplitude in
     voltage traces recorded during whole-cell patch clamp experiments.
-    The user of the library provides a set of traces and selects the 
-    features to be calculated. The library will then extract the requested 
+    The user of the library provides a set of traces and selects the
+    features to be calculated. The library will then extract the requested
     features and return the values to the user."""
     homepage = "https://github.com/BlueBrain/eFEL"
-    url = "https://pypi.io/packages/source/e/efel/efel-3.0.22.tar.gz"
+    url = "https://pypi.io/packages/source/e/efel/efel-3.0.70.tar.gz"
 
+    version('3.0.70')
     version('3.0.22', sha256='97b2c1a0425b12cd419e8539bb1e936ce64c4e93f5d0dd7f81f38554490064a2')
-    
+
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy', type='run')
     depends_on('py-six', type='run')

--- a/var/spack/repos/builtin/packages/py-efel/package.py
+++ b/var/spack/repos/builtin/packages/py-efel/package.py
@@ -37,7 +37,7 @@ class PyEfel(PythonPackage):
     homepage = "https://github.com/BlueBrain/eFEL"
     url = "https://pypi.io/packages/source/e/efel/efel-3.0.70.tar.gz"
 
-    version('3.0.70')
+    version('3.0.70', sha256='3f3368012cdec5ca7d5551cea35b30a53befd0c0c740fc535209f840616c07b1')
     version('3.0.22', sha256='97b2c1a0425b12cd419e8539bb1e936ce64c4e93f5d0dd7f81f38554490064a2')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
In order to make psp-validation compatible with new sonata format.
See https://bbpteam.epfl.ch/project/issues/browse/BLPY-172