### PR TITLE
Simulation Stack - January Release

### DIFF
--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -83,6 +83,7 @@ modules:
         '^python@3:': '/python3'
         '+mpi': '/parallel'
         '~mpi': '/serial'
+        '+common': '+common'  # neurodamus-core
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'

--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -38,6 +38,7 @@ modules:
       - emsim
       - functionalizer
       - meshball
+      - model-neocortex
       - nest
       - neurodamus-core
       - neurodamus-hippocampus

--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -40,7 +40,8 @@ modules:
       - meshball
       - model-neocortex
       - nest
-      - neurodamus-core
+      - 'neurodamus-core+common@2.7.3:'
+      - 'neurodamus-core~common@2.9.0:'
       - neurodamus-hippocampus
       - neurodamus-neocortex
       - neurodamus-thalamus
@@ -83,7 +84,7 @@ modules:
         '^python@3:': '/python3'
         '+mpi': '/parallel'
         '~mpi': '/serial'
-        '+common': '+common'  # neurodamus-core
+        '+common': 'commonmods'  # neurodamus-core
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'

--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -39,8 +39,7 @@ modules:
       - functionalizer
       - meshball
       - nest
-      - 'neurodamus%intel'
-      - 'neurodamus-core+common'
+      - neurodamus-core
       - neurodamus-hippocampus
       - neurodamus-neocortex
       - neurodamus-thalamus

--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -40,8 +40,7 @@ modules:
       - meshball
       - model-neocortex
       - nest
-      - 'neurodamus-core+common@2.7.3:'
-      - 'neurodamus-core~common@2.9.0:'
+      - neurodamus-core
       - neurodamus-hippocampus
       - neurodamus-neocortex
       - neurodamus-thalamus

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -151,7 +151,8 @@ packages:
       - architecture
       - compiler
     specs:
-      - neurodamus-core+common
+      - neurodamus-core+common@2.7.3
+      - neurodamus-core+common  # latest
       - ultraliser
 
   intel-stable:

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -74,7 +74,7 @@ packages:
     specs:
       - functionalizer@3.12.2
       - parquet-converters@0.5.2
-      - synapsetool
+      - synapsetool@0.5.8
       - touchdetector@4.4.2
       - touchdetector@5.1.0
       - touchdetector@5.3.3
@@ -151,8 +151,7 @@ packages:
       - architecture
       - compiler
     specs:
-      - neurodamus-core+common@2.7.3
-      - neurodamus-core+common  # latest
+      - neurodamus-core+common@2.9.1
       - ultraliser
 
   intel-stable:
@@ -183,7 +182,7 @@ packages:
       - mpi
       - python
     specs:
-      - neurodamus-core~common
+      - neurodamus-core~common@2.9.1
       - neurodamus-neocortex+coreneuron@0.3
       - neurodamus-hippocampus+coreneuron@0.4
       - neurodamus-thalamus+coreneuron@0.3

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -154,6 +154,15 @@ packages:
       - neurodamus-core+common
       - ultraliser
 
+  intel-stable:
+    target_matrix:
+      - intel-stable
+    requires:
+      - architecture
+      - compiler
+    specs:
+      - model-neocortex
+
   intel-stable-parallel:
     target_matrix:
       - intel-stable

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -30,7 +30,7 @@ packages:
       - brainbuilder@0.11.7
       - brion@3.0.0 +python ^boost@1.65.0
       - connectome-tools@0.3.2
-      - spatial-index@0.1.0
+      - spatial-index@0.2.1
       - spykfunc@0.15.2
       - psp-validation@0.2.0
       - psp-validation@0.1.12
@@ -151,7 +151,7 @@ packages:
       - architecture
       - compiler
     specs:
-      - neurodamus-core+common@2.7.3
+      - neurodamus-core+common
       - ultraliser
 
   intel-stable-parallel:
@@ -173,6 +173,7 @@ packages:
       - mpi
       - python
     specs:
+      - neurodamus-core
       - neurodamus-neocortex+coreneuron@0.3
       - neurodamus-hippocampus+coreneuron@0.4
       - neurodamus-thalamus+coreneuron@0.3

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -173,7 +173,7 @@ packages:
       - mpi
       - python
     specs:
-      - neurodamus-core
+      - neurodamus-core~common
       - neurodamus-neocortex+coreneuron@0.3
       - neurodamus-hippocampus+coreneuron@0.4
       - neurodamus-thalamus+coreneuron@0.3

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -74,7 +74,7 @@ packages:
     specs:
       - functionalizer@3.12.2
       - parquet-converters@0.5.2
-      - synapsetool@0.5.6
+      - synapsetool
       - touchdetector@4.4.2
       - touchdetector@5.1.0
       - touchdetector@5.3.3

--- a/deploy/packages/parallel-libraries.yaml
+++ b/deploy/packages/parallel-libraries.yaml
@@ -90,3 +90,4 @@ packages:
       - neuron+debug
       - py-h5py
       - py-mpi4py
+      - py-mvdtool

--- a/deploy/packages/parallel-libraries.yaml
+++ b/deploy/packages/parallel-libraries.yaml
@@ -90,4 +90,3 @@ packages:
       - neuron+debug
       - py-h5py
       - py-mpi4py
-      - py-mvdtool

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -39,6 +39,8 @@ class Fmt(CMakePackage):
         if '+pic' in spec:
             args.extend([
                 '-DCMAKE_C_FLAGS={0}'.format(self.compiler.pic_flag),
-                '-DCMAKE_CXX_FLAGS={0}'.format(self.compiler.pic_flag)
+                '-DCMAKE_CXX_FLAGS={0}'.format(self.compiler.pic_flag),
+                '-DFMT_DOC=OFF',
+                '-DFMT_TEST=OFF'
             ])
         return args

--- a/var/spack/repos/builtin/packages/highfive/package.py
+++ b/var/spack/repos/builtin/packages/highfive/package.py
@@ -15,6 +15,7 @@ class Highfive(CMakePackage):
     git      = "https://github.com/BlueBrain/HighFive.git"
 
     version('develop', branch='master')
+    version('2.1.2', branch='build_find_hdf5')
     version('2.1.1', tag='v2.1.1')
     version('2.0', '51676953bfeeaf5f0368840525d269e3')
     version('1.5', '5e631c91d2ea7f3677e99d6bb6db8167')
@@ -42,12 +43,13 @@ class Highfive(CMakePackage):
 
     def cmake_args(self):
         return [
-            '-DUSE_EIGEN:Bool=' + ('TRUE' if '+eigen' in self.spec else 'FALSE'),
-            '-DUSE_XTENSOR:Bool=' + ('TRUE' if '+xtensor' in self.spec else 'FALSE'),
-            '-DUSE_BOOST:Bool={0}'.format('+boost' in self.spec),
+            '-DHIGHFIVE_USE_BOOST:Bool={0}'.format('+boost' in self.spec),
             '-DHIGHFIVE_PARALLEL_HDF5:Bool={0}'.format('+mpi' in self.spec),
+            '-DHIGHFIVE_USE_EIGEN:Bool=' + ('TRUE' if '+eigen' in self.spec else 'FALSE'),
+            '-DHIGHFIVE_USE_XTENSOR:Bool=' + ('TRUE' if '+xtensor' in self.spec else 'FALSE'),
             '-DHIGHFIVE_EXAMPLES:Bool={0}'.format(self.spec.satisfies('@develop')),
             '-DHIGHFIVE_UNIT_TESTS:Bool={0}'.format(self.spec.satisfies('@develop')),
             '-DHIGHFIVE_TEST_SINGLE_INCLUDES:Bool={0}'.format(self.spec.satisfies('@develop')),
             '-DHDF5_NO_FIND_PACKAGE_CONFIG_FILE=1',  # Dont use targets
+            '-DHIGHFIVE_USE_INSTALL_DEPS:Bool=ON',  # Newer highfive. Otherwise dynamic deps
         ]

--- a/var/spack/repos/builtin/packages/highfive/package.py
+++ b/var/spack/repos/builtin/packages/highfive/package.py
@@ -15,7 +15,6 @@ class Highfive(CMakePackage):
     git      = "https://github.com/BlueBrain/HighFive.git"
 
     version('develop', branch='master')
-    version('2.1.2', branch='build_find_hdf5')
     version('2.1.1', tag='v2.1.1')
     version('2.0', '51676953bfeeaf5f0368840525d269e3')
     version('1.5', '5e631c91d2ea7f3677e99d6bb6db8167')
@@ -43,13 +42,13 @@ class Highfive(CMakePackage):
 
     def cmake_args(self):
         return [
-            '-DHIGHFIVE_USE_BOOST:Bool={0}'.format('+boost' in self.spec),
-            '-DHIGHFIVE_PARALLEL_HDF5:Bool={0}'.format('+mpi' in self.spec),
-            '-DHIGHFIVE_USE_EIGEN:Bool=' + ('TRUE' if '+eigen' in self.spec else 'FALSE'),
-            '-DHIGHFIVE_USE_XTENSOR:Bool=' + ('TRUE' if '+xtensor' in self.spec else 'FALSE'),
-            '-DHIGHFIVE_EXAMPLES:Bool={0}'.format(self.spec.satisfies('@develop')),
-            '-DHIGHFIVE_UNIT_TESTS:Bool={0}'.format(self.spec.satisfies('@develop')),
-            '-DHIGHFIVE_TEST_SINGLE_INCLUDES:Bool={0}'.format(self.spec.satisfies('@develop')),
+            '-DUSE_BOOST:Bool=' + str(self.spec.satisfies('+boost')),
+            '-DUSE_EIGEN:Bool=' + str(self.spec.satisfies('+eigen')),
+            '-DUSE_XTENSOR:Bool=' + str(self.spec.satisfies('+xtensor')),
+            '-DHIGHFIVE_PARALLEL_HDF5:Bool=' + str(self.spec.satisfies('+mpi')),
+            '-DHIGHFIVE_EXAMPLES:Bool=' + str(self.spec.satisfies('@develop')),
+            '-DHIGHFIVE_UNIT_TESTS:Bool=' + str(self.spec.satisfies('@develop')),
+            '-DHIGHFIVE_TEST_SINGLE_INCLUDES:Bool=' + str(self.spec.satisfies('@develop')),
             '-DHDF5_NO_FIND_PACKAGE_CONFIG_FILE=1',  # Dont use targets
-            '-DHIGHFIVE_USE_INSTALL_DEPS:Bool=ON',  # Newer highfive. Otherwise dynamic deps
+            #'-DHIGHFIVE_USE_INSTALL_DEPS:Bool=ON',  # Newer highfive. Otherwise dynamic deps
         ]

--- a/var/spack/repos/builtin/packages/model-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/model-neocortex/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+from spack.pkg.builtin.sim_model import SimModel
+
+
+class ModelNeocortex(SimModel):
+    """
+    The Norcortex neuron mechanisms for (core)Neuron
+    """
+
+    homepage = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
+    git      = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
+
+    version('develop', branch='master', submodules=True, clean=False)
+    version('0.3', tag='0.3-1', submodules=True, clean=False)
+    version('0.2', tag='0.2', submodules=True, clean=False)
+    version('0.1', tag='0.1', submodules=True, clean=False)
+
+    variant('v5', default=True, description='Enable support for previous v5 circuits')
+    variant('plasticity', default=False, description="Use optimized ProbAMPANMDA_EMS and ProbGABAAB_EMS")
+
+    mech_name = "neocortex"
+
+    @run_before('build')
+    def prepare_mods(self):
+        if self.spec.satisfies('+v5'):
+            copy_all('mod/v5', 'mod', make_link)
+        copy_all('mod/v6', 'mod', make_link)
+        # Plasticity
+        if self.spec.satisfies('+plasticity'):
+            copy_all('mod/v6/optimized', 'mod', make_link)

--- a/var/spack/repos/builtin/packages/model-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/model-neocortex/package.py
@@ -9,7 +9,7 @@ from spack.pkg.builtin.sim_model import SimModel
 
 class ModelNeocortex(SimModel):
     """
-    The Norcortex neuron mechanisms for (core)Neuron
+    The Neocortex neuron mechanisms for (core)Neuron
     """
 
     homepage = "ssh://bbpcode.epfl.ch/sim/models/neocortex"

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -37,9 +37,11 @@ class NeurodamusCore(SimModel):
     variant('reportinglib', default=True, description="Enable ReportingLib")
     variant('synapsetool',  default=True, description="Enable SynapseTool reader (for edges)")
     variant('mvdtool',      default=True, description="Enable MVDTool reader (for nodes)")
-
     # NOTE: Several variants / dependencies come from SimModel
-    depends_on("mpi",  when='+mpi', type=('build', 'run'))  # dont link
+
+    # Note: We dont request link to MPI so that mpicc can do what is best
+    # and dont rpath it so we stay dynamic. 'run' mode will load the same mpi module
+    depends_on("mpi",  when='+mpi', type=('build', 'run'))
     depends_on("hdf5+mpi", when='+hdf5+mpi')
     depends_on("hdf5~mpi", when='+hdf5~mpi')
     depends_on('reportinglib',         when='+reportinglib')

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -16,7 +16,8 @@ class NeurodamusCore(SimModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
-    version('optional_mpi', branch='sandbox/leite/optional_mpi', clean=False)
+    version('develop', branch='sandbox/leite/fix_warns', clean=False)
+    version('2.9.0', tag='2.9.0', clean=False)
     version('2.8.0', tag='2.8.0', clean=False)
     version('2.7.3', tag='2.7.3', clean=False)
     version('2.7.2', tag='2.7.2', clean=False)
@@ -37,8 +38,9 @@ class NeurodamusCore(SimModel):
     variant('mvdtool',      default=False, description="Enable MVDTool reader (for nodes)")
 
     # NOTE: Several variants / dependencies come from SimModel
-    depends_on("mpi", when='+mpi', type=('build', 'run'))  # dont link
-    depends_on("hdf5", when='+hdf5')
+    depends_on("mpi",  when='+mpi', type=('build', 'run'))  # dont link
+    depends_on("hdf5+mpi", when='+hdf5+mpi')
+    depends_on("hdf5~mpi", when='+hdf5~mpi')
     depends_on('reportinglib',         when='+reportinglib')
     depends_on('reportinglib+profile', when='+reportinglib+profile')
     depends_on('synapsetool',          when='+synapsetool')
@@ -94,7 +96,7 @@ class NeurodamusCore(SimModel):
             "~mpi": "-DDISABLE_MPI",
             "~hdf5": "-DDISABLE_HDF5",
             "~reportinglib": "-DDISABLE_REPORTINGLIB",
-            "~synapsetool": "-DDISABLE_SYNTOOL"
+            "+synapsetool": "-DENABLE_SYNTOOL"
         }
 
         compile_flags = " ".join(flag for variant, flag in variant_to_compile_flag.items()
@@ -104,8 +106,6 @@ class NeurodamusCore(SimModel):
     # NOTE: install() is inherited
 
     def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('HOC_LIBRARY_PATH', self.prefix.lib.hoc)
-        run_env.prepend_path('MOD_LIBRARY_PATH', self.prefix.share.mod)
-        run_env.prepend_path("PYTHONPATH", self.prefix.lib.python)
-        for lib in find(self.prefix.lib, 'libnrndamus*'):
-            run_env.set('BGLIBPY_MOD_LIBRARY_PATH', lib)
+        self._setup_environment_common(spack_env, run_env)
+        for lib in find(self.prefix.lib, 'libnrnmech*'):
+            run_env.set('NRNMECH_LIB_PATH', lib)

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -1,103 +1,111 @@
 # Copyright (c) 2013-2018, Lawrence Livermore National Security, LLC.
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
-from spack import *
 import os
 import shutil
 import llnl.util.tty as tty
+from spack import *
+from spack.pkg.builtin.sim_model import SimModel
+
+# Definitions
+_CORENRN_MODLIST_FNAME = "coreneuron_modlist.txt"
 
 
-class NeurodamusCore(Package):
+class NeurodamusCore(SimModel):
     """Library of channels developed by Blue Brain Project, EPFL"""
 
     homepage = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
-    version('develop', git=git, branch='master', clean=False)
-    version('2.8.0', git=git, tag='2.8.0', clean=False)
-    version('2.7.3', git=git, tag='2.7.3', clean=False)
-    version('2.7.2', git=git, tag='2.7.2', clean=False)
-    version('2.7.0', git=git, tag='2.7.0', clean=False)
-    version('2.6.0', git=git, tag='2.6.0', clean=False)
-    version('2.5.0', git=git, tag='2.5.0', clean=False)
-    version('2.4.3', git=git, tag='2.4.3', clean=False)
-    version('2.4.1', git=git, tag='2.4.1', clean=False)
-    version('2.3.4', git=git, tag='2.3.4', clean=False)
-    version('2.3.3', git=git, tag='2.3.3', clean=False)
-    version('2.2.1', git=git, tag='2.2.1', clean=False)
+    version('optional_mpi', branch='sandbox/leite/optional_mpi', clean=False)
+    version('2.8.0', tag='2.8.0', clean=False)
+    version('2.7.3', tag='2.7.3', clean=False)
+    version('2.7.2', tag='2.7.2', clean=False)
+    version('2.7.0', tag='2.7.0', clean=False)
+    version('2.6.0', tag='2.6.0', clean=False)
+    version('2.5.0', tag='2.5.0', clean=False)
+    version('2.4.3', tag='2.4.3', clean=False)
+    version('2.4.1', tag='2.4.1', clean=False)
+    version('2.3.4', tag='2.3.4', clean=False)
+    version('2.3.3', tag='2.3.3', clean=False)
+    version('2.2.1', tag='2.2.1', clean=False)
 
-    variant('python', default=False, description="Enable Python Neurodamus")
-    variant('common', default=False, description="Merge in synapse mechanisms hoc & mods")
+    variant('mpi',    default=True,  description="Enable MPI support")
+    variant('common', default=False, description="Bring in common synapse mechanisms")
+    variant('hdf5',   default=True,  description="Enable old Hdf5 reader")
+    variant('reportinglib', default=True,  description="Enable ReportingLib")
+    variant('synapsetool',  default=True,  description="Enable SynapseTool reader (for edges)")
+    variant('mvdtool',      default=False, description="Enable MVDTool reader (for nodes)")
 
-    # Attempt to support building
-    depends_on('neuron~binary+python', when='+common')
-
-    # Neurodamus py is currently an extension to core
-    resource(name='pydamus',
-             git='ssh://bbpcode.epfl.ch/sim/neurodamus-py',
-             when='+python',
-             destination='resources')
+    # NOTE: Several variants / dependencies come from SimModel
+    depends_on("mpi", when='+mpi', type=('build', 'run'))  # dont link
+    depends_on("hdf5", when='+hdf5')
+    depends_on('reportinglib',         when='+reportinglib')
+    depends_on('reportinglib+profile', when='+reportinglib+profile')
+    depends_on('synapsetool',          when='+synapsetool')
+    depends_on('py-mvdtool',           when='+mvdtool', type='run')
+    # If external & static, we must bring their dependencies.
+    depends_on('zlib')  # for hdf5
 
     resource(name='common',
              git='ssh://bbpcode.epfl.ch/sim/models/common',
              when='+common',
              destination='resources')
 
-    depends_on('python@2.7:',      type=('build', 'run'), when='+python')
-    depends_on('py-setuptools',    type=('build', 'run',), when='+python')
-    depends_on('py-h5py',          type=('run',), when='+python')
-    depends_on('py-numpy',         type=('run',), when='+python')
-    depends_on('py-enum34',        type=('run',), when='^python@2.4:2.7.999,3.1:3.3.999')
-    depends_on('py-lazy-property', type=('run'), when='+python')
-    depends_on('py-docopt',        type=('run'), when='+python')
+    depends_on('python@2.7:', type=('build', 'run'))
 
-    def install(self, spec, prefix):
-        shutil.copytree('hoc', prefix.hoc)
-        shutil.copytree('mod', prefix.mod)
-        if spec.satisfies('+python'):
-            copy_tree('resources/neurodamus-py', prefix.python)
+    mech_name = "neurodamus"
 
-        filter_file(r'UNKNOWN_CORE_VERSION', r'%s' % spec.version, prefix.hoc.join('defvar.hoc'))
+    @run_before('build')
+    def prepare(self):
+        filter_file(r'UNKNOWN_CORE_VERSION', r'%s' % self.spec.version,
+                    join_path('hoc', 'defvar.hoc'))
         try:
             commit_hash = self.fetcher[0].get_commit()
-            filter_file(r'UNKNOWN_CORE_HASH', r'\'%s\'' % commit_hash, prefix.hoc.join('defvar.hoc'))
         except Exception as e:
-            tty.warn(str(e))
+            tty.warn("Error extracting commit hash: " + str(e))
+        else:
+            filter_file(r'UNKNOWN_CORE_HASH', r"'%s'" % commit_hash[:8],
+                        join_path('hoc', 'defvar.hoc'))
 
-        # +Common will bring common mods and build a bare nrnmechlib
-        if spec.satisfies('+common'):
-            copy_all('resources/common/hoc', prefix.hoc)
-            copy_all('resources/common/mod', prefix.mod)
+        # '+common' will bring common mods.
+        # Otherwise build purely neurodamus helper mechs
+        if self.spec.satisfies('+common'):
+            copy_all('resources/common/hoc', "hoc")
+            copy_all('resources/common/mod', "mod")
+        else:
+            # These two mods are also part of common
+            os.remove("mod/VecStim.mod")
+            os.remove("mod/netstim_inhpoisson.mod")
 
-            # However it brings some files that require Mpi and we must avoid them
-            for f in ('MemUsage.mod', 'SpikeWriter.mod'):
-                os.remove(prefix.mod.join(f))
+        # If we shall build mods for coreneuron, only bring from core those specified
+        if self.spec.satisfies("+coreneuron"):
+            mkdirp("mod_core")
+            with open(join_path("mod", _CORENRN_MODLIST_FNAME)) as core_mods:
+                for aux_mod in core_mods:
+                    modpath = join_path("mod", aux_mod.strip())
+                    if os.path.isfile(modpath):
+                        shutil.copy(modpath, 'mod_core')
 
-            with working_dir(prefix):
-                which('nrnivmodl')('-incflags', '-DDISABLE_REPORTINGLIB -DDISABLE_HDF5', 'mod')
+    def build(self, spec, prefix):
+        """ Build mod files from with nrnivmodl / nrnivmodl-core.
+            To support shared libs, nrnivmodl is also passed RPATH flags.
+        """
+        variant_to_compile_flag = {
+            "~mpi": "-DDISABLE_MPI",
+            "~hdf5": "-DDISABLE_HDF5",
+            "~reportinglib": "-DDISABLE_REPORTINGLIB",
+            "~synapsetool": "-DDISABLE_SYNTOOL"
+        }
 
-                bindir = os.path.basename(self.neuron_archdir)
-                special = join_path(bindir, 'special')
-                open('.bindir', 'w').write(bindir)
+        compile_flags = " ".join(flag for variant, flag in variant_to_compile_flag.items()
+                                 if spec.satisfies(variant))
+        self._build_mods('mod', '', compile_flags, 'mod_core')
 
-                if not os.path.isfile(special):
-                    raise Exception("Failed to build neurodamus core mods")
-
-                # Cleanup
-                for f in find(bindir, '*.lo'): os.remove(f)
-                for f in find(bindir, '*.mod'): os.remove(f)
-                for f in find(bindir + '/.libs', '*.o'): os.remove(f)
-                os.mkdir(bindir + "/modc")
-                for f in find(bindir, "*.c*"): shutil.move(f, bindir + "/modc/")
+    # NOTE: install() is inherited
 
     def setup_environment(self, spack_env, run_env):
-        run_env.set('HOC_LIBRARY_PATH', self.prefix.hoc)
-        if self.spec.satisfies('+common'):
-            run_env.set('MOD_LIBRARY_PATH', self.prefix.mod)
-            bindir_info = self.prefix.join('.bindir')
-            if os.path.isfile(bindir_info):
-                bindir = open(bindir_info, 'r').readline()
-                mechlib = find_libraries('libnrnmech', join_path(self.prefix, bindir, '.libs'))[0]
-                run_env.set('NRNMECH_LIB_PATH', mechlib)
-                run_env.set('BGLIBPY_MOD_LIBRARY_PATH', mechlib)
-            else:
-                tty.warn("No .bindir info file found. NRNMECH_LIB_PATH env var wont be set")
+        run_env.prepend_path('HOC_LIBRARY_PATH', self.prefix.lib.hoc)
+        run_env.prepend_path('MOD_LIBRARY_PATH', self.prefix.share.mod)
+        run_env.prepend_path("PYTHONPATH", self.prefix.lib.python)
+        for lib in find(self.prefix.lib, 'libnrndamus*'):
+            run_env.set('BGLIBPY_MOD_LIBRARY_PATH', lib)

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -33,9 +33,9 @@ class NeurodamusCore(SimModel):
     variant('mpi',    default=True,  description="Enable MPI support")
     variant('common', default=False, description="Bring in common synapse mechanisms")
     variant('hdf5',   default=True,  description="Enable old Hdf5 reader")
-    variant('reportinglib', default=True,  description="Enable ReportingLib")
-    variant('synapsetool',  default=True,  description="Enable SynapseTool reader (for edges)")
-    variant('mvdtool',      default=False, description="Enable MVDTool reader (for nodes)")
+    variant('reportinglib', default=True, description="Enable ReportingLib")
+    variant('synapsetool',  default=True, description="Enable SynapseTool reader (for edges)")
+    variant('mvdtool',      default=True, description="Enable MVDTool reader (for nodes)")
 
     # NOTE: Several variants / dependencies come from SimModel
     depends_on("mpi",  when='+mpi', type=('build', 'run'))  # dont link

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -16,7 +16,8 @@ class NeurodamusCore(SimModel):
     homepage = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
-    version('develop', branch='sandbox/leite/fix_warns', clean=False)
+    version('develop', branch='master', clean=False)
+    version('2.9.1', tag='2.9.1', clean=False)
     version('2.9.0', tag='2.9.0', clean=False)
     version('2.8.0', tag='2.8.0', clean=False)
     version('2.7.3', tag='2.7.3', clean=False)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -21,11 +21,11 @@ class NeurodamusModel(SimModel):
     variant('mvdtool',     default=True , description="Enable MVDTool reader (for nodes)")
     variant('common_mods', default='',    description="Source of common mods. '': no change,"
                                                       " other string: alternate path")
-
+    # Note: We dont request link to MPI so that mpicc can do what is best
+    # and dont rpath it so we stay dynamic. 'run' mode will load the same mpi module
+    depends_on("mpi", type=('build', 'run'))
     depends_on('neurodamus-core', type='build')
     depends_on('neurodamus-core@develop', type='build', when='@develop')
-
-    depends_on("mpi", type=('build', 'run'))
     depends_on("hdf5+mpi")
     depends_on('reportinglib')
     depends_on('reportinglib+profile', when='+profile')

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -19,13 +19,10 @@ class NeurodamusModel(SimModel):
     # NOTE: Several variants / dependencies come from SimModel
     variant('synapsetool', default=True,  description="Enable SynapseTool reader (for edges)")
     variant('mvdtool',     default=True , description="Enable MVDTool reader (for nodes)")
-    variant('python',      default=False, description="Install neurodamus-python alongside")
     variant('common_mods', default='',    description="Source of common mods. '': no change,"
                                                       " other string: alternate path")
-
-    depends_on('neurodamus-core')
+    depends_on('neurodamus-core', type='build')
     depends_on('neurodamus-core@develop', when='@develop')
-    depends_on('neurodamus-core+python', when='+python')
 
     depends_on("mpi")
     depends_on("hdf5+mpi")
@@ -45,7 +42,7 @@ class NeurodamusModel(SimModel):
         """Build and install the bare model.
         """
         SimModel.build(self, spec, prefix)
-        # Dont install intermediate src. Worse, would move mod
+        # Dont install intermediate src.
         SimModel.install(self, spec, prefix, install_src=False)
 
     def merge_hoc_mod(self, spec, prefix):
@@ -65,35 +62,26 @@ class NeurodamusModel(SimModel):
         # If we shall build mods for coreneuron, only bring from core those specified
         if spec.satisfies("+coreneuron"):
             shutil.copytree('mod', 'mod_core', True)
-            with open(core_prefix.mod.join(_CORENRN_MODLIST_FNAME)) as core_mods:
+            with open(core_prefix.lib.mod.join(_CORENRN_MODLIST_FNAME)) as core_mods:
                 for aux_mod in core_mods:
-                    shutil.copy(core_prefix.mod.join(aux_mod.strip()), 'mod_core')
+                    mod_fil = core_prefix.lib.mod.join(aux_mod.strip())
+                    if os.path.isfile(mod_fil):
+                        shutil.copy(mod_fil, 'mod_core')
 
-        copy_all(core_prefix.hoc, 'hoc', make_link)
-        copy_all(core_prefix.mod, 'mod', make_link)
+        copy_all(core_prefix.lib.hoc, 'hoc', make_link)
+        copy_all(core_prefix.lib.mod, 'mod', make_link)
 
     def build(self, spec, prefix):
         """ Build mod files from with nrnivmodl / nrnivmodl-core.
             To support shared libs, nrnivmodl is also passed RPATH flags.
         """
-        dep_libs = ['reportinglib', 'hdf5',  'zlib']
-        link_flag = '-Wl,-rpath,' + prefix.lib
-        include_flag = ' -I%s -I%s' % (spec['reportinglib'].prefix.include,
-                                       spec['hdf5'].prefix.include)
-        if '+synapsetool' in spec:
-            include_flag += ' -DENABLE_SYNTOOL -I ' + spec['synapsetool'].prefix.include
-            dep_libs.append('synapsetool')
+        # NOTE: sim-model now attempts to build all link and include flags from the dependencies
+        # link_flag += ' ' + spec['synapsetool'].package.dependency_libs(spec).joined()
 
-        for dep in dep_libs:
-            link_flag += ' ' + self._get_link_flags(dep)
+        self.mech_name += _LIB_SUFFIX  # Final lib name
+        base_include_flag = "-DENABLE_SYNTOOL" if spec.satisfies('+synapsetool') else ""
 
-        # If synapsetool is static we have to bring dependencies
-        if spec.satisfies('+synapsetool') and spec['synapsetool'].satisfies('~shared'):
-            link_flag += ' ' + spec['synapsetool'].package.dependency_libs(spec).joined()
-
-        # Override mech_name in order to generate a library with a different name
-        self.mech_name += _LIB_SUFFIX
-        self._build_mods('mod', link_flag, include_flag, 'mod_core')
+        include_flag, link_flag = self._build_mods('mod', "", base_include_flag, 'mod_core')
 
         # Create rebuild script
         with open(_BUILD_NEURODAMUS_FNAME, "w") as f:
@@ -112,18 +100,14 @@ class NeurodamusModel(SimModel):
         """
         # base dest dirs already created by model install
         # We install binaries normally, except lib has a suffix
-        self._install_binaries(lib_suffix=_LIB_SUFFIX)
-
-        if spec.satisfies('+coreneuron'):
-            install = which('nrnivmech_install.sh', path=".")
-            install(prefix)
+        self._install_binaries()
 
         # Install mods/hocs, and a builder script
         self._install_src(prefix)
         shutil.move(_BUILD_NEURODAMUS_FNAME, prefix.bin)
 
         # Create mods links in share
-        force_symlink(spec['neurodamus-core'].prefix.mod, prefix.share.mod_neurodamus)
+        force_symlink(spec['neurodamus-core'].prefix.lib.mod, prefix.share.mod_neurodamus)
         force_symlink(prefix.lib.mod, prefix.share.mod_full)
 
         if spec.satisfies('+python'):
@@ -136,26 +120,18 @@ class NeurodamusModel(SimModel):
             for name in ('neurodamus', 'init.py', '_debug.py'):
                 force_symlink(py_src.join(name), py_dst.join(name))
 
-        filter_file(r'UNKNOWN_NEURODAMUS_MODEL', r'%s' % spec.name, prefix.lib.hoc.join('defvar.hoc'))
-        filter_file(r'UNKNOWN_NEURODAMUS_VERSION', r'%s' % spec.version, prefix.lib.hoc.join('defvar.hoc'))
+        filter_file(r'UNKNOWN_NEURODAMUS_MODEL', r'%s' % spec.name,
+                    prefix.lib.hoc.join('defvar.hoc'))
+        filter_file(r'UNKNOWN_NEURODAMUS_VERSION', r'%s' % spec.version,
+                    prefix.lib.hoc.join('defvar.hoc'))
 
         try:
             commit_hash = self.fetcher[0].get_commit()
-            filter_file(r'UNKNOWN_NEURODAMUS_HASH', r'\'%s\'' % commit_hash, prefix.lib.hoc.join('defvar.hoc'))
         except Exception as e:
             tty.warn(e)
-
-    def setup_environment(self, spack_env, run_env):
-        SimModel.setup_environment(self, spack_env, run_env)
-        run_env.set('HOC_LIBRARY_PATH', self.prefix.lib.hoc)
-
-        if self.spec.satisfies("+python"):
-            pylib = self.prefix.lib.python
-            for m in spack_env.env_modifications:
-                if m.name == 'PYTHONPATH':
-                    run_env.prepend_path('PYTHONPATH', m.value)
-            run_env.prepend_path('PYTHONPATH', pylib)
-            run_env.set('NEURODAMUS_PYTHON', pylib)
+        else:
+            filter_file(r'UNKNOWN_NEURODAMUS_HASH', r"'%s'" % commit_hash[:8],
+                        prefix.lib.hoc.join('defvar.hoc'))
 
 
 _BUILD_NEURODAMUS_TPL = """#!/bin/sh

--- a/var/spack/repos/builtin/packages/neuron/apply_79a4d2af_load_balance_fix.patch
+++ b/var/spack/repos/builtin/packages/neuron/apply_79a4d2af_load_balance_fix.patch
@@ -1,0 +1,31 @@
+From 79a4d2afdbffc41603b37b04b2ff29e5eaa89558 Mon Sep 17 00:00:00 2001
+From: nrnhines <michael.hines@yale.edu>
+Date: Thu, 2 Jan 2020 19:40:06 -0500
+Subject: [PATCH] Revert "finitialize could fail if pc.set_maxstep had not been
+ called" (#391)
+
+This reverts commit d9605cb44c7a6094301927d39a8d8e106a35a011.
+That commit broke ExperimentalMechComplex.
+---
+ src/nrniv/netpar.cpp | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/nrniv/netpar.cpp b/src/nrniv/netpar.cpp
+index 8dde510..8b37b9e 100644
+--- a/src/nrniv/netpar.cpp
++++ b/src/nrniv/netpar.cpp
+@@ -461,10 +461,8 @@ void nrn_spike_exchange_init() {
+     return;
+ #endif
+ //printf("nrn_spike_exchange_init\n");
+-#if NRNMPI
+-	if (nrnmpi_use) { active_ = 1; } // in case set_mindelay has not yet been called
+-#endif
+ 	if (!nrn_need_npe()) { return; }
++//	if (!active_ && !nrn_use_selfqueue_) { return; }
+ 	alloc_space();
+ //printf("nrnmpi_use=%d active=%d\n", nrnmpi_use, active_);
+ 	calc_actual_mindelay();	
+-- 
+1.8.3.1
+

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -25,6 +25,8 @@ class Neuron(Package):
 
     # Patch which reverts 81a7a39 for numerical compat
     patch('revert_Import3d_numerical_format.patch', when='@7.8.0:')
+    # Patch which reverts d9605cb for not hanging on ExperimentalMechComplex
+    patch('revert_d9605cb.patch', when='@7.8.0a')
 
     # Patch which applies load balancing fix
     patch('apply_79a4d2af_load_balance_fix.patch', when='@7.8.0:')

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -26,8 +26,11 @@ class Neuron(Package):
     # Patch which reverts 81a7a39 for numerical compat
     patch('revert_Import3d_numerical_format.patch', when='@7.8.0:')
 
+    # Patch which applies load balancing fix
+    patch('apply_79a4d2af_load_balance_fix.patch', when='@7.8.0:')
+
     version('develop', branch='master')
-    version('7.8.0a',  commit='92a208b', preferred=True)
+    version('7.8.0b',  commit='92a208b', preferred=True)
     version('7.6.8',   tag='7.6.8')
     version('7.6.6',   tag='7.6.6')
     version('2018-10', commit='b3097b7')

--- a/var/spack/repos/builtin/packages/neuron/revert_d9605cb.patch
+++ b/var/spack/repos/builtin/packages/neuron/revert_d9605cb.patch
@@ -1,0 +1,16 @@
+diff --git a/src/nrniv/netpar.cpp b/src/nrniv/netpar.cpp
+index ead25cb3..c294ef16 100644
+--- a/src/nrniv/netpar.cpp
++++ b/src/nrniv/netpar.cpp
+@@ -461,10 +461,8 @@ void nrn_spike_exchange_init() {
+     return;
+ #endif
+ //printf("nrn_spike_exchange_init\n");
+-#if NRNMPI
+-	if (nrnmpi_use) { active_ = 1; } // in case set_mindelay has not yet been called
+-#endif
+ 	if (!nrn_need_npe()) { return; }
++//	if (!active_ && !nrn_use_selfqueue_) { return; }
+ 	alloc_space();
+ //printf("nrnmpi_use=%d active=%d\n", nrnmpi_use, active_);
+ 	calc_actual_mindelay();	

--- a/var/spack/repos/builtin/packages/parquet-converters/package.py
+++ b/var/spack/repos/builtin/packages/parquet-converters/package.py
@@ -48,6 +48,7 @@ class ParquetConverters(CMakePackage):
     depends_on('arrow+parquet@0.12:', when='@0.4:')
     depends_on('snappy~shared')
     depends_on('synapsetool+mpi')
+    depends_on('synapsetool+mpi@:0.5.6', when='@:0.5.2')
     depends_on('mpi')
     depends_on('range-v3', when='@0.4:')
 

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -15,7 +15,7 @@ class PyNeurodamus(PythonPackage):
     version('develop', branch='master')
     version('0.7.1',   tag='0.7.1')
 
-    # We depend on Neurodamus but let the user decide which one
+    depends_on('neurodamus-core',  type=('build', 'run'))
     depends_on('python@3.4:',      type=('build', 'run'))
     depends_on('py-setuptools',    type=('build', 'run'))
     depends_on('py-h5py',          type='run')

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -16,7 +16,7 @@ class PyNeurodamus(PythonPackage):
     version('0.8.0',   branch='sandbox/leite/split_mechs')
     version('0.7.2',   tag='0.7.2')
 
-    depends_on('neurodamus-core',  type=('build', 'run'))
+    depends_on('neuron',           type=('build', 'run'))
     depends_on('python@3.4:',      type=('build', 'run'))
     depends_on('py-setuptools',    type=('build', 'run'))
     depends_on('py-h5py',          type='run')

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,7 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
-    version('0.8.0',   branch='sandbox/leite/split_mechs')
+    version('0.8.0',   tag='0.8.0')
     version('0.7.2',   tag='0.7.2')
 
     depends_on('neuron',           type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -16,7 +16,7 @@ class PyNeurodamus(PythonPackage):
     version('0.8.0',   tag='0.8.0')
     version('0.7.2',   tag='0.7.2')
 
-    depends_on('neuron',           type=('build', 'run'))
+    # We depend on Neurodamus but let the user decide which one
     depends_on('python@3.4:',      type=('build', 'run'))
     depends_on('py-setuptools',    type=('build', 'run'))
     depends_on('py-h5py',          type='run')

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,7 +13,8 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
-    version('0.7.1',   tag='0.7.1')
+    version('0.8.0',   branch='sandbox/leite/split_mechs')
+    version('0.7.2',   tag='0.7.2')
 
     depends_on('neurodamus-core',  type=('build', 'run'))
     depends_on('python@3.4:',      type=('build', 'run'))
@@ -23,3 +24,13 @@ class PyNeurodamus(PythonPackage):
     depends_on('py-lazy-property', type='run')
     depends_on('py-docopt',        type='run')
     depends_on('py-six',           type='run')
+
+    @run_after('install')
+    def install_scripts(self):
+        mkdirp(self.prefix.share)
+        for script in ('init.py', '_debug.py'):
+            copy(script, self.prefix.share)
+
+    def setup_environment(self, spack_env, run_env):
+        PythonPackage.setup_environment(self, spack_env, run_env)
+        run_env.set('NEURODAMUS_PYTHON', self.prefix.share)

--- a/var/spack/repos/builtin/packages/reportinglib/package.py
+++ b/var/spack/repos/builtin/packages/reportinglib/package.py
@@ -35,7 +35,7 @@ class Reportinglib(CMakePackage):
     git      = "ssh://bbpcode.epfl.ch/sim/reportinglib/bbp"
 
     version('develop', branch='master')
-    version('2.5.3a', branch='sandbox/leite/mpi_ub_fix')
+    version('2.5.3', tag='2.5.3')
     version('2.5.2', tag='2.5.2')
     version('2.5.1', tag='2.5.1')
     version('2.5.0', tag='2.5.0')

--- a/var/spack/repos/builtin/packages/reportinglib/package.py
+++ b/var/spack/repos/builtin/packages/reportinglib/package.py
@@ -32,11 +32,13 @@ class Reportinglib(CMakePackage):
 
     homepage = "https://bbpcode.epfl.ch/code/a/sim/reportinglib/bbp"
     url      = "ssh://bbpcode.epfl.ch/sim/reportinglib/bbp"
+    git      = "ssh://bbpcode.epfl.ch/sim/reportinglib/bbp"
 
-    version('develop', git=url, branch='master')
-    version('2.5.2', git=url, tag='2.5.2', preferred=True)
-    version('2.5.1', git=url, tag='2.5.1')
-    version('2.5.0', git=url, tag='2.5.0')
+    version('develop', branch='master')
+    version('2.5.3a', branch='sandbox/leite/mpi_ub_fix')
+    version('2.5.2', tag='2.5.2')
+    version('2.5.1', tag='2.5.1')
+    version('2.5.0', tag='2.5.0')
 
     variant('profile', default=False, description="Enable profiling using Tau")
     variant('shared', default=True, description="Build shared library")

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -31,11 +31,12 @@ class SimModel(Package):
     variant('coreneuron',  default=False, description="Enable CoreNEURON Support")
     variant('profile',     default=False, description="Enable profiling using Tau")
 
-    # We dont link automatically to neuron/corenrn, nrnivmodl does it for us (=> no 'link' mode)
+    # neuron/corenrn get linked automatically when using nrnivmodl[-core]
+    # Dont duplicate the link dependency (only 'build' and 'run')
     depends_on('neuron+mpi', type=('build', 'run'))
     depends_on('coreneuron', when='+coreneuron', type=('build', 'run'))
-    depends_on('coreneuron+profile', when='+coreneuron+profile')
-    depends_on('neuron+profile', when='+profile')
+    depends_on('neuron+profile', when='+profile', type=('build', 'run'))
+    depends_on('coreneuron+profile', when='+coreneuron+profile', type=('build', 'run'))
     depends_on('tau', when='+profile')
 
     conflicts('^neuron~python', when='+coreneuron')
@@ -163,7 +164,7 @@ class SimModel(Package):
 
     def _setup_environment_common(self, spack_env, run_env):
         spack_env.unset('LC_ALL')
-        # Remove LD_LIB_PATHs
+        # Dont export /lib as an ldpath. We dont want to find these libs automatically
         to_rm = ('LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH', 'DYLD_FALLBACK_LIBRARY_PATH')
         run_env.env_modifications = [envmod for envmod in run_env.env_modifications
                                      if envmod.name not in to_rm]

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -74,6 +74,7 @@ class SimModel(Package):
             )
             # Relevant flags to build neuron's nrnmech lib
             include_flag += ' -DENABLE_CORENEURON'  # only now, otherwise mods assume neuron
+            include_flag += ' -I%s' % self.spec['coreneuron'].prefix.include
             link_flag += ' ' + libnrncoremech.ld_flags
 
         # Neuron mechlib and special

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -64,7 +64,7 @@ class SimModel(Package):
                 raise Exception('Dependency lib "' + dep + '" coming from system prefix')
         link_flag += ' ' + ' '.join(self.spec[dep].libs.ld_flags for dep in dep_names)
         link_flag += ' ' + ' '.join(self.spec[dep].libs.rpath_flags for dep in dep_names)
-        include_flag += ' ' + ' '.join(self.spec[dep].headers.include_flags for dep in dep_names)
+        include_flag += ''.join(' -I' + str(self.spec[dep].prefix.include) for dep in dep_names)
         include_flag += ' -DENABLE_TAU_PROFILER' if '+profile' in self.spec else ''
         output_dir = os.path.basename(self.neuron_archdir)
 

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -79,7 +79,7 @@ class SimModel(Package):
 
         # Neuron mechlib and special
         with profiling_wrapper_on():
-            link_flag += ' -Wl,-rpath,' + self.prefix.lib
+            link_flag += ' -L{0} -Wl,-rpath,{0}'.format(str(self.prefix.lib))
             which('nrnivmodl')('-incflags', include_flag, '-loadflags', link_flag, mods_location)
 
         assert os.path.isfile(os.path.join(output_dir, 'special'))
@@ -107,7 +107,7 @@ class SimModel(Package):
         """Install phase
 
         bin/ <- special and special-core
-        libs/ <- hoc, mod and lib*mech*.so
+        lib/ <- hoc, mod and lib*mech*.so
         share/ <- neuron & coreneuron mod.c's (modc and modc_core)
         """
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -1,8 +1,12 @@
 # Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 from spack import *
+from llnl.util import tty
+
 from contextlib import contextmanager
-import os, shutil
+import os
+import shutil
+
 
 class SimModel(Package):
     """The abstract base package for simulation models.
@@ -27,8 +31,9 @@ class SimModel(Package):
     variant('coreneuron',  default=False, description="Enable CoreNEURON Support")
     variant('profile',     default=False, description="Enable profiling using Tau")
 
-    depends_on('neuron+mpi', type=('build', 'link', 'run'))
-    depends_on('coreneuron', when='+coreneuron', type=('build', 'link', 'run'))
+    # We dont link automatically to neuron/corenrn, nrnivmodl does it for us (=> no 'link' mode)
+    depends_on('neuron+mpi', type=('build', 'run'))
+    depends_on('coreneuron', when='+coreneuron', type=('build', 'run'))
     depends_on('coreneuron+profile', when='+coreneuron+profile')
     depends_on('neuron+profile', when='+profile')
     depends_on('tau', when='+profile')
@@ -37,97 +42,105 @@ class SimModel(Package):
 
     phases = ('build', 'install')
 
-    mech_name = ''
+    mech_name = None
     """The name of the mechanism, defined in subclasses"""
 
     def build(self, spec, prefix):
-        """Build phase
-        """
-        link_flag = '-Wl,-rpath,' + prefix.lib
-        self._build_mods('mod', link_flag)
+        """Build phase"""
+        self._build_mods('mod')
+
+    @property
+    def lib_suffix(self):
+        return ('_' + self.mech_name) if self.mech_name else ''
 
     def _build_mods(self, mods_location, link_flag='', include_flag='', corenrn_mods=None):
         """Build shared lib & special from mods in a given path
         """
-        profile_flag = ' -DENABLE_TAU_PROFILER' if '+profile' in self.spec else ''
-        include_flag += profile_flag
+        # pass include and link flags for all dependency libraries
+        # Compiler wrappers are not used to have a more reproducible building
+        dep_names = set(self.spec.dependencies_dict('link').keys())
+        for dep in dep_names:
+            if self.spec[dep].prefix in ('/usr', '/usr/local'):
+                raise Exception('Dependency lib "' + dep + '" coming from system prefix')
+        link_flag += ' ' + ' '.join(self.spec[dep].libs.ld_flags for dep in dep_names)
+        link_flag += ' ' + ' '.join(self.spec[dep].libs.rpath_flags for dep in dep_names)
+        include_flag += ' ' + ' '.join(self.spec[dep].headers.include_flags for dep in dep_names)
+        include_flag += ' -DENABLE_TAU_PROFILER' if '+profile' in self.spec else ''
+        output_dir = os.path.basename(self.neuron_archdir)
 
         if self.spec.satisfies('+coreneuron'):
-            mechlib = self.__build_mods_coreneuron(
-                corenrn_mods or mods_location, link_flag, include_flag)
-            # Link neuron special with this mechs lib
-            link_flag += ' %s %s' % (mechlib.ld_flags, self._get_link_flags('coreneuron'))
+            libnrncoremech = self.__build_mods_coreneuron(
+                corenrn_mods or mods_location, link_flag, include_flag
+            )
+            # Relevant flags to build neuron's nrnmech lib
             include_flag += ' -DENABLE_CORENEURON'  # only now, otherwise mods assume neuron
+            link_flag += ' ' + libnrncoremech.ld_flags
 
+        # Neuron mechlib and special
         with profiling_wrapper_on():
-            which('nrnivmodl')('-incflags', include_flag, '-loadflags', link_flag, 'mod')
-        special = os.path.join(os.path.basename(self.neuron_archdir), 'special')
-        assert os.path.isfile(special)
-        return special
+            link_flag += ' -Wl,-rpath,' + self.prefix.lib
+            which('nrnivmodl')('-incflags', include_flag, '-loadflags', link_flag, mods_location)
+
+        assert os.path.isfile(os.path.join(output_dir, 'special'))
+        return include_flag, link_flag
 
     def __build_mods_coreneuron(self, mods_location, link_flag, include_flag):
         spec = self.spec
-        assert os.path.isdir(mods_location), mods_location
-        include_flag += ' -I%s' % (spec['coreneuron'].prefix.include)
-        nrnivmodl_params = ['-i', include_flag,
+        assert os.path.isdir(mods_location), 'Invalid mods dir: ' + mods_location
+        nrnivmodl_params = ['-n', self.mech_name,
+                            '-i', include_flag,
                             '-l', link_flag,
-                            '-n', self.mech_name,
+                            '-V',
                             mods_location]
-        which('nrnivmodl-core')(*nrnivmodl_params)
-        output_dir = os.path.basename(self.neuron_archdir)
-        expected_name = "libcorenrnmech" + ('_' + self.mech_name if self.mech_name else '')
-        mechlib = find_libraries(expected_name + '*', output_dir)
-        assert len(mechlib.names) == 1, "Error creating corenrnmech lib."
+        with working_dir('build_' + self.mech_name, create=True):
+            which('nrnivmodl-core')(*nrnivmodl_params)
+            output_dir = os.path.basename(self.neuron_archdir)
+            mechlib = find_libraries('libcorenrnmech' + self.lib_suffix + '*', output_dir)
+            assert len(mechlib.names) == 1, 'Error creating corenrnmech. Found: ' + str(mechlib.names)
         return mechlib
-
-    def _get_link_flags(self, lib_name):
-        """Helper method to get linking flags similar to spack build, for solid deployments.
-
-        1. static libs passed via full path
-        2. shared libs passed with -L -l and RPATH flags
-        Attention: This func doesnt handle recursive deps of static libs.
-        """
-        spec = self.spec[lib_name]
-        if spec.satisfies('+shared'):  # Prefer shared if both exist
-            return "%s %s" % (spec.libs.rpath_flags, spec.libs.ld_flags)
-        return spec.libs.joined()
 
     def install(self, spec, prefix, install_src=True):
         """Install phase
 
         bin/ <- special and special-core
-        lib/ <- hoc, mod and lib*mech*.so
+        libs/ <- hoc, mod and lib*mech*.so
         share/ <- neuron & coreneuron mod.c's (modc and modc_core)
         """
         mkdirp(prefix.bin)
-        mkdirp(prefix.lib.mod, prefix.lib.hoc)
+        mkdirp(prefix.lib)
         mkdirp(prefix.share.modc)
 
         self._install_binaries()
 
-        if spec.satisfies('+coreneuron'):
-            install = which('nrnivmech_install.sh', path=".")
-            install(prefix)
-
         if install_src:
             self._install_src(prefix)
 
-    def _install_binaries(self, lib_suffix=''):
+    def _install_binaries(self, mech_name=None):
         # Install special
+        mech_name = mech_name or self.mech_name
         arch = os.path.basename(self.neuron_archdir)
         prefix = self.prefix
+
+        if self.spec.satisfies('+coreneuron'):
+            with working_dir('build_' + mech_name):
+                if self.spec.satisfies('^coreneuron@0.14:0.16.99'):
+                    which('nrnivmech_install.sh', path=".")(prefix)
+                elif self.spec.satisfies('^coreneuron@0.17:'):
+                    which('nrnivmodl-core')("-d", prefix)  # Set dest to install
+
+        # Install special
         shutil.copy(join_path(arch, 'special'), prefix.bin)
 
         if self.spec.satisfies('^neuron~binary'):
             # Install libnrnmech - might have several links.
-            for f in find(arch + "/.libs", 'libnrnmech*.so*', recursive=False):
+            for f in find(arch + '/.libs', 'libnrnmech*.so*', recursive=False):
                 if not os.path.islink(f):
                     bname = os.path.basename(f)
-                    lib_dst = prefix.lib.join(bname[:bname.find(".")] + lib_suffix + ".so")
-                    shutil.move(f, lib_dst)
+                    lib_dst = prefix.lib.join(bname[:bname.find('.')] + self.lib_suffix + '.so')
+                    shutil.move(f, lib_dst)  # Move so its not copied twice
                     break
             else:
-                raise Exception("No libnrnmech found")
+                raise Exception('No libnrnmech found')
 
             # Patch special for the new libname
             which('sed')('-i.bak',
@@ -139,23 +152,32 @@ class SimModel(Package):
         """Copy original and translated c mods
         """
         arch = os.path.basename(self.neuron_archdir)
+        mkdirp(prefix.lib.mod, prefix.lib.hoc, prefix.lib.python)
         copy_all('mod', prefix.lib.mod)
         copy_all('hoc', prefix.lib.hoc)
+        if os.path.isdir('python'):
+            copy_all('python', prefix.lib.python)  # Recent neurodamus
+        else:
+            shutil.copy('hoc/mapping.py', prefix.lib.python)
 
-        for cmod in find(arch, "*.c", recursive=False):
+        for cmod in find(arch, '*.c', recursive=False):
             shutil.move(cmod, prefix.share.modc)
-
-        if self.spec.satisfies('+coreneuron'):
-            shutil.move(join_path(arch, 'core/mod2c'), prefix.share.modc_core)
 
     def setup_environment(self, spack_env, run_env):
         spack_env.unset('LC_ALL')
-        run_env.set('NRNMECH_LIB_PATH', self.spec.prefix.lib.join('libnrnmech.so'))
-        run_env.set('BGLIBPY_MOD_LIBRARY_PATH', self.spec.prefix.lib.join('libnrnmech.so'))
+        # Remove LD_LIB_PATHs
+        to_rem = ('LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH', 'DYLD_FALLBACK_LIBRARY_PATH')
+        run_env.env_modifications = [envmod for envmod in run_env.env_modifications
+                                     if envmod.name not in to_rem]
+        run_env.prepend_path('HOC_LIBRARY_PATH', self.prefix.lib.hoc)
+        run_env.prepend_path('PYTHONPATH', self.prefix.lib.python)
+        for libnrnmech_name in find(self.prefix.lib, 'libnrnmech*_nd.so', recursive=False):
+            run_env.set('NRNMECH_LIB_PATH', libnrnmech_name)
+            run_env.set('BGLIBPY_MOD_LIBRARY_PATH', libnrnmech_name)
 
 
 @contextmanager
 def profiling_wrapper_on():
-    os.environ["USE_PROFILER_WRAPPER"] = "1"
+    os.environ['USE_PROFILER_WRAPPER'] = '1'
     yield
-    del os.environ["USE_PROFILER_WRAPPER"]
+    del os.environ['USE_PROFILER_WRAPPER']

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -34,7 +34,7 @@ class Synapsetool(CMakePackage):
     git      = "ssh://bbpcode.epfl.ch/hpc/synapse-tool"
 
     version('develop', submodules=True)
-    version('0.5.8', branch='sandbox/leite/fix_header', submodules=True)
+    version('0.5.8', tag='v0.5.8', submodules=True)
     version('0.5.7', tag='v0.5.7', submodules=True)
     version('0.5.6', tag='v0.5.6', submodules=True)
     version('0.5.5', tag='v0.5.5', submodules=True)

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -34,7 +34,7 @@ class Synapsetool(CMakePackage):
     git      = "ssh://bbpcode.epfl.ch/hpc/synapse-tool"
 
     version('develop', submodules=True)
-    version('0.5.8', branch='sandbox/leite/fix_cmake', submodules=True)
+    version('0.5.8', branch='sandbox/leite/fix_header', submodules=True)
     version('0.5.7', tag='v0.5.7', submodules=True)
     version('0.5.6', tag='v0.5.6', submodules=True)
     version('0.5.5', tag='v0.5.5', submodules=True)

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -34,6 +34,7 @@ class Synapsetool(CMakePackage):
     git      = "ssh://bbpcode.epfl.ch/hpc/synapse-tool"
 
     version('develop', submodules=True)
+    version('0.5.8', branch='sandbox/leite/fix_cmake', submodules=True)
     version('0.5.7', tag='v0.5.7', submodules=True)
     version('0.5.6', tag='v0.5.6', submodules=True)
     version('0.5.5', tag='v0.5.5', submodules=True)
@@ -51,12 +52,12 @@ class Synapsetool(CMakePackage):
 
     depends_on('boost@1.55:')
     depends_on('cmake@3.0:', type='build')
+    depends_on('mpi',    when='+mpi')
+    depends_on('python', when='+python', type=('build', 'run'))
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('hdf5~mpi', when='~mpi')
     depends_on('highfive+mpi', when='+mpi')
     depends_on('highfive~mpi', when='~mpi')
-    depends_on('mpi', when='+mpi')
-    depends_on('python', when='+python')
     depends_on('libsonata+mpi', when='+mpi')
     depends_on('libsonata~mpi', when='~mpi')
 

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -35,7 +35,6 @@ class Synapsetool(CMakePackage):
 
     version('develop', submodules=True)
     version('0.5.8', tag='v0.5.8', submodules=True)
-    version('0.5.7', tag='v0.5.7', submodules=True)
     version('0.5.6', tag='v0.5.6', submodules=True)
     version('0.5.5', tag='v0.5.5', submodules=True)
     version('0.5.4', tag='v0.5.4', submodules=True)

--- a/var/spack/repos/builtin/packages/synapsetool/package.py
+++ b/var/spack/repos/builtin/packages/synapsetool/package.py
@@ -34,6 +34,7 @@ class Synapsetool(CMakePackage):
     git      = "ssh://bbpcode.epfl.ch/hpc/synapse-tool"
 
     version('develop', submodules=True)
+    version('0.5.7', tag='v0.5.7', submodules=True)
     version('0.5.6', tag='v0.5.6', submodules=True)
     version('0.5.5', tag='v0.5.5', submodules=True)
     version('0.5.4', tag='v0.5.4', submodules=True)


### PR DESCRIPTION
**New package versions:**
- Neuron 7.8.0b: Fix the load balance issue
- Synapsetool 0.5.8: consolidated indexing, prevent truncating, improved clang compat
- neurodamus-core 2.9.1: Delete corenrn data, fixed MPI guards, improved clang compat
- neurodamus-py 0.8.0: new CLI options: keep corenrn data (default delete), build model only...
- reportinglib 2.5.3: Improved MPI 2+ compat (drop deprecated calls)

**Other recipe changes:**
- Deployment of neurodamus-core as a standalone compiled module.
 Initial support for any neurodmus-core + model-xxx for neurodamus-py 
- neurodamus-core, neurodamus-model-xxx, sim-model-xxx all to share the same code to build mod libraries with support for core-neuron and auto detection of dependencies.
- Pin synapsetool for older versions of parquet-converters

**Extra**
- deploy spatial-index v0.2.1