### PR TITLE
synapsetool: bump to 0.5.7

### DIFF
--- a/var/spack/repos/builtin/packages/parquet-converters/package.py
+++ b/var/spack/repos/builtin/packages/parquet-converters/package.py
@@ -48,6 +48,7 @@ class ParquetConverters(CMakePackage):
     depends_on('arrow+parquet@0.12:', when='@0.4:')
     depends_on('snappy~shared')
     depends_on('synapsetool+mpi')
+    depends_on('synapsetool+mpi@:0.5.6', when='@:0.5.2')
     depends_on('mpi')
     depends_on('range-v3', when='@0.4:')
 

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -34,6 +34,7 @@ class Synapsetool(CMakePackage):
     git      = "ssh://bbpcode.epfl.ch/hpc/synapse-tool"
 
     version('develop', submodules=True)
+    version('0.5.7', tag='v0.5.7', submodules=True)
     version('0.5.6', tag='v0.5.6', submodules=True)
     version('0.5.5', tag='v0.5.5', submodules=True)
     version('0.5.4', tag='v0.5.4', submodules=True)


### PR DESCRIPTION
Needed for upcoming ParquetConverters update. @ferdonline, this could be folded into a broader update, although this is just a minor change.