### PR TITLE
parquet-converters: pin arrow for all versions.

### DIFF
--- a/var/spack/repos/builtin/packages/parquet-converters/package.py
+++ b/var/spack/repos/builtin/packages/parquet-converters/package.py
@@ -24,8 +24,7 @@ class ParquetConverters(CMakePackage):
 
     depends_on('hdf5+mpi')
     depends_on('highfive+mpi')
-    depends_on('arrow+parquet')
-    depends_on('arrow+parquet@:0.12', when='@0.4:0.5.3')
+    depends_on('arrow+parquet@:0.12')
     depends_on('snappy~shared')
     depends_on('synapsetool+mpi')
     depends_on('synapsetool+mpi@:0.5.6', when='@:0.5.2')


### PR DESCRIPTION
Since the switch to the new arrow version is delayed, adjust the pin globally.