### PR TITLE
py-traceback2: requires package linecache2

### DIFF
--- a/var/spack/repos/builtin/packages/py-traceback2/package.py
+++ b/var/spack/repos/builtin/packages/py-traceback2/package.py
@@ -16,7 +16,7 @@ class PyTraceback2(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-pbr', type='build')
-    depends_on('py-linecache2', type='build')
+    depends_on('py-linecache2', type='run')
 
     # test-requirements.txt
     depends_on('py-contextlib2', type='test')

--- a/var/spack/repos/builtin/packages/py-traceback2/package.py
+++ b/var/spack/repos/builtin/packages/py-traceback2/package.py
@@ -16,6 +16,7 @@ class PyTraceback2(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-pbr', type='build')
+    depends_on('py-linecache2', type='build')
 
     # test-requirements.txt
     depends_on('py-contextlib2', type='test')


### PR DESCRIPTION
This will fix the UT in STEPS CI:
```
  File "run_parallel_unit_tests.py", line 25, in <module>
    import unittest2
  File "/jenkins/05/workspace/sim.steps.github/INSTALL/install/linux-rhel7-x86_64/gcc-8.3.0/py-unittest2-1.1.0-x6edu4/lib/python3.7/site-packages/unittest2/__init__.py", line 40, in <module>
    from unittest2.collector import collector
  File "/jenkins/05/workspace/sim.steps.github/INSTALL/install/linux-rhel7-x86_64/gcc-8.3.0/py-unittest2-1.1.0-x6edu4/lib/python3.7/site-packages/unittest2/collector.py", line 3, in <module>
    from unittest2.loader import defaultTestLoader
  File "/jenkins/05/workspace/sim.steps.github/INSTALL/install/linux-rhel7-x86_64/gcc-8.3.0/py-unittest2-1.1.0-x6edu4/lib/python3.7/site-packages/unittest2/loader.py", line 13, in <module>
    from unittest2 import case, suite, util
  File "/jenkins/05/workspace/sim.steps.github/INSTALL/install/linux-rhel7-x86_64/gcc-8.3.0/py-unittest2-1.1.0-x6edu4/lib/python3.7/site-packages/unittest2/case.py", line 10, in <module>
    import traceback2 as traceback
  File "/jenkins/05/workspace/sim.steps.github/INSTALL/install/linux-rhel7-x86_64/gcc-8.3.0/py-traceback2-1.4.0-wjfor7/lib/python3.7/site-packages/traceback2/__init__.py", line 6, in <module>
    import linecache2 as linecache
ModuleNotFoundError: No module named 'linecache2'
```