### PR TITLE
py-sonata-network-reduction0.0.6

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -38,7 +38,7 @@ packages:
       - py-simwriter@1.0.1
       - py-morph-tool@0.1.14
       - py-neurodamus
-      - py-sonata-network-reduction@0.0.5 ^neuron%intel@19.0.4^py-ipython%gcc
+      - py-sonata-network-reduction@0.0.6 ^neuron%intel@19.0.4^py-ipython%gcc
 
   gnu-stable-serial-ophiophob:
     target_matrix:

--- a/var/spack/repos/builtin/packages/py-aibs-circuit-converter/package.py
+++ b/var/spack/repos/builtin/packages/py-aibs-circuit-converter/package.py
@@ -14,15 +14,16 @@ class PyAibsCircuitConverter(PythonPackage):
     url      = "ssh://bbpcode.epfl.ch/nse/aibs-circuit-converter"
 
     version('develop', branch='master')
+    version('0.0.3', tag='aibs-circuit-converter-v0.0.3')
     version('0.0.1', tag='aibs-circuit-converter-v0.0.1')
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('py-numpy@1.17:', type='run')
-    depends_on('py-h5py@2.9:', type='run')
-    depends_on('py-pandas@0.25:0.30', type='run')
+    depends_on('py-numpy@1.14:', type='run')
+    depends_on('py-h5py@2.8:', type='run')
+    depends_on('py-pandas@0.23:0.30', type='run')
     depends_on('py-lxml@4.3.4:', type='run')
     depends_on('py-tqdm@4.34:', type='run')
-    depends_on('py-transforms3d@0.3.1:', type='run')
+    depends_on('py-transforms3d@0.3:', type='run')
     depends_on('py-six@1.0:', type='run')
     depends_on('py-bluepyopt@1.8.68:', type='run')

--- a/var/spack/repos/builtin/packages/py-neuron-reduce/package.py
+++ b/var/spack/repos/builtin/packages/py-neuron-reduce/package.py
@@ -18,7 +18,7 @@ class PyNeuronReduce(PythonPackage):
     version('0.0.7', commit='1bad597f2faa5ff6aa8c94b6f326f86a02e656d7')
 
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-numpy@1.17:', type='run')
+    depends_on('py-numpy@1.14:', type='run')
     depends_on('neuron+python', type='run')
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/py-sonata-network-reduction/package.py
+++ b/var/spack/repos/builtin/packages/py-sonata-network-reduction/package.py
@@ -13,13 +13,14 @@ class PySonataNetworkReduction(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/nse/sonata-network-reduction"
 
     version('develop', branch='master')
+    version('0.0.6', tag='sonata-network-reduction-v0.0.6')
     version('0.0.5', tag='sonata-network-reduction-v0.0.5')
     version('0.0.4', tag='sonata-network-reduction-v0.0.4')
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('py-numpy@1.17:', type='run')
-    depends_on('py-h5py@2.9:', type='run')
+    depends_on('py-numpy@1.14:', type='run')
+    depends_on('py-h5py@2.8:', type='run')
     depends_on('py-pandas@0.23:0.30', type='run')
     depends_on('py-lxml@4.3.4:', type='run')
     depends_on('py-tqdm@4.34:', type='run')
@@ -29,7 +30,7 @@ class PySonataNetworkReduction(PythonPackage):
     depends_on('py-bglibpy@4.2:', type='run')
     depends_on('py-morphio@2.3.4:', type='run')
     depends_on('neuron+python', type='run')
-    depends_on('py-aibs-circuit-converter@0.0.1', type='run')
+    depends_on('py-aibs-circuit-converter@0.0.3:', type='run')
     depends_on('py-bluepysnap@0.1.2:', type='run')
     depends_on('py-neuron-reduce@0.0.7:', type='run')
 

--- a/var/spack/repos/builtin/packages/py-sonata-network-reduction/package.py
+++ b/var/spack/repos/builtin/packages/py-sonata-network-reduction/package.py
@@ -20,8 +20,8 @@ class PySonataNetworkReduction(PythonPackage):
     depends_on('py-setuptools', type=('build', 'run'))
 
     depends_on('py-numpy@1.14:', type='run')
-    depends_on('py-h5py@2.8:', type='run')
-    depends_on('py-pandas@0.23:0.30', type='run')
+    depends_on('py-h5py@2.10:', type='run')
+    depends_on('py-pandas@0.25:0.30', type='run')
     depends_on('py-lxml@4.3.4:', type='run')
     depends_on('py-tqdm@4.34:', type='run')
     depends_on('py-click@6.7:', type='run')


### PR DESCRIPTION
All necessary changes for the version with lower dependencies.

I checked. It worked on BB5.
```
-bash-4.2$ . spack/share/spack/setup-env.sh
-bash-4.2$ export SPACK_INSTALL_PREFIX=${HOME}/software
-bash-4.2$ spack install --no-cache py-sonata-network-reduction
....
==> Installing py-sonata-network-reduction
==> Cloning git repository: ssh://bbpcode.epfl.ch/nse/sonata-network-reduction at tag sonata-network-reduction-v0.0.6.dev0
Total 111 (delta 14), reused 76 (delta 14)
Total 435 (delta 182), reused 435 (delta 182)
Fetching tags only, you probably meant:
  git fetch --tags
==> No checksum needed when fetching with git
==> Already staged spack-stage-py-sonata-network-reduction-0.0.6-4kv2vrx5eum2dwglaynpxjvrke2pxspw in /tmp/sanin/spack-stage-py-sonata-network-reduction-0.0.6-4kv2vrx5eum2dwglaynpxjvrke2pxspw
==> No patches needed for py-sonata-network-reduction
==> Building py-sonata-network-reduction [PythonPackage]
==> Executing phase: 'build'
==> Executing phase: 'install'
==> Successfully installed py-sonata-network-reduction
  Fetch: 2.91s.  Build: 8.15s.  Total: 11.06s.
[+] /gpfs/bbp.cscs.ch/home/sanin/software/install/linux-rhel7-x86_64/gcc-8.3.0/py-sonata-network-reduction-0.0.6-4kv2vr
-bash-4.2$ module load unstable
-bash-4.2$ spack module tcl refresh py-sonata-network-reduction@0.0.6 
==> You are about to regenerate tcl module files for:

-- linux-rhel7-x86_64 / gcc@8.3.0 -------------------------------
4kv2vrx py-sonata-network-reduction@0.0.6

==> Do you want to proceed? [y/n] y
==> Regenerating tcl module files
-bash-4.2$ module load py-sonata-network-reduction
Autoloading python/3.7.4
Autoloading py-efel/3.0.70
Autoloading py-bluepyopt/1.9.12
py-bluepyopt(37):ERROR:105: Unable to locate a modulefile for 'py-bluepyopt/1.9.12'
Autoloading py-bluepy/0.14.6
Autoloading brion/3.1.0
Autoloading py-bglibpy/4.2.14
Autoloading hpe-mpi/2.21
-bash-4.2$ module load neurodamus-hippocampus/0.4
Autoloading reportinglib/2.5.3
-bash-4.2$ cd /gpfs/bbp.cscs.ch/project/proj30/home/sanin/CA1.O0/
-bash-4.2$ sonata-network-reduction node 0 sonata-reduced-node All sonata/circuit_config.json 
loading template 'model'
loading default reduced model
There is no segment to segment copy, it means that some segments in the reduced model did not receive channels from the original cell
trying to compensate by copying channels from neighboring segments

Warning: section 1 is the only child of section: 0
It will be merged with the parent section
-bash-4.2$
```