### PR TITLE
core: add more transactional locks

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -109,23 +109,24 @@ def find_matching_specs(pkgs, allow_multiple_matches=False, force=False):
     specs_from_cli = []
     has_errors = False
     specs = spack.cmd.parse_specs(pkgs)
-    for spec in specs:
-        matching = spack.store.db.query(spec)
-        # For each spec provided, make sure it refers to only one package.
-        # Fail and ask user to be unambiguous if it doesn't
-        if not allow_multiple_matches and len(matching) > 1:
-            tty.error('%s matches multiple installed packages:' % spec)
-            for match in matching:
-                tty.msg('"%s"' % match.format())
-            has_errors = True
+    with spack.store.db.read_transaction():
+        for spec in specs:
+            matching = spack.store.db.query(spec)
+            # For each spec provided, make sure it refers to only one package.
+            # Fail and ask user to be unambiguous if it doesn't
+            if not allow_multiple_matches and len(matching) > 1:
+                tty.error('%s matches multiple installed packages:' % spec)
+                for match in matching:
+                    tty.msg('"%s"' % match.format())
+                has_errors = True
 
-        # No installed package matches the query
-        if len(matching) == 0 and spec is not any:
-            tty.error('{0} does not match any installed packages.'.format(
-                spec))
-            has_errors = True
+            # No installed package matches the query
+            if len(matching) == 0 and spec is not any:
+                tty.error('{0} does not match any installed packages.'.format(
+                    spec))
+                has_errors = True
 
-        specs_from_cli.extend(matching)
+            specs_from_cli.extend(matching)
     if has_errors:
         tty.die('use one of the matching specs above')
 

--- a/lib/spack/spack/cmd/filter.py
+++ b/lib/spack/spack/cmd/filter.py
@@ -69,21 +69,22 @@ def setup_parser(subparser):
 
 
 def filter(parser, args):
-
     Request = collections.namedtuple('Request', 'abstract,concrete')
-    specs = [Request(s, s.concretized())
-             for s in spack.cmd.parse_specs(args.specs)]
 
-    # Filter specs eagerly
-    if args.installed is True:
-        specs = [s for s in specs if s.concrete.package.installed]
-    elif args.installed is False:
-        specs = [s for s in specs if not s.concrete.package.installed]
+    with spack.store.db.read_transaction():
+        specs = [Request(s, s.concretized())
+                 for s in spack.cmd.parse_specs(args.specs)]
 
-    if args.explicit is True:
-        specs = [s for s in specs if s.concrete._installed_explicitly()]
-    elif args.explicit is False:
-        specs = [s for s in specs if not s.concrete._installed_explicitly()]
+        # Filter specs eagerly
+        if args.installed is True:
+            specs = [s for s in specs if s.concrete.package.installed]
+        elif args.installed is False:
+            specs = [s for s in specs if not s.concrete.package.installed]
 
-    for spec in specs:
-        args.output.write(str(spec.abstract) + '\n')
+        if args.explicit is True:
+            specs = [s for s in specs if s.concrete._installed_explicitly()]
+        elif args.explicit is False:
+            specs = [s for s in specs if not s.concrete._installed_explicitly()]
+
+        for spec in specs:
+            args.output.write(str(spec.abstract) + '\n')

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -230,8 +230,9 @@ def install(parser, args, **kwargs):
     kwargs['tests'] = tests
 
     try:
-        specs = spack.cmd.parse_specs(
-            args.package, concretize=True, tests=tests)
+        with spack.store.db.read_transaction():
+            specs = spack.cmd.parse_specs(
+                args.package, concretize=True, tests=tests)
     except SpackError as e:
         reporter.concretization_report(e.message)
         raise


### PR DESCRIPTION
Lock the database at a higher level for commands that process a lot of specs. The lock involves a database read, which itself parses all the JSON of the database.

Without the higher level lock, components further down the call stack will create their own locks and the database will be read repeatedly without any alteration. Locking higher up the call stack should result in a sizable speed-up for our large databases.

See also spack/spack#14190