### PR TITLE
Add newer version of environment-modules and enable module for the same

### DIFF
--- a/deploy/configs/tools/modules.yaml
+++ b/deploy/configs/tools/modules.yaml
@@ -36,6 +36,7 @@ modules:
       - darshan-util
       - doxygen
       - emacs
+      - environment-modules
       - ffmpeg
       - git
       - graphviz

--- a/deploy/packages/tools.yaml
+++ b/deploy/packages/tools.yaml
@@ -27,7 +27,7 @@ packages:
       - darshan-util
       - doxygen@1.8.15
       - emacs@26.1
-      - environment-modules@3.2.10
+      - environment-modules@4.5.1
       - ffmpeg
       - flex@2.6.3
       - gdb~python@8.2

--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -12,10 +12,11 @@ class EnvironmentModules(Package):
     """
 
     homepage = 'https://cea-hpc.github.io/modules/'
-    url = 'https://github.com/cea-hpc/modules/releases/download/v4.3.1/modules-4.3.1.tar.gz'
+    url = 'https://github.com/cea-hpc/modules/releases/download/v4.5.1/modules-4.5.1.tar.gz'
 
     maintainers = ['xdelaruelle']
 
+    version('4.5.1', sha256='7d4bcc8559e7fbbc52e526fc86a15b161ff4422aa49eee37897ee7a48eb64ac2')
     version('4.3.1', sha256='979efb5b3d3c8df2c3c364aaba61f97a459456fc5bbc092dfc02677da63e5654')
     version('4.3.0', sha256='231f059c4109a2d3028c771f483f6c92f1f3689eb0033648ce00060dad00e103')
     version('4.2.5', sha256='3375b454568e7bbec7748cd6173516ef9f30a3d8e13c3e99c02794a6a3bc3c8c')


### PR DESCRIPTION
The reason for installing newer version and providing module is:
* For some JupyterHub related ongoing work, CS is updating  environment-modules in [BSD-142](https://bbpteam.epfl.ch/project/issues/browse/BSD-142)
* Instead of installing that on specific nodes, we should do wider testing of this update
* To enable this, we can provide modules under tools section that can be loaded by users.

~Note that is required only for beta testing. This means, it won't be necessary to merge this PR. We can just use module from `pulls` directory.~

~- [ ] we should check if Spack deployment workflow will work using this update. (It should be just to be sure)~

For testing o JupyterHub, we can make this available already.