### PR TITLE
Add missing boost dependency for py-mvdtool

### DIFF
--- a/var/spack/repos/builtin/packages/py-mvdtool/package.py
+++ b/var/spack/repos/builtin/packages/py-mvdtool/package.py
@@ -28,6 +28,7 @@ class PyMvdtool(PythonPackage):
     depends_on('cmake@3.2:', type='build')
     depends_on('py-numpy', type='run')
 
+    depends_on('boost')
     depends_on('mpi', when='+mpi')
     depends_on('hdf5+mpi', type=('build', 'run'), when="+mpi")
     depends_on('hdf5~mpi', type=('build', 'run'), when="~mpi")


### PR DESCRIPTION
fixes #665