### PR TITLE
Add git=url in develop version of coreneuron to avoid issue with patc…

### DIFF
--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -36,7 +36,7 @@ class Coreneuron(CMakePackage):
     homepage = "https://github.com/BlueBrain/CoreNeuron"
     url      = "https://github.com/BlueBrain/CoreNeuron"
 
-    version('develop', branch='master', submodules=True)
+    version('develop', git=url, branch='master', submodules=True)
     version('0.16', git=url, tag='0.16', submodules=True)
     version('0.15', git=url, tag='0.15', submodules=True)
     version('0.14', git=url, tag='0.14', submodules=True)


### PR DESCRIPTION
…hing versions in jenkins

This was there issue in jenkins:
```
==> Error: coreneuron version 'develop' has extra arguments: 'branch'

Valid arguments for a url fetcher are: 

    'url', 'sha1', 'sha224', 'sha384', 'sha256', 'sha512', 'md5', and 'checksum'
```