### PR TITLE
Update neurodamus-py to 1.2.0 - sonata populations

### DIFF
--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
+    version('1.2.0',   tag='1.2.0')
     version('1.1.0',   tag='1.1.0')
     version('0.8.0',   tag='0.8.0')
     version('0.7.2',   tag='0.7.2')


### PR DESCRIPTION
### What's new with neurodamus-py 1.2.0
 - Multipopulation for edges
 - **CRITICAL**: Current neurodamus-py 1.1.0  is incompatible with latest deployed neurodamus-core due to the update to 14 synapse fields. This version improves the matching so that future updates to the format won't break things. 