### PR TITLE
coreneuron: put a branch for 'develop' version

### DIFF
--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -36,7 +36,7 @@ class Coreneuron(CMakePackage):
     homepage = "https://github.com/BlueBrain/CoreNeuron"
     url      = "https://github.com/BlueBrain/CoreNeuron"
 
-    version('develop', git=url, submodules=True)
+    version('develop', git=url, branch='master', submodules=True)
     version('0.16', git=url, tag='0.16', submodules=True)
     version('0.15', git=url, tag='0.15', submodules=True)
     version('0.14', git=url, tag='0.14', submodules=True)

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -36,7 +36,7 @@ class Coreneuron(CMakePackage):
     homepage = "https://github.com/BlueBrain/CoreNeuron"
     url      = "https://github.com/BlueBrain/CoreNeuron"
 
-    version('develop', git=url, branch='master', submodules=True)
+    version('develop', branch='master', submodules=True)
     version('0.16', git=url, tag='0.16', submodules=True)
     version('0.15', git=url, tag='0.15', submodules=True)
     version('0.14', git=url, tag='0.14', submodules=True)


### PR DESCRIPTION
Besides being a good convention to set `branch='master'` for the develop version, in simulationStack tests we require patching it, and so the key `branch=` must exist.