### PR TITLE
option for include timemory in zee

### DIFF
--- a/deploy/configs/packages.yaml
+++ b/deploy/configs/packages.yaml
@@ -123,7 +123,7 @@ packages:
             tar@1.26: /usr
         version: [1.26]
     timemory:
-        variants: ~caliper~cuda~cupti~gperftools~papi~python~mpi
+        variants: +mpi+cuda+cupti+caliper~gperftools~python@3.0.0a
     tk:
         paths:
             tk@8.5.13: /usr

--- a/deploy/configs/packages.yaml
+++ b/deploy/configs/packages.yaml
@@ -122,6 +122,8 @@ packages:
         paths:
             tar@1.26: /usr
         version: [1.26]
+    timemory:
+        variants: ~caliper~cuda~cupti~gperftools~papi~python~mpi
     tk:
         paths:
             tk@8.5.13: /usr

--- a/sysconfig/ubuntu-18.04/packages.yaml
+++ b/sysconfig/ubuntu-18.04/packages.yaml
@@ -103,6 +103,8 @@ packages:
         paths:
             tcl@8.6: /usr
         version: [8.6]
+    timemory:
+        variants: ~caliper~cuda~cupti~gperftools~papi~python~mpi
     trilinos:
         variants: ~hypre
     all:

--- a/var/spack/repos/builtin/packages/zee/package.py
+++ b/var/spack/repos/builtin/packages/zee/package.py
@@ -49,7 +49,7 @@ class Zee(CMakePackage):
 
     depends_on('metis+int64')
     depends_on('petsc +int64', when='+petsc')
-    depends_on('timemory ~caliper~cuda~cupti~gperftools~papi~python~mpi', when='+timemory')
+    depends_on('timemory', when='+timemory')
 
     def _bob_options(self):
         cmake_var_prefix = self.name.capitalize() + '_CXX_'

--- a/var/spack/repos/builtin/packages/zee/package.py
+++ b/var/spack/repos/builtin/packages/zee/package.py
@@ -32,6 +32,9 @@ class Zee(CMakePackage):
     variant('codechecks', default=False,
             description='Perform additional code checks like ' +
                         'formatting or static analysis')
+    variant('timemory', default=False,
+            description='Add timemory API for time/memory measurement')
+
     depends_on('boost')
     depends_on('cmake@3:', type='build')
     depends_on('pkg-config', type='build')
@@ -46,6 +49,7 @@ class Zee(CMakePackage):
 
     depends_on('metis+int64')
     depends_on('petsc +int64', when='+petsc')
+    depends_on('timemory ~caliper~cuda~cupti~gperftools~papi~python~mpi', when='+timemory')
 
     def _bob_options(self):
         cmake_var_prefix = self.name.capitalize() + '_CXX_'
@@ -61,6 +65,8 @@ class Zee(CMakePackage):
             yield '-DPYTHON_EXECUTABLE:FILEPATH=' + self.spec['python'].command.path
             yield '-DZee_FORMATTING:BOOL=TRUE'
             yield '-DZee_TEST_FORMATTING:BOOL=TRUE'
+        if '+timemory' in self.spec:
+            yield '-DZee_USE_TIMEMORY:BOOL=ON'
 
     def cmake_args(self):
         return list(self._bob_options())


### PR DESCRIPTION
At the moment, we only need the basic feature of timemory for memory measurement. So here ```
```
+timemory = "timemory ~caliper~cuda~cupti~gperftools~papi~python~mpi"
```