### PR TITLE
core: skip environment modifications for *system* paths only

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -336,7 +336,12 @@ class EnvironmentModifications(object):
             return path
         values = values.split(os.pathsep)
         path = path.split(os.pathsep)
-        return os.pathsep.join(p for p in path if p not in values)
+        def good(p):
+            # If the path in question is already in the environment *and*
+            # is a system path, don't add it to the environment
+            # modifications
+            return not (p in values and is_system_path(p))
+        return os.pathsep.join(p for p in path if good(p))
 
     @staticmethod
     def _check_other(other):
@@ -424,7 +429,7 @@ class EnvironmentModifications(object):
             name: name of the path list in the environment
             path: path to be appended
         """
-        path = self._purge_system(name ,path)
+        path = self._purge_system(name, path)
         if not path:
             return
         kwargs.update(self._get_outside_caller_attributes())
@@ -438,7 +443,7 @@ class EnvironmentModifications(object):
             name: name of the path list in the environment
             path: path to be pre-pended
         """
-        path = self._purge_system(name ,path)
+        path = self._purge_system(name, path)
         if not path:
             return
         kwargs.update(self._get_outside_caller_attributes())


### PR DESCRIPTION
Fixes a modification that I did a while ago.

Originally, we had noticed that `/usr/bin` got promoted in some cases through environment modifications. The first solution removed *all* paths already present in the `os.environ`.

But when installing new packages and generating modules in the install process, module generation is performed in the build environment. Thus the environment modifications did not end up in the module file.

Thus explicitly disallow system paths only during {pre,ap}pending.