### PR TITLE
deploy: propagate build failures in deployment

### DIFF
--- a/var/spack/repos/builtin.mock/packages/b/package.py
+++ b/var/spack/repos/builtin.mock/packages/b/package.py
@@ -15,4 +15,5 @@ class B(Package):
     version('1.0', '0123456789abcdef0123456789abcdef')
 
     def install(self, spec, prefix):
-        pass
+        with working_dir(prefix):
+            touch("fake_install")


### PR DESCRIPTION
Solves BSD-127. When running with JUnit reporting, build failures are
captured via exceptions and not propagated. This does not happen when
building manually without any reporting.

As a result, there may be dependent installations with missing "run"
dependencies, creating unusable modules. Fixing dependencies may require
changes that yield different installation hashes, resulting in
permanently broken packages scattered through the system.

I think this is the minimal invasive solution to not build broken
packages: propagate build failures for all dependent packages, but
continue building other requested top-level packages.