### PR TITLE
Fix self.spec in NMODL recipe

### DIFF
--- a/var/spack/repos/builtin/packages/nmodl/package.py
+++ b/var/spack/repos/builtin/packages/nmodl/package.py
@@ -39,13 +39,13 @@ class Nmodl(CMakePackage):
         return options
 
     def setup_build_environment(self, env):
-        if '@:0.3b' in spec:
+        if '@:0.3b' in self.spec:
             env.prepend_path('PYTHONPATH', self.prefix.lib.python)
         else:
             env.prepend_path('PYTHONPATH', self.prefix.lib)
 
     def setup_run_environment(self, env):
-        if '@:0.3b' in spec:
+        if '@:0.3b' in self.spec:
             env.prepend_path('PYTHONPATH', self.prefix.lib.python)
         else:
             env.prepend_path('PYTHONPATH', self.prefix.lib)


### PR DESCRIPTION
- Introduced a bug in NMODL recipe in https://github.com/BlueBrain/spack/pull/849 which was not caught by the CI
- CI is not testing nmodl because it's not deployed (?) @matz-e 