### PR TITLE
add unifurcation branch in spack recipe

### DIFF
--- a/var/spack/repos/builtin/packages/py-morphio/package.py
+++ b/var/spack/repos/builtin/packages/py-morphio/package.py
@@ -13,6 +13,7 @@ class PyMorphio(PythonPackage):
     git      = "https://github.com/BlueBrain/MorphIO.git"
 
     version('develop', branch='master', submodules=True, get_full_repo=True)
+    version('unifurcation', branch='unifurcation', submodules=True, get_full_repo=True)
     version('2.3.4', tag='v2.3.4', submodules=True, get_full_repo=True)
     version('2.2.1', tag='v2.2.1', submodules=True, get_full_repo=True)
     version('2.1.2', tag='v2.1.2', submodules=True, get_full_repo=True)


### PR DESCRIPTION
Need to have this available in spack to be able to use py-morphio to load h5 morphologies. 
The branch is simply "allowing" morphology unifurcation