### PR TITLE
deployment: remove libx11 from exposed packages.yaml

### DIFF
--- a/deploy/packages/tools.yaml
+++ b/deploy/packages/tools.yaml
@@ -40,7 +40,6 @@ packages:
       - intel-mpi@2018.1.163
       - isl@0.18
       - ispc@1.10.0
-      - libx11@1.6.5
       - m4@1.4.18
       - mpc@1.1.0
       - 'mvapich2@2.3 fabrics=mrail process_managers=slurm file_systems=gpfs'


### PR DESCRIPTION
Software depending on x11 often uses autotools and fails to install, as
the dependencies of libx11 are not exposed when sourcing it from
packages.yaml.