### PR TITLE
core: more unique mirror id w.r.t. git options

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -752,11 +752,14 @@ class GitFetchStrategy(VCSFetchStrategy):
         return self.commit or self.tag
 
     def mirror_id(self):
-        repo_ref = self.commit or self.tag or self.branch
-        if repo_ref:
-            repo_path = url_util.parse(self.url).path
-            result = os.path.sep.join(['git', repo_path, repo_ref])
-            return result
+        repo_ref = self.commit or self.tag or self.branch or 'HEAD'
+        if self.submodules:
+            repo_ref += '_submodules'
+        if self.get_full_repo:
+            repo_ref += '_full'
+        repo_path = url_util.parse(self.url).path
+        result = os.path.sep.join(['git', repo_path, repo_ref])
+        return result
 
     def get_source_id(self):
         if not self.branch:

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -690,6 +690,21 @@ def mock_git_repository(tmpdir_factory):
     git = spack.util.executable.which('git', required=True)
 
     tmpdir = tmpdir_factory.mktemp('mock-git-repo-dir')
+    tmpdir.ensure("submodule", dir=True)
+    moddir = tmpdir.join("submodule")
+    with moddir.as_cwd():
+        git('init')
+        git('config', 'user.name', 'Spack')
+        git('config', 'user.email', 'spack@spack.io')
+
+        # s0 is just the first commit
+        s0_file = 's0_file'
+        moddir.ensure(s0_file)
+        git('add', s0_file)
+        git('commit', '-m', 'mock-git-submodule-repo s0')
+
+        url = 'file://' + str(moddir)
+
     tmpdir.ensure(spack.stage._source_path_subdir, dir=True)
     repodir = tmpdir.join(spack.stage._source_path_subdir)
 
@@ -698,6 +713,10 @@ def mock_git_repository(tmpdir_factory):
         git('init')
         git('config', 'user.name', 'Spack')
         git('config', 'user.email', 'spack@spack.io')
+        git('submodule', 'add', url, 'submodule')
+        git('submodule', 'update', '--init', '--recursive')
+        git('add', '.gitmodules', 'submodule')
+        git('commit', '-m', 'add submodule')
         url = 'file://' + str(repodir)
 
         # r0 is just the first commit

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -213,7 +213,7 @@ def test_get_full_repo(get_full_repo, git_version, mock_git_repository,
 
         if get_full_repo:
             assert(nbranches == 5)
-            assert(ncommits == 2)
+            assert(ncommits == 3)
         else:
             assert(nbranches == 2)
             assert(ncommits == 1)

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -94,21 +94,11 @@ def check_mirror():
                     fetcher = pkg.fetcher[0]
                     fetcher.set_stage(truth)
                     fetcher.fetch()
+                    fetcher.expand()
                     original_path = truth.source_path
 
                     with pkg.stage:
                         pkg.do_stage(mirror_only=True)
-
-                        # Compare the original repo with the expanded archive
-                        # original_path = mock_repo.path
-                        # if 'svn' in name:
-                        #     # have to check out the svn repo to compare.
-                        #     original_path = os.path.join(
-                        #         mock_repo.path, 'checked_out')
-
-                        #     svn = which('svn', required=True)
-                        #     svn('checkout', mock_repo.url, original_path)
-
                         compare(original_path, pkg.stage.source_path)
 
 

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -71,33 +71,45 @@ def check_mirror():
                 mirror_root, mirror_paths.storage_path)
             assert os.path.exists(expected_path)
 
+        def compare(left, right):
+            dcmp = filecmp.dircmp(left, right)
+
+            # make sure there are no new files in the expanded
+            # tarball
+            assert not dcmp.right_only
+            # and that all original files are present.
+            assert all(l in exclude for l in dcmp.left_only)
+
+            for subdir in dcmp.common_dirs:
+                compare(os.path.join(left, subdir),
+                        os.path.join(right, subdir))
+
         # Now try to fetch each package.
         for name, mock_repo in repos.items():
             spec = Spec(name).concretized()
             pkg = spec.package
 
             with spack.config.override('config:checksum', False):
-                with pkg.stage:
-                    pkg.do_stage(mirror_only=True)
+                with Stage('baseline') as truth:
+                    fetcher = pkg.fetcher[0]
+                    fetcher.set_stage(truth)
+                    fetcher.fetch()
+                    original_path = truth.source_path
 
-                    # Compare the original repo with the expanded archive
-                    original_path = mock_repo.path
-                    if 'svn' in name:
-                        # have to check out the svn repo to compare.
-                        original_path = os.path.join(
-                            mock_repo.path, 'checked_out')
+                    with pkg.stage:
+                        pkg.do_stage(mirror_only=True)
 
-                        svn = which('svn', required=True)
-                        svn('checkout', mock_repo.url, original_path)
+                        # Compare the original repo with the expanded archive
+                        # original_path = mock_repo.path
+                        # if 'svn' in name:
+                        #     # have to check out the svn repo to compare.
+                        #     original_path = os.path.join(
+                        #         mock_repo.path, 'checked_out')
 
-                    dcmp = filecmp.dircmp(
-                        original_path, pkg.stage.source_path)
+                        #     svn = which('svn', required=True)
+                        #     svn('checkout', mock_repo.url, original_path)
 
-                    # make sure there are no new files in the expanded
-                    # tarball
-                    assert not dcmp.right_only
-                    # and that all original files are present.
-                    assert all(l in exclude for l in dcmp.left_only)
+                        compare(original_path, pkg.stage.source_path)
 
 
 def test_url_mirror(mock_archive):
@@ -110,6 +122,7 @@ def test_url_mirror(mock_archive):
     not which('git'), reason='requires git to be installed')
 def test_git_mirror(mock_git_repository):
     set_up_package('git-test', mock_git_repository, 'git')
+    set_up_package('git-test-full', mock_git_repository, 'git')
     check_mirror()
     repos.clear()
 

--- a/var/spack/repos/builtin.mock/packages/git-test-full/package.py
+++ b/var/spack/repos/builtin.mock/packages/git-test-full/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -6,11 +6,11 @@
 from spack import *
 
 
-class GitTest(Package):
+class GitTestFull(Package):
     """Mock package that uses git for fetching."""
     homepage = "http://www.git-fetch-example.com"
 
-    version('git', branch='master', git='to-be-filled-in-by-test')
+    version('git', branch='master', git='to-be-filled-in-by-test', submodules=True)
 
     def install(self, spec, prefix):
         pass


### PR DESCRIPTION
No unit tests here currently, as these are tough to modify. More as a stop-gap measure to get our builds rolling again.