### PR TITLE
spykfunc: revert part of "spykfunc: pin JDK, too. (#880)"

### DIFF
--- a/var/spack/repos/builtin/packages/spykfunc/package.py
+++ b/var/spack/repos/builtin/packages/spykfunc/package.py
@@ -35,7 +35,7 @@ class Spykfunc(PythonPackage):
     depends_on('py-cython', type='run', when='@:0.15.3')
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('spark+hadoop@3.0.0:^openjdk', type='run')
+    depends_on('spark+hadoop@3.0.0:', type='run')
     depends_on('hadoop@:2.999', type='run')
 
     depends_on('py-bb5', type=('build', 'run'), when='@:0.15.6')


### PR DESCRIPTION
Seems like Spack is stuck in an endless loop at times. See if relaxing
the constraints on Java will fix this.

This reverts commit 82fb6e8779d914af1ece6b747b0b175377ab10df.