### PR TITLE
deploy: remove timer.

### DIFF
--- a/deploy/Jenkinsfile
+++ b/deploy/Jenkinsfile
@@ -121,9 +121,9 @@ pipeline {
     }
 
     // Configured via the UI to allow concurrent PR builds
-    triggers {
-        cron('H H(0-7) * * *')
-    }
+    // triggers {
+    //     cron('H H(0-7) * * *')
+    // }
 
     stages {
         stage('Setup') {


### PR DESCRIPTION
Should resolve conflicts between our two Jenkins workflows using the
same Jenkinsfile, but with different triggers.