### PR TITLE
Disable MPI correctly in CMake with ~mpi

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -126,9 +126,10 @@ class Neuron(CMakePackage):
                                                              "+coreneuron",
                                                              "+tests"]]
         if "+mpi" in self.spec:
+            args.append("-DNRN_ENABLE_MPI=ON")
             args.append("-DNRN_ENABLE_MPI_DYNAMIC=ON")
         else:
-            args.append("-DNRN_ENABLE_MPI_DYNAMIC=OFF")
+            args.append("-DNRN_ENABLE_MPI=OFF")
         if "+python" in self.spec:
             args.append("-DPYTHON_EXECUTABLE:FILEPATH="
                         + self.spec["python"].command.path)

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -127,6 +127,8 @@ class Neuron(CMakePackage):
                                                              "+tests"]]
         if "+mpi" in self.spec:
             args.append("-DNRN_ENABLE_MPI_DYNAMIC=ON")
+        else:
+            args.append("-DNRN_ENABLE_MPI_DYNAMIC=OFF")
         if "+python" in self.spec:
             args.append("-DPYTHON_EXECUTABLE:FILEPATH="
                         + self.spec["python"].command.path)


### PR DESCRIPTION
MPI is ON by default and hence we need to explicitly make it off with `~mpi`.