### PR TITLE
Brion depends on python > 3.4

### DIFF
--- a/var/spack/repos/builtin/packages/brion/package.py
+++ b/var/spack/repos/builtin/packages/brion/package.py
@@ -25,7 +25,7 @@ class Brion(CMakePackage):
     depends_on('ninja', type='build')
     depends_on('doxygen', type='build')
 
-    depends_on('python', type=('build', 'run'), when='+python')
+    depends_on('python@3.4:', type=('build', 'run'), when='+python')
     depends_on('py-numpy', type=('build', 'run'), when='+python')
 
     depends_on('boost +shared', when='~python')
@@ -40,6 +40,9 @@ class Brion(CMakePackage):
     depends_on('vmmlib')
     depends_on('highfive@2.1: +boost ~mpi')
     depends_on('mvdtool ~mpi')
+
+    def patch(self):
+        filter_file(r'-py36', r'36 -py36', 'CMake/common/ChoosePython.cmake')
 
     def cmake_args(self):
         args = ['-DDISABLE_SUBPROJECTS=ON']

--- a/var/spack/repos/builtin/packages/brion/package.py
+++ b/var/spack/repos/builtin/packages/brion/package.py
@@ -7,6 +7,7 @@ import os
 
 from spack import *
 
+
 class Brion(CMakePackage):
     """Blue Brain C++ File IO Library"""
 
@@ -54,7 +55,8 @@ class Brion(CMakePackage):
 
     @when('+python')
     def setup_run_environment(self, env):
-        site_dir = self.spec['python'].package.site_packages_dir.split(os.sep)[1:]
+        site_dir = (self.spec['python']
+                    .package.site_packages_dir.split(os.sep)[1:])
         for target in (self.prefix.lib, self.prefix.lib64):
             pathname = os.path.join(target, *site_dir)
             if os.path.isdir(pathname):


### PR DESCRIPTION
 * Added patch Boost.Python to find python 3.6
   - See PR: https://github.com/Eyescale/CMake/pull/597