### PR TITLE
Fix X11 dependency for the interviews GUI on Ubuntu 20.04

### DIFF
--- a/sysconfig/ubuntu-20.04/packages
+++ b/sysconfig/ubuntu-20.04/packages
@@ -30,3 +30,5 @@ software-properties-common
 tcl-dev
 unzip
 zlib1g-dev
+libx11-dev
+libxcomposite-dev


### PR DESCRIPTION
If you follow the tutorial provided by the **HPC Team newcomer bootcamp** and try to install NEURON on Ubuntu 20.04, the following error will appear on Spack after executing `spack install neuron +interviews`:

```
...
25    CMake Error at CMakeLists.txt:186 (message):
26      You must install X11 to build iv e.g.  'apt install libx11-dev
27      libxcomposite-dev' on Ubuntu
...
```

The pull request is about a small fix that just adds the missing packages to the `sysconfig/ubuntu-20.04/packages` file.


