### PR TITLE
Fix neurodamus-model to build base model w/o deps

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -42,7 +42,7 @@ class NeurodamusModel(SimModel):
     def build_model(self, spec, prefix):
         """Build and install the bare model.
         """
-        SimModel.build(self, spec, prefix)
+        SimModel._build_mods(self, 'mod', dependencies=[])  # No dependencies
         # Dont install intermediate src.
         SimModel.install(self, spec, prefix, install_src=False)
 

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -54,12 +54,15 @@ class SimModel(Package):
     def lib_suffix(self):
         return ('_' + self.mech_name) if self.mech_name else ''
 
-    def _build_mods(self, mods_location, link_flag='', include_flag='', corenrn_mods=None):
+    def _build_mods(self, mods_location, link_flag='', include_flag='', corenrn_mods=None,
+                    dependencies=None):
         """Build shared lib & special from mods in a given path
         """
         # pass include and link flags for all dependency libraries
         # Compiler wrappers are not used to have a more reproducible building
-        for dep in set(self.spec.dependencies_dict('link').keys()):
+        if dependencies is None:
+            dependencies = self.spec.dependencies_dict('link').keys()
+        for dep in set(dependencies):
             link_flag += " {0.ld_flags} {0.rpath_flags}".format(self.spec[dep].libs)
             include_flag += " -I " + str(self.spec[dep].prefix.include)
 


### PR DESCRIPTION
Allow specifying the dependencies in sim-model, so that we can build pure models without dependencies from packages which have dependencies (e.g. neurodamus-neocortex can build a pure neocortex lib)