### PR TITLE
Fixes for Neurodamus and Mac instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,21 +209,21 @@ The information for external packages is stored in
           zlib@1.2.11 +optimize+pic+shared: /gpfs/bbp.cscs.ch/apps/hpc/jenkins/deploy/external-libraries/2019-01-04/linux-rhel7-x86_64/gcc-6.4.0/zlib-1.2.11-w43e56tzqj
 </details>
 
-## Building software in MAC
+## Building software on OS X
 
 <details>
 <summary>
-Install software in MAC. Use BREW as a source of binary packages
+Install software on OS X, using Homebrew for binary packages
 </summary>
 
-In MAC the build process is very similar to Ubuntu. To avoid building
-the whole stack from source we can likewise use a package manager.
-For that end we have successfully used Brew. We also provide a skeleton 
-packages.yaml that you should review and adapt to your needs.
+On OS X the build process is very similar to Ubuntu. To avoid building
+the whole stack from source we can likewise use another package manager to provide precompiled binaries.
+To that end we have successfully used Homebrew. We also provide a skeleton 
+`packages.yaml` that you should review and adapt to your needs.
 
 Before starting, please install brew and the required packages.
 If you require Python please install a version dowloaded from
-Python.org, as several issues have been found with "brewed" Python
+Python.org, as several issues have been found with Homebrew's Python
 
     $ git clone https://github.com/BlueBrain/spack.git
     $ mkdir ~/.spack

--- a/README.md
+++ b/README.md
@@ -209,6 +209,30 @@ The information for external packages is stored in
           zlib@1.2.11 +optimize+pic+shared: /gpfs/bbp.cscs.ch/apps/hpc/jenkins/deploy/external-libraries/2019-01-04/linux-rhel7-x86_64/gcc-6.4.0/zlib-1.2.11-w43e56tzqj
 </details>
 
+## Building software in MAC
+
+<details>
+<summary>
+Install software in MAC. Use BREW as a source of binary packages
+</summary>
+
+In MAC the build process is very similar to Ubuntu. To avoid building
+the whole stack from source we can likewise use a package manager.
+For that end we have successfully used Brew. We also provide a skeleton 
+packages.yaml that you should review and adapt to your needs.
+
+Before starting, please install brew and the required packages.
+If you require Python please install a version dowloaded from
+Python.org, as several issues have been found with "brewed" Python
+
+    $ git clone https://github.com/BlueBrain/spack.git
+    $ mkdir ~/.spack
+    $ cp spack/sysconfig/mac_osx/*.yaml ~/.spack
+    $ . spack/share/spack/setup-env.sh
+    $ spack compiler find
+</details>
+
+
 ## Using Spack for Continuous Integration on BlueBrain5
 
 <details>

--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -25,7 +25,3 @@ packages:
     # although the version number used here isn't critical
       apple-libunwind@35.3: /usr
     buildable: False
-  python:
-    paths:
-      python@3.7.7: /usr/local/opt/python3
-    version: [3.7.7]

--- a/sysconfig/mac_osx/packages.yaml
+++ b/sysconfig/mac_osx/packages.yaml
@@ -1,0 +1,111 @@
+packages:
+    autoconf:
+        paths:
+            autoconf@2.69: /usr/local/opt/autoconf
+        version: [2.69]
+    automake:
+        paths:
+            automake@1.16.1: /usr/local/opt/automake
+        version: [1.16.1]
+    bison:
+        paths:
+            bison@3.4: /usr/local/opt/bison
+        version: [3.4]
+    boost:
+        paths:
+            boost@1.68.0: /usr/local/opt/boost
+        buildable: False
+    bzip2:
+        paths:
+            bzip2@1.0.6: /usr/local/opt/bzip
+        version: [1.0.6]
+    cairo:
+        paths:
+            cairo@1.8.10: /usr/local/opt/cairo
+        version: [1.8.10]
+    catch:
+        paths:
+            catch~single_header@2.x: /usr/local/opt/catch2
+        version: [2.x]
+    cmake:
+        paths:
+            cmake@3.13.3: /usr/local/opt/cmake
+        buildable: False
+    curl:
+        paths:
+            curl@7.29.0: /usr/local/opt/curl
+        version: [7.29.0]
+    environment-modules:
+        paths:
+            environment-modules@4.1.4: /usr/local/opt/modules
+        buildable: False
+    flex:
+        paths:
+            flex@2.6.4: /usr/local/opt/flex
+        version: [2.6.4]
+    fontconfig:
+        paths:
+            fontconfig@2.10.95: /usr/local/opt/fontconfig
+        version: [2.10.95]
+    gettext:
+        paths:
+            gettext@0.20.1: /usr/local/opt/gettext
+        version: [0.20.1]
+    hdf5:
+        paths:
+            hdf5@1.12.0+mpi: /usr/local/opt/hdf5-parallel
+        version: [1.12]
+        buildable: False
+    hdf5:
+        paths:
+            hdf5@1.12.0~mpi: /usr/local/opt/hdf5
+        version: [1.12]
+    hwloc:
+        paths:
+            hwloc@1.11.2: /usr/local/opt/hwloc
+        version: [1.11.2]
+    openblas:
+        paths:
+            openblas@0.3.5: /usr/local/opt/openblas
+        version: [0.3.5]
+    openmpi:
+        paths:
+            openmpi@4.0.1: /usr/local/opt/openmpi
+        buildable: False
+    openssl:
+        paths:
+            openssl@1.0.2k: /usr/local/opt/openssl
+        version: [1.0.2k]
+    pcre:
+        paths:
+            pcre@8.32+jit+utf: /usr/local/opt/pcre
+        version: [8.32]
+    petsc:
+        variants: +patchmpi64
+    pkg-config:
+        paths:
+            pkg-config@0.29.2: /usr/local/opt/pkg-config
+        version: [0.29.2]
+    python:
+        paths:
+            python@3.7.5+shared: /Library/Frameworks/Python.framework/Versions/3.7
+        version: [3.7.5]
+    tcl:
+        paths:
+            tcl@8.5.13: /usr
+        version: [8.5.13]
+    trilinos:
+        variants: +kokkos+teuchos~amesos~hypre~superlu-dist~mumps~metis~suite-sparse
+        version: [xsdk-0.4.0-rc1]
+    tk:
+        paths:
+            tk@8.5.13: /usr
+        version: [8.5.13]
+    xz:
+        paths:
+            xz@5.2: /usr/local/opt/xz
+        version: [5.2]
+    zlib:
+        paths:
+            zlib@1.2.11: /usr/local/opt/zlib
+        version: [1.2.11]

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -71,6 +71,13 @@ class NeurodamusCore(SimModel):
     # Dont apply name for now for compat with neuron+binary
     # mech_name = "neurodamus"
 
+    # We want neurodamus-model to fully depend on core, but no modules
+    # loaded at runtime. 'link' dependency requires libraries which we
+    # dont provide so we override libs to allow an empty LibraryList
+    @property
+    def libs(self):
+        return LibraryList([])
+
     @run_before('build')
     def prepare(self):
         filter_file(r'UNKNOWN_CORE_VERSION', r'%s' % self.spec.version,

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -27,8 +27,8 @@ class NeurodamusModel(SimModel):
     # and dont rpath it so we stay dynamic.
     # 'run' mode will load the same mpi module
     depends_on("mpi", type=('build', 'run'))
-    depends_on('neurodamus-core', type=('build', 'link'))
-    depends_on('neurodamus-core@develop', type=('build', 'link'), when='@develop')
+    depends_on('neurodamus-core', type=('build', 'run'))
+    depends_on('neurodamus-core@develop', type=('build', 'run'), when='@develop')
     depends_on('hdf5+mpi')
     depends_on('reportinglib')
     depends_on('libsonata-report')
@@ -152,7 +152,6 @@ class NeurodamusModel(SimModel):
                         prefix.lib.hoc.join('defvar.hoc'))
 
     def setup_run_environment(self, env):
-        tty.warn("WTF")
         self._setup_run_environment_common(env)
         for libnrnmech_name in find(self.prefix.lib, 'libnrnmech*',
                                     recursive=False):
@@ -160,7 +159,6 @@ class NeurodamusModel(SimModel):
             #  - NRNMECH_LIB_PATH the combined lib (used by neurodamus-py)
             #  - BGLIBPY_MOD_LIBRARY_PATH is the pure mechanism
             #        (used by bglib-py)
-            tty.warn("Handling ", libnrnmech_name)
             if 'libnrnmech.' in libnrnmech_name:
                 env.set('NRNMECH_LIB_PATH', libnrnmech_name)
             else:

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -27,8 +27,8 @@ class NeurodamusModel(SimModel):
     # and dont rpath it so we stay dynamic.
     # 'run' mode will load the same mpi module
     depends_on("mpi", type=('build', 'run'))
-    depends_on('neurodamus-core')
-    depends_on('neurodamus-core@develop', when='@develop')
+    depends_on('neurodamus-core', type=('build', 'link'))
+    depends_on('neurodamus-core@develop', type=('build', 'link'), when='@develop')
     depends_on('hdf5+mpi')
     depends_on('reportinglib')
     depends_on('libsonata-report')
@@ -152,13 +152,15 @@ class NeurodamusModel(SimModel):
                         prefix.lib.hoc.join('defvar.hoc'))
 
     def setup_run_environment(self, env):
+        tty.warn("WTF")
         self._setup_run_environment_common(env)
-        for libnrnmech_name in find(self.prefix.lib, 'libnrnmech*.so',
+        for libnrnmech_name in find(self.prefix.lib, 'libnrnmech*',
                                     recursive=False):
             # We have the two libs and must export them in different vars
             #  - NRNMECH_LIB_PATH the combined lib (used by neurodamus-py)
             #  - BGLIBPY_MOD_LIBRARY_PATH is the pure mechanism
             #        (used by bglib-py)
+            tty.warn("Handling ", libnrnmech_name)
             if 'libnrnmech.' in libnrnmech_name:
                 env.set('NRNMECH_LIB_PATH', libnrnmech_name)
             else:

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -27,9 +27,9 @@ class NeurodamusModel(SimModel):
     # and dont rpath it so we stay dynamic.
     # 'run' mode will load the same mpi module
     depends_on("mpi", type=('build', 'run'))
-    depends_on('neurodamus-core', type=('build', 'run'))
-    depends_on('neurodamus-core@develop', type='build', when='@develop')
-    depends_on("hdf5+mpi")
+    depends_on('neurodamus-core')
+    depends_on('neurodamus-core@develop', when='@develop')
+    depends_on('hdf5+mpi')
     depends_on('reportinglib')
     depends_on('libsonata-report')
     depends_on('reportinglib+profile', when='+profile')


### PR DESCRIPTION
Neurodamus, when building in mac suffered from two issues:
 - always assume a brew Python
 - link to neurodamus-core with "run" dependency, which made
   it load modules and have variables overwritten. See
   https://github.com/BlueBrain/spack/pull/757#discussion_r441807535

### This PR
 - the hardcoded Python version was removed and instructions how to use BlueBrain spack with Mac were added.
 - ~~the dependency was changed to "link",~~ (doesn't help) - in the future we should remove the dependency altogether and use submodule
