### PR TITLE
modules: don't add non-existant modules to autoload

### DIFF
--- a/lib/spack/spack/test/modules/conftest.py
+++ b/lib/spack/spack/test/modules/conftest.py
@@ -47,10 +47,23 @@ def filename_dict(file_registry, monkeypatch):
 
 
 @pytest.fixture()
-def modulefile_content(filename_dict, request):
+def modulefile_content(filename_dict, request, monkeypatch):
     """Returns a function that generates the content of a module file
     as a list of lines.
     """
+
+    # Pach out to avoid read access
+    def _mock(self, what):
+        mod = self.conf.module
+        return [mod.make_layout(x).use_name
+                for x in getattr(self.conf, what)]
+
+    monkeypatch.setattr(
+        spack.modules.common.BaseContext,
+        '_create_module_list_of',
+        _mock,
+        raising=False
+    )
 
     writer_cls = getattr(request.module, 'writer_cls')
 


### PR DESCRIPTION
Should solve issues where modules attempt to load the modules of their
dependencies, but the latter have not been generated.  Note that the
requirement here is that a module for the dependent DAG hash has to be
present, otherwise a warning is printed, and nothing will be
auto-loaded.

This could be potentially loosened to a version-match, at the risk of
loading incompatible modules (different variants could not be
discriminated reliably). Better safe than sorry.

- [x] make sure that specs are considered as a set, i.e., dependency modules may be generated later in the same execution.