### PR TITLE
deploy: reinstate proper paths for configuration.

### DIFF
--- a/deploy/Jenkinsfile
+++ b/deploy/Jenkinsfile
@@ -320,7 +320,7 @@ pipeline {
                 stage("Test Modules") {
                     steps {
                         build job: "hpc.module-testing", parameters: [
-                            string(name: "MODULE_SCRIPT_PATH", value: "${DEPLOYMENT_ROOT}/config/2020/modules.sh")
+                            string(name: "MODULE_SCRIPT_PATH", value: "${DEPLOYMENT_ROOT}/config/modules.sh")
                         ]
                     }
                 }

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -579,7 +579,7 @@ copy_user_configuration() {
     what="$1"
 
     local source="$(install_dir ${what})/data"
-    local target="${DEPLOYMENT_ROOT}/config/$(date +%Y)"
+    local target="${DEPLOYMENT_ROOT}/config/"
 
     local root="${DEPLOYMENT_ROOT}/modules/all"
 


### PR DESCRIPTION
Old configurations are backed up in a `2019` directory. I'd like to get this in, and then rebuild properly setting all the symlinks so that we don't have to enter the deployment date any longer.