### PR TITLE
Small fixes in neurodamus and neuron recipes

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -154,11 +154,11 @@ class NeurodamusModel(SimModel):
             #  - BGLIBPY_MOD_LIBRARY_PATH is the pure mechanism
             #        (used by bglib-py)
             if 'darwin' in self.spec.architecture:
-                lib_suffix = ".dylib"
+                dso_suffix = ".dylib"
             else:
-                lib_suffix = ".so"
+                dso_suffix = ".so"
 
-            if 'libnrnmech' + lib_suffix in libnrnmech_name:
+            if 'libnrnmech' + dso_suffix in libnrnmech_name:
                 env.set('NRNMECH_LIB_PATH', libnrnmech_name)
             else:
                 env.set('BGLIBPY_MOD_LIBRARY_PATH', libnrnmech_name)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -12,8 +12,6 @@ import llnl.util.tty as tty
 # Definitions
 _CORENRN_MODLIST_FNAME = "coreneuron_modlist.txt"
 _BUILD_NEURODAMUS_FNAME = "build_neurodamus.sh"
-_LIB_SUFFIX = "_nd"
-
 
 class NeurodamusModel(SimModel):
     """An 'abstract' base package for Simulation Models. Therefore no version.
@@ -92,7 +90,9 @@ class NeurodamusModel(SimModel):
         # link_flag += ' '
         #         + spec['synapsetool'].package.dependency_libs(spec).joined()
 
-        self.mech_name += _LIB_SUFFIX  # Final lib name
+        if self.spec.satisfies('^neuron+binary+cmake'):
+            self.mech_name = ""  # keep lib name as libnrnmech.so for binary neuron
+
         if spec.satisfies('+synapsetool'):
             base_include_flag = "-DENABLE_SYNTOOL"
         else:
@@ -152,7 +152,14 @@ class NeurodamusModel(SimModel):
             #  - NRNMECH_LIB_PATH the combined lib (used by neurodamus-py)
             #  - BGLIBPY_MOD_LIBRARY_PATH is the pure mechanism
             #        (used by bglib-py)
-            if '_nd.' in libnrnmech_name:
+            libnrnmech_name = 'libnrnmech'
+            if "darwin" in self.spec.architecture:
+                lib_suffix = ".dylib"
+            else:
+                lib_suffix = ".so"
+            libnrnmech_name += lib_suffix
+
+            if libnrnmech_name == 'libnrnmech.so':
                 env.set('NRNMECH_LIB_PATH', libnrnmech_name)
             else:
                 env.set('BGLIBPY_MOD_LIBRARY_PATH', libnrnmech_name)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -152,14 +152,12 @@ class NeurodamusModel(SimModel):
             #  - NRNMECH_LIB_PATH the combined lib (used by neurodamus-py)
             #  - BGLIBPY_MOD_LIBRARY_PATH is the pure mechanism
             #        (used by bglib-py)
-            libnrnmech_name = 'libnrnmech'
             if "darwin" in self.spec.architecture:
                 lib_suffix = ".dylib"
             else:
                 lib_suffix = ".so"
-            libnrnmech_name += lib_suffix
 
-            if libnrnmech_name == 'libnrnmech.so':
+            if 'libnrnmech' + lib_suffix in libnrnmech_name:
                 env.set('NRNMECH_LIB_PATH', libnrnmech_name)
             else:
                 env.set('BGLIBPY_MOD_LIBRARY_PATH', libnrnmech_name)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -90,8 +90,8 @@ class NeurodamusModel(SimModel):
         # link_flag += ' '
         #         + spec['synapsetool'].package.dependency_libs(spec).joined()
 
-        if self.spec.satisfies('^neuron+binary+cmake'):
-            self.mech_name = ""  # keep lib name as libnrnmech.so for binary neuron
+        # Create the library with all the mod files as libnrnmech.so/.dylib
+        self.mech_name = ''
 
         if spec.satisfies('+synapsetool'):
             base_include_flag = "-DENABLE_SYNTOOL"

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -153,12 +153,7 @@ class NeurodamusModel(SimModel):
             #  - NRNMECH_LIB_PATH the combined lib (used by neurodamus-py)
             #  - BGLIBPY_MOD_LIBRARY_PATH is the pure mechanism
             #        (used by bglib-py)
-            if 'darwin' in self.spec.architecture:
-                dso_suffix = ".dylib"
-            else:
-                dso_suffix = ".so"
-
-            if 'libnrnmech' + dso_suffix in libnrnmech_name:
+            if 'libnrnmech.' in libnrnmech_name:
                 env.set('NRNMECH_LIB_PATH', libnrnmech_name)
             else:
                 env.set('BGLIBPY_MOD_LIBRARY_PATH', libnrnmech_name)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -13,6 +13,7 @@ import llnl.util.tty as tty
 _CORENRN_MODLIST_FNAME = "coreneuron_modlist.txt"
 _BUILD_NEURODAMUS_FNAME = "build_neurodamus.sh"
 
+
 class NeurodamusModel(SimModel):
     """An 'abstract' base package for Simulation Models. Therefore no version.
        Eventually in the future Models are independent entities,
@@ -152,7 +153,7 @@ class NeurodamusModel(SimModel):
             #  - NRNMECH_LIB_PATH the combined lib (used by neurodamus-py)
             #  - BGLIBPY_MOD_LIBRARY_PATH is the pure mechanism
             #        (used by bglib-py)
-            if "darwin" in self.spec.architecture:
+            if 'darwin' in self.spec.architecture:
                 lib_suffix = ".dylib"
             else:
                 lib_suffix = ".so"

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -143,6 +143,7 @@ class Neuron(CMakePackage):
     # Create symlink in share/nrn/lib for the python libraries
     # which is the place that neuron expects the library similarly
     # to autotools installation
+    # See : https://github.com/neuronsimulator/nrn/issues/567
     @when("+cmake+python")
     @run_after("install")
     def symlink_python_lib(self):

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -446,6 +446,11 @@ class Neuron(CMakePackage):
             filter_file(env["CC"], cc_compiler, nrniv_makefile, **kwargs)
             filter_file(env["CXX"], cxx_compiler, nrniv_makefile, **kwargs)
 
+    @when("~cmake")
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path("PATH", join_path(self.basedir, "bin"))
+        env.prepend_path("LD_LIBRARY_PATH", join_path(self.basedir, "lib"))
+
     def setup_run_environment(self, env):
         env.prepend_path("PATH", join_path(self.basedir, "bin"))
         env.prepend_path("LD_LIBRARY_PATH", join_path(self.basedir, "lib"))

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -455,6 +455,8 @@ class Neuron(CMakePackage):
             filter_file(env["CC"], cc_compiler, nrniv_makefile, **kwargs)
             filter_file(env["CXX"], cxx_compiler, nrniv_makefile, **kwargs)
 
+    # Added because the bin and lib directories are inside x86_64 dir in the
+    # installation directory of autotools installation
     @when("~cmake")
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.prepend_path("PATH", join_path(self.basedir, "bin"))

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -144,10 +144,10 @@ class Neuron(CMakePackage):
     # which is the place that neuron expects the library similarly
     # to autotools installation
     # See : https://github.com/neuronsimulator/nrn/issues/567
-    @when("+cmake+python")
     @run_after("install")
     def symlink_python_lib(self):
-        os.symlink(self.prefix.lib.python, self.prefix.share.nrn.lib.python)
+        if "+cmake+python" in self.spec:
+            os.symlink(self.prefix.lib.python, self.prefix.share.nrn.lib.python)
 
     # ==============================================
     # == Autotools build system related functions ==

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -71,7 +71,7 @@ class Neuron(CMakePackage):
         default=True,
         description="Build Python module with setup.py",
     )
-    variant("rx3d",       default=False,  description="Enable cython translated 3-d rxd. Depends on pysetup")
+    variant("rx3d",       default=True,  description="Enable cython translated 3-d rxd. Depends on pysetup")
     variant("shared",     default=True,  description="Build shared libraries")
     variant("tests",      default=False, description="Enable unit tests")
 
@@ -139,6 +139,14 @@ class Neuron(CMakePackage):
             args.append("-DNRN_ENABLE_BINARY_SPECIAL=ON")
 
         return args
+
+    # Create symlink in share/nrn/lib for the python libraries
+    # which is the place that neuron expects the library similarly
+    # to autotools installation
+    @when("+cmake+python")
+    @run_after("install")
+    def symlink_python_lib(self):
+        os.symlink(self.prefix.lib.python, self.prefix.share.nrn.lib.python)
 
     # ==============================================
     # == Autotools build system related functions ==

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -147,7 +147,8 @@ class Neuron(CMakePackage):
     @run_after("install")
     def symlink_python_lib(self):
         if "+cmake+python" in self.spec:
-            os.symlink(self.prefix.lib.python, self.prefix.share.nrn.lib.python)
+            os.symlink(self.prefix.lib.python,
+                       self.prefix.share.nrn.lib.python)
 
     # ==============================================
     # == Autotools build system related functions ==

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -22,10 +22,10 @@ class PyNeurodamus(PythonPackage):
     depends_on('py-setuptools',    type=('build', 'run'))
     depends_on('py-h5py',          type='run')
     depends_on('py-numpy',         type='run')
-    depends_on('py-lazy-property', type='run')
     depends_on('py-docopt',        type='run')
-    depends_on('py-six',           type='run')
-    depends_on('py-scipy',         type='run')
+    depends_on('py-lazy-property', type='run', when='@:1.0.0')
+    depends_on('py-six',           type='run', when='@:1.0.0')
+    depends_on('py-scipy',         type='run', when='@1.2.0:')
 
     @run_after('install')
     def install_scripts(self):

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
+    version('1.1.0',   tag='1.1.0')
     version('0.8.0',   tag='0.8.0')
     version('0.7.2',   tag='0.7.2')
 

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -153,12 +153,13 @@ class SimModel(Package):
 
         if (self.spec.satisfies('^neuron~binary') or
                 self.spec.satisfies('^neuron+binary+cmake')):
-            lib_suffix = '.so'
+            if 'darwin' in self.spec.architecture:
+                lib_suffix = '.dylib'
+            else:
+                lib_suffix = '.so'
             # Install libnrnmech - might have several links
             if self.spec.satisfies('^neuron+cmake'):
                 libnrnmech_path = self.nrnivmodl_outdir
-                if 'darwin' in self.spec.architecture:
-                    lib_suffix = '.dylib'
             else:
                 libnrnmech_path = self.nrnivmodl_outdir + '/.libs'
             for f in find(libnrnmech_path,

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -153,24 +153,21 @@ class SimModel(Package):
 
         if (self.spec.satisfies('^neuron~binary') or
                 self.spec.satisfies('^neuron+binary+cmake')):
-            lib_suffix = ".so"
+            lib_suffix = '.so'
             # Install libnrnmech - might have several links
             if self.spec.satisfies('^neuron+cmake'):
                 libnrnmech_path = self.nrnivmodl_outdir
-                if "darwin" in self.spec.architecture:
-                    lib_suffix = ".dylib"
+                if 'darwin' in self.spec.architecture:
+                    lib_suffix = '.dylib'
             else:
-                libnrnmech_path = self.nrnivmodl_outdir + "/.libs"
+                libnrnmech_path = self.nrnivmodl_outdir + '/.libs'
             for f in find(libnrnmech_path,
                           'libnrnmech*' + lib_suffix + '*',
                           recursive=False):
                 if not os.path.islink(f):
                     bname = os.path.basename(f)
-                    if self.spec.satisfies('^neuron+binary+cmake'):
-                        lib_dst = prefix.lib.join(bname)
-                    else:
-                        lib_dst = prefix.lib.join(
-                            bname[:bname.find('.')] + self.lib_suffix + '.so')
+                    lib_dst = prefix.lib.join(
+                        bname[:bname.find('.')] + self.lib_suffix + lib_suffix)
                     shutil.move(f, lib_dst)  # Move so its not copied twice
                     break
             else:

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -154,21 +154,21 @@ class SimModel(Package):
         if (self.spec.satisfies('^neuron~binary') or
                 self.spec.satisfies('^neuron+binary+cmake')):
             if 'darwin' in self.spec.architecture:
-                lib_suffix = '.dylib'
+                dso_suffix = '.dylib'
             else:
-                lib_suffix = '.so'
+                dso_suffix = '.so'
             # Install libnrnmech - might have several links
             if self.spec.satisfies('^neuron+cmake'):
                 libnrnmech_path = self.nrnivmodl_outdir
             else:
                 libnrnmech_path = self.nrnivmodl_outdir + '/.libs'
             for f in find(libnrnmech_path,
-                          'libnrnmech*' + lib_suffix + '*',
+                          'libnrnmech*' + dso_suffix + '*',
                           recursive=False):
                 if not os.path.islink(f):
                     bname = os.path.basename(f)
                     lib_dst = prefix.lib.join(
-                        bname[:bname.find('.')] + self.lib_suffix + lib_suffix)
+                        bname[:bname.find('.')] + self.lib_suffix + dso_suffix)
                     shutil.move(f, lib_dst)  # Move so its not copied twice
                     break
             else:

--- a/var/spack/repos/builtin/packages/sim-model/package.py
+++ b/var/spack/repos/builtin/packages/sim-model/package.py
@@ -153,22 +153,19 @@ class SimModel(Package):
 
         if (self.spec.satisfies('^neuron~binary') or
                 self.spec.satisfies('^neuron+binary+cmake')):
-            if 'darwin' in self.spec.architecture:
-                dso_suffix = '.dylib'
-            else:
-                dso_suffix = '.so'
             # Install libnrnmech - might have several links
             if self.spec.satisfies('^neuron+cmake'):
                 libnrnmech_path = self.nrnivmodl_outdir
             else:
                 libnrnmech_path = self.nrnivmodl_outdir + '/.libs'
             for f in find(libnrnmech_path,
-                          'libnrnmech*' + dso_suffix + '*',
+                          'libnrnmech.*',
                           recursive=False):
                 if not os.path.islink(f):
                     bname = os.path.basename(f)
                     lib_dst = prefix.lib.join(
-                        bname[:bname.find('.')] + self.lib_suffix + dso_suffix)
+                        bname[:bname.find('.')] + self.lib_suffix
+                        + '.' + dso_suffix)
                     shutil.move(f, lib_dst)  # Move so its not copied twice
                     break
             else:


### PR DESCRIPTION
- Fixes wrongly generated libraries for neurodamus
  - Set NRNMECH_LIB_PATH as libnrnmech.so/.dylib which is the library
      that binary special is expecting
  - Set BGLIBPY_MOD_LIBRARY_PATH to libnrnmech_<model>.so/.dylib for
      model specific library
  - Set library suffix to .dylib as special in macos is linked with
      libnrnmech.dylib
- Sets PATH and LD_LIBRARY_PATH for neuron autotools build
- Creates all the libraries in macos with `.dylib` suffix to avoid issue with binary neuron looking for `libnrnmech.dylib` in macos