### PR TITLE
Update/neurodamus core to 2.10 and py to 0.9

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -23,7 +23,8 @@ class NeurodamusModel(SimModel):
     # NOTE: Several variants / dependencies come from SimModel
     variant('synapsetool', default=True,  description="Enable SynapseTool reader (for edges)")
     variant('mvdtool',     default=True,  description="Enable MVDTool reader (for nodes)")
-    variant('common_mods', default='default', description="Source of common mods. '': no change, other string: alternate path")
+    variant('common_mods', default='default',
+            description="Source of common mods. '': no change, other string: alternate path")
     # Note: We dont request link to MPI so that mpicc can do what is best
     # and dont rpath it so we stay dynamic.
     # 'run' mode will load the same mpi module
@@ -93,10 +94,8 @@ class NeurodamusModel(SimModel):
         #         + spec['synapsetool'].package.dependency_libs(spec).joined()
 
         self.mech_name += _LIB_SUFFIX  # Final lib name
-        if spec.satisfies('+synapsetool'):
-            base_include_flag = "-DENABLE_SYNTOOL"
-        else:
-            base_include_flag = ""
+        base_include_flag = "-DENABLE_SYNTOOL" \
+                if spec.satisfies('+synapsetool') else ""
 
         include_flag, link_flag = self._build_mods('mod', "",
                                                    base_include_flag,

--- a/var/spack/repos/builtin/packages/py-morphio/package.py
+++ b/var/spack/repos/builtin/packages/py-morphio/package.py
@@ -19,8 +19,17 @@ class PyMorphio(PythonPackage):
     version('2.1.2', tag='v2.1.2', submodules=True, get_full_repo=True)
     version('2.0.8', tag='v2.0.8', submodules=True, get_full_repo=True)
 
-    depends_on('py-setuptools', type='build')
+    variant('mpi', default=True)
 
+    depends_on('py-setuptools', type='build')
     depends_on('cmake@3.2:', type='build')
     depends_on('py-numpy', type='run')
-    depends_on('hdf5~mpi', type=('build', 'run'))
+    depends_on('mpi', when='+mpi', type='build')
+    depends_on('hdf5', type=('build', 'run'))
+
+    @run_before('build')
+    def configure(self):
+        # we cant use @when('+mpi'), raises NoSuchMethodError
+        if self.spec.satisfies('+mpi'):
+            env['CC'] = self.spec['mpi'].mpicc
+            env['CXX'] = self.spec['mpi'].mpicxx

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
+    version('0.9.0',   tag='0.9.0')
     version('0.8.0',   tag='0.8.0')
     version('0.7.2',   tag='0.7.2')
 


### PR DESCRIPTION
Bring new versions of neurodamus

Plus, py-morphio can now be compiled with MPI