### PR TITLE
Intel stack update

### DIFF
--- a/deploy/packages/compilers.yaml
+++ b/deploy/packages/compilers.yaml
@@ -39,7 +39,7 @@ packages:
     specs:
       - gcc@9.3.0
       - gcc@8.3.0
-      - intel-parallel-studio+advisor+clck+daal+gdb+inspector+ipp+itac+mkl~mpi+rpath+shared+tbb+vtune@cluster.2019.5
+      - intel-parallel-studio+advisor+clck+daal+gdb+inspector+ipp+itac+mkl+mpi+rpath+shared+tbb+vtune@cluster.2019.5
       #- intel@18.0.3
       - intel@19.0.4
       - pgi+network+nvidia+mpi@19.10

--- a/deploy/packages/compilers.yaml
+++ b/deploy/packages/compilers.yaml
@@ -39,7 +39,7 @@ packages:
     specs:
       - gcc@9.3.0
       - gcc@8.3.0
-      - intel-parallel-studio+advisor+clck+daal+gdb+inspector+ipp+itac+mkl+mpi+rpath+shared+tbb+vtune@cluster.2019.5
+      - intel-parallel-studio+advisor+clck+daal+gdb+inspector+ipp+itac+mkl~mpi+rpath+shared+tbb+vtune@cluster.2019.5
       #- intel@18.0.3
       - intel@19.0.4
       - pgi+network+nvidia+mpi@19.10

--- a/deploy/packages/tools.yaml
+++ b/deploy/packages/tools.yaml
@@ -39,7 +39,7 @@ packages:
       - help2man@1.47.4
       - hpctoolkit
       - hpe-mpi@2.21
-      - intel-mpi@2018.1.163
+      - intel-mpi@2019.5.281
       - isl@0.18
       - ispc@1.10.0
       - m4@1.4.18

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -89,7 +89,7 @@ class IntelPackage(PackageBase):
     2. :py:meth:`~.IntelPackage.install`
 
     They both have sensible defaults and for many packages the
-    only thing necessary will be to override setup_run_environment
+    only thing necessary will be to override setup_environment
     to set the appropriate environment variables.
     """
     #: Phases of an Intel package
@@ -455,7 +455,9 @@ class IntelPackage(PackageBase):
                     break
 
             if not matching_dirs:
-                # No match -- return a sensible value anyway.
+                # No match -- this *will* happen during pre-build call to
+                # setup_environment() when the destination dir is still empty.
+                # Return a sensible value anyway.
                 d = unversioned_dirname
 
         debug_print(d)
@@ -784,8 +786,7 @@ class IntelPackage(PackageBase):
         debug_print(mkl_libs)
 
         if len(mkl_libs) < 3:
-            raise_lib_error('Cannot locate core MKL libraries:', mkl_libnames,
-                            'in:', self.component_lib_dir('mkl'))
+            raise_lib_error('Cannot locate core MKL libraries:', mkl_libnames)
 
         # The Intel MKL link line advisor recommends these system libraries
         system_libs = find_system_libraries(
@@ -817,11 +818,11 @@ class IntelPackage(PackageBase):
         elif ('^mpich@2:' in spec_root or
               '^mvapich2' in spec_root or
               '^intel-mpi' in spec_root or
-              '^intel-mpi-external' in spec_root or
               '^intel-parallel-studio' in spec_root):
             blacs_lib = 'libmkl_blacs_intelmpi'
         elif ('^mpt' in spec_root or
-              '^hpe-mpi' in spec_root):
+              '^hpe-mpi' in spec_root or
+              '^intel-mpi-external' in spec_root):
             blacs_lib = 'libmkl_blacs_sgimpt'
         else:
             raise_lib_error('Cannot find a BLACS library for the given MPI.')
@@ -889,15 +890,15 @@ class IntelPackage(PackageBase):
         # debug_print("wrapper_vars =", wrapper_vars)
         return wrapper_vars
 
-    def mpi_setup_dependent_build_environment(
-            self, env, dependent_spec, compilers_of_client={}):
-        '''Unified back-end for setup_dependent_build_environment() of
-        Intel packages that provide 'mpi'.
+    def mpi_setup_dependent_environment(
+            self, spack_env, run_env, dependent_spec, compilers_of_client={}):
+        '''Unified back-end for setup_dependent_environment() of Intel packages
+        that provide 'mpi'.
 
         Parameters:
 
-            env, dependent_spec: same as in
-                setup_dependent_build_environment().
+            spack_env, run_env, dependent_spec: same as in
+                setup_dependent_environment().
 
             compilers_of_client (dict): Conveys spack_cc, spack_cxx, etc.,
                 from the scope of dependent packages; constructed in caller.
@@ -939,12 +940,12 @@ class IntelPackage(PackageBase):
         # Ensure that the directory containing the compiler wrappers is in the
         # PATH. Spack packages add `prefix.bin` to their dependents' paths,
         # but because of the intel directory hierarchy that is insufficient.
-        env.prepend_path('PATH', os.path.dirname(wrapper_vars['MPICC']))
+        spack_env.prepend_path('PATH', os.path.dirname(wrapper_vars['MPICC']))
 
         for key, value in wrapper_vars.items():
-            env.set(key, value)
+            spack_env.set(key, value)
 
-        debug_print("adding to build env:", wrapper_vars)
+        debug_print("adding to spack_env:", wrapper_vars)
 
     # ---------------------------------------------------------------------
     # General support for child packages
@@ -995,7 +996,7 @@ class IntelPackage(PackageBase):
         debug_print(result)
         return result
 
-    def setup_run_environment(self, env):
+    def setup_environment(self, spack_env, run_env):
         """Adds environment variables to the generated module file.
 
         These environment variables come from running:
@@ -1005,7 +1006,24 @@ class IntelPackage(PackageBase):
            $ source parallel_studio_xe_2017/bin/psxevars.sh intel64
            [and likewise for MKL, MPI, and other components]
         """
+        # https://spack.readthedocs.io/en/latest/spack.html#spack.package.PackageBase.setup_environment
+        #
+        #   spack_env   -> Applied when dependent is built within Spack.
+        #                  Not used here.
+        #   run_env     -> Applied to the modulefile of dependent.
+        #
+        # NOTE: Spack runs setup_environment twice, once pre-build to set up
+        # the build environment, and once post-installation to determine
+        # the environment variables needed at run-time to add to the module
+        # file. The script we need to source is only present post-installation,
+        # so check for its existence before sourcing.
+        # TODO: At some point we should split setup_environment into
+        # setup_build_environment and setup_run_environment to get around
+        # this problem.
         f = self.file_to_source
+        if not f or not os.path.isfile(f):
+            return
+
         tty.debug("sourcing " + f)
 
         # All Intel packages expect at least the architecture as argument.
@@ -1017,9 +1035,15 @@ class IntelPackage(PackageBase):
         # if sys.platform == 'darwin':
         #     args = ()
 
-        env.extend(EnvironmentModifications.from_sourcing_file(f, *args))
+        run_env.extend(EnvironmentModifications.from_sourcing_file(f, *args))
 
-    def setup_dependent_build_environment(self, env, dependent_spec):
+    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+        # https://spack.readthedocs.io/en/latest/spack.html#spack.package.PackageBase.setup_dependent_environment
+        #
+        #   spack_env   -> Applied when dependent is built within Spack.
+        #   run_env     -> Applied to the modulefile of dependent.
+        #                  Not used here.
+        #
         # NB: This function is overwritten by 'mpi' provider packages:
         #
         # var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -1029,20 +1053,18 @@ class IntelPackage(PackageBase):
         # dictionary kwarg compilers_of_client{} present and populated.
 
         # Handle everything in a callback version.
-        self._setup_dependent_env_callback(env, dependent_spec)
+        self._setup_dependent_env_callback(spack_env, run_env, dependent_spec)
 
     def _setup_dependent_env_callback(
-            self, env, dependent_spec, compilers_of_client={}):
-        # Expected to be called from a client's
-        # setup_dependent_build_environment(),
+            self, spack_env, run_env, dependent_spec, compilers_of_client={}):
+        # Expected to be called from a client's setup_dependent_environment(),
         # with args extended to convey the client's compilers as needed.
 
         if '+mkl' in self.spec or self.provides('mkl'):
             # Spack's env philosophy demands that we replicate some of the
             # settings normally handled by file_to_source ...
             #
-            # TODO: Why is setup_run_environment()
-            # [which uses file_to_source()]
+            # TODO: Why is setup_environment() [which uses file_to_source()]
             # not called as a matter of course upon entering the current
             # function? (guarding against multiple calls notwithstanding)
             #
@@ -1050,40 +1072,23 @@ class IntelPackage(PackageBase):
             env_mods = {
                 'MKLROOT': self.normalize_path('mkl'),
                 'SPACK_COMPILER_EXTRA_RPATHS': self.component_lib_dir('mkl'),
-                'CMAKE_PREFIX_PATH': self.normalize_path('mkl'),
-                'CMAKE_LIBRARY_PATH': self.component_lib_dir('mkl'),
-                'CMAKE_INCLUDE_PATH': self.component_include_dir('mkl'),
             }
 
-            env.set('MKLROOT', env_mods['MKLROOT'])
-            env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
-                            env_mods['SPACK_COMPILER_EXTRA_RPATHS'])
-            env.append_path('CMAKE_PREFIX_PATH', env_mods['CMAKE_PREFIX_PATH'])
-            env.append_path('CMAKE_LIBRARY_PATH',
-                            env_mods['CMAKE_LIBRARY_PATH'])
-            env.append_path('CMAKE_INCLUDE_PATH',
-                            env_mods['CMAKE_INCLUDE_PATH'])
+            spack_env.set('MKLROOT', env_mods['MKLROOT'])
+            spack_env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
+                                  env_mods['SPACK_COMPILER_EXTRA_RPATHS'])
 
-            debug_print("adding/modifying build env:", env_mods)
+            debug_print("adding/modifying spack_env:", env_mods)
 
         if '+mpi' in self.spec or self.provides('mpi'):
             if compilers_of_client:
-                self.mpi_setup_dependent_build_environment(
-                    env, dependent_spec, compilers_of_client)
+                self.mpi_setup_dependent_environment(
+                    spack_env, run_env, dependent_spec, compilers_of_client)
                 # We could forego this nonce function and inline its code here,
                 # but (a) it sisters mpi_compiler_wrappers() [needed twice]
                 # which performs dizzyingly similar but necessarily different
                 # actions, and (b) function code leaves a bit more breathing
                 # room within the suffocating corset of flake8 line length.
-
-                # Intel MPI since 2019 depends on libfabric which is not in the
-                # lib directory but in a directory of its own which should be
-                # included in the rpath
-                if self.version >= ver('2019'):
-                    d = ancestor(self.component_lib_dir('mpi'))
-                    libfabrics_path = os.path.join(d, 'libfabric', 'lib')
-                    env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
-                                    libfabrics_path)
             else:
                 raise InstallError('compilers_of_client arg required for MPI')
 

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -89,7 +89,7 @@ class IntelPackage(PackageBase):
     2. :py:meth:`~.IntelPackage.install`
 
     They both have sensible defaults and for many packages the
-    only thing necessary will be to override setup_environment
+    only thing necessary will be to override setup_run_environment
     to set the appropriate environment variables.
     """
     #: Phases of an Intel package
@@ -455,9 +455,7 @@ class IntelPackage(PackageBase):
                     break
 
             if not matching_dirs:
-                # No match -- this *will* happen during pre-build call to
-                # setup_environment() when the destination dir is still empty.
-                # Return a sensible value anyway.
+                # No match -- return a sensible value anyway.
                 d = unversioned_dirname
 
         debug_print(d)
@@ -786,7 +784,8 @@ class IntelPackage(PackageBase):
         debug_print(mkl_libs)
 
         if len(mkl_libs) < 3:
-            raise_lib_error('Cannot locate core MKL libraries:', mkl_libnames)
+            raise_lib_error('Cannot locate core MKL libraries:', mkl_libnames,
+                            'in:', self.component_lib_dir('mkl'))
 
         # The Intel MKL link line advisor recommends these system libraries
         system_libs = find_system_libraries(
@@ -818,11 +817,11 @@ class IntelPackage(PackageBase):
         elif ('^mpich@2:' in spec_root or
               '^mvapich2' in spec_root or
               '^intel-mpi' in spec_root or
+              '^intel-mpi-external' in spec_root or
               '^intel-parallel-studio' in spec_root):
             blacs_lib = 'libmkl_blacs_intelmpi'
         elif ('^mpt' in spec_root or
-              '^hpe-mpi' in spec_root or
-              '^intel-mpi-external' in spec_root):
+              '^hpe-mpi' in spec_root):
             blacs_lib = 'libmkl_blacs_sgimpt'
         else:
             raise_lib_error('Cannot find a BLACS library for the given MPI.')
@@ -890,15 +889,15 @@ class IntelPackage(PackageBase):
         # debug_print("wrapper_vars =", wrapper_vars)
         return wrapper_vars
 
-    def mpi_setup_dependent_environment(
-            self, spack_env, run_env, dependent_spec, compilers_of_client={}):
-        '''Unified back-end for setup_dependent_environment() of Intel packages
-        that provide 'mpi'.
+    def mpi_setup_dependent_build_environment(
+            self, env, dependent_spec, compilers_of_client={}):
+        '''Unified back-end for setup_dependent_build_environment() of
+        Intel packages that provide 'mpi'.
 
         Parameters:
 
-            spack_env, run_env, dependent_spec: same as in
-                setup_dependent_environment().
+            env, dependent_spec: same as in
+                setup_dependent_build_environment().
 
             compilers_of_client (dict): Conveys spack_cc, spack_cxx, etc.,
                 from the scope of dependent packages; constructed in caller.
@@ -940,12 +939,12 @@ class IntelPackage(PackageBase):
         # Ensure that the directory containing the compiler wrappers is in the
         # PATH. Spack packages add `prefix.bin` to their dependents' paths,
         # but because of the intel directory hierarchy that is insufficient.
-        spack_env.prepend_path('PATH', os.path.dirname(wrapper_vars['MPICC']))
+        env.prepend_path('PATH', os.path.dirname(wrapper_vars['MPICC']))
 
         for key, value in wrapper_vars.items():
-            spack_env.set(key, value)
+            env.set(key, value)
 
-        debug_print("adding to spack_env:", wrapper_vars)
+        debug_print("adding to build env:", wrapper_vars)
 
     # ---------------------------------------------------------------------
     # General support for child packages
@@ -996,7 +995,7 @@ class IntelPackage(PackageBase):
         debug_print(result)
         return result
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         """Adds environment variables to the generated module file.
 
         These environment variables come from running:
@@ -1006,24 +1005,7 @@ class IntelPackage(PackageBase):
            $ source parallel_studio_xe_2017/bin/psxevars.sh intel64
            [and likewise for MKL, MPI, and other components]
         """
-        # https://spack.readthedocs.io/en/latest/spack.html#spack.package.PackageBase.setup_environment
-        #
-        #   spack_env   -> Applied when dependent is built within Spack.
-        #                  Not used here.
-        #   run_env     -> Applied to the modulefile of dependent.
-        #
-        # NOTE: Spack runs setup_environment twice, once pre-build to set up
-        # the build environment, and once post-installation to determine
-        # the environment variables needed at run-time to add to the module
-        # file. The script we need to source is only present post-installation,
-        # so check for its existence before sourcing.
-        # TODO: At some point we should split setup_environment into
-        # setup_build_environment and setup_run_environment to get around
-        # this problem.
         f = self.file_to_source
-        if not f or not os.path.isfile(f):
-            return
-
         tty.debug("sourcing " + f)
 
         # All Intel packages expect at least the architecture as argument.
@@ -1035,15 +1017,9 @@ class IntelPackage(PackageBase):
         # if sys.platform == 'darwin':
         #     args = ()
 
-        run_env.extend(EnvironmentModifications.from_sourcing_file(f, *args))
+        env.extend(EnvironmentModifications.from_sourcing_file(f, *args))
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
-        # https://spack.readthedocs.io/en/latest/spack.html#spack.package.PackageBase.setup_dependent_environment
-        #
-        #   spack_env   -> Applied when dependent is built within Spack.
-        #   run_env     -> Applied to the modulefile of dependent.
-        #                  Not used here.
-        #
+    def setup_dependent_build_environment(self, env, dependent_spec):
         # NB: This function is overwritten by 'mpi' provider packages:
         #
         # var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -1053,18 +1029,20 @@ class IntelPackage(PackageBase):
         # dictionary kwarg compilers_of_client{} present and populated.
 
         # Handle everything in a callback version.
-        self._setup_dependent_env_callback(spack_env, run_env, dependent_spec)
+        self._setup_dependent_env_callback(env, dependent_spec)
 
     def _setup_dependent_env_callback(
-            self, spack_env, run_env, dependent_spec, compilers_of_client={}):
-        # Expected to be called from a client's setup_dependent_environment(),
+            self, env, dependent_spec, compilers_of_client={}):
+        # Expected to be called from a client's
+        # setup_dependent_build_environment(),
         # with args extended to convey the client's compilers as needed.
 
         if '+mkl' in self.spec or self.provides('mkl'):
             # Spack's env philosophy demands that we replicate some of the
             # settings normally handled by file_to_source ...
             #
-            # TODO: Why is setup_environment() [which uses file_to_source()]
+            # TODO: Why is setup_run_environment()
+            # [which uses file_to_source()]
             # not called as a matter of course upon entering the current
             # function? (guarding against multiple calls notwithstanding)
             #
@@ -1072,23 +1050,40 @@ class IntelPackage(PackageBase):
             env_mods = {
                 'MKLROOT': self.normalize_path('mkl'),
                 'SPACK_COMPILER_EXTRA_RPATHS': self.component_lib_dir('mkl'),
+                'CMAKE_PREFIX_PATH': self.normalize_path('mkl'),
+                'CMAKE_LIBRARY_PATH': self.component_lib_dir('mkl'),
+                'CMAKE_INCLUDE_PATH': self.component_include_dir('mkl'),
             }
 
-            spack_env.set('MKLROOT', env_mods['MKLROOT'])
-            spack_env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
-                                  env_mods['SPACK_COMPILER_EXTRA_RPATHS'])
+            env.set('MKLROOT', env_mods['MKLROOT'])
+            env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
+                            env_mods['SPACK_COMPILER_EXTRA_RPATHS'])
+            env.append_path('CMAKE_PREFIX_PATH', env_mods['CMAKE_PREFIX_PATH'])
+            env.append_path('CMAKE_LIBRARY_PATH',
+                            env_mods['CMAKE_LIBRARY_PATH'])
+            env.append_path('CMAKE_INCLUDE_PATH',
+                            env_mods['CMAKE_INCLUDE_PATH'])
 
-            debug_print("adding/modifying spack_env:", env_mods)
+            debug_print("adding/modifying build env:", env_mods)
 
         if '+mpi' in self.spec or self.provides('mpi'):
             if compilers_of_client:
-                self.mpi_setup_dependent_environment(
-                    spack_env, run_env, dependent_spec, compilers_of_client)
+                self.mpi_setup_dependent_build_environment(
+                    env, dependent_spec, compilers_of_client)
                 # We could forego this nonce function and inline its code here,
                 # but (a) it sisters mpi_compiler_wrappers() [needed twice]
                 # which performs dizzyingly similar but necessarily different
                 # actions, and (b) function code leaves a bit more breathing
                 # room within the suffocating corset of flake8 line length.
+
+                # Intel MPI since 2019 depends on libfabric which is not in the
+                # lib directory but in a directory of its own which should be
+                # included in the rpath
+                if self.version >= ver('2019'):
+                    d = ancestor(self.component_lib_dir('mpi'))
+                    libfabrics_path = os.path.join(d, 'libfabric', 'lib')
+                    env.append_path('SPACK_COMPILER_EXTRA_RPATHS',
+                                    libfabrics_path)
             else:
                 raise InstallError('compilers_of_client arg required for MPI')
 

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -11,6 +11,8 @@ class IntelMpi(IntelPackage):
 
     homepage = "https://software.intel.com/en-us/intel-mpi-library"
 
+    version('2019.5.281', sha256='9c59da051f1325b221e5bc4d8b689152e85d019f143069fa39e17989306811f4',
+            url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15838/l_mpi_2019.5.281.tgz')
     version('2019.4.243', sha256='233a8660b92ecffd89fedd09f408da6ee140f97338c293146c9c080a154c5fcd',
             url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15553/l_mpi_2019.4.243.tgz')
     version('2019.3.199', sha256='5304346c863f64de797250eeb14f51c5cfc8212ff20813b124f20e7666286990',

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -45,7 +45,7 @@ class IntelMpi(IntelPackage):
 
     provides('mpi')
 
-    def setup_dependent_environment(self, *args):
+    def setup_dependent_build_environment(self, *args):
         # Handle in callback, conveying client's compilers in additional arg.
         # CAUTION - DUP code in:
         #   ../intel-mpi/package.py

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -200,7 +200,7 @@ class IntelParallelStudio(IntelPackage):
     conflicts('auto_dispatch=SSE3', 'platform=darwin target=x86_64:',
               msg='SSE3 is not supported on MacOS x86_64')
 
-    def setup_dependent_environment(self, *args):
+    def setup_dependent_build_environment(self, *args):
         # Handle in callback, conveying client's compilers in additional arg.
         # CAUTION - DUP code in:
         #   ../intel-mpi/package.py


### PR DESCRIPTION
  - remove mpi from parallel-studio as we have separate intel-mpi module
  - update intel-mpi to the newer 2019.5 release