### PR TITLE
updated BGLibPy to 4.3.12

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -121,7 +121,7 @@ packages:
       - nest@2.18.0
       - py-efel@3.0.80
       - py-bluepyefe@0.3.13
-      - py-bglibpy@4.2.23 ^neuron%intel@19.0.4
+      - py-bglibpy@4.3.12 ^neuron%intel@19.0.4
       - py-bluepy@0.14.8
       - py-bluepymm@0.7.15 ^neuron%intel@19.0.4
       - py-bluepyopt@1.9.27 ^neuron%intel@19.0.4

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -17,6 +17,7 @@ class PyBglibpy(PythonPackage):
     version('4.3', commit='61293ef3f64a18e7a336d7a5a959020c8237b207')
     version('4.2.23', commit='4f88c9df716ca1c7b1c779ee934b28aa991a366b')
     version('4.1.4', commit='e54d294460e5bdf6b9990bc10a4606b412b76d90')
+    version('4.3.12', commit='eb4accd2dc4ebcb01e65d6429bb8221af5aa14bf')
 
     depends_on('py-setuptools', type=('build', 'run'))
 


### PR DESCRIPTION
BGLibPy Changelog:
 4.3.9:
 - Add support for a* targets in connection blocks

 4.3.8:
 - Vectorised usage of bluepy api for get_sonama_mecombo_emodels

 4.3.4:
 - Add node_properties_available to check if nodes.h5 can be used
 - Add get_sonata_mecombo_emodels to extract nodes.h5 properties
 - setup.py to use bluepy[sonata]>=0.14.12, needed for bluepysnap
 - Add bglibpy/tests/examples/sim_sonata_node/ test directory

 4.3:
 - Add ability to read inh/exc minis from sonata nodes file
 - Add use scaling based on hill coefficient / extracellular calcium concentration
 - Add ability to read conductance ratio from sonata nodes file
 - Rely on BluePy to read nrn.h5 version
 - Execute nosetests in parallel
 - Add OMP_NUM_THREADS=1 to test to avoid running out of resources
 - Stop testing for deprecation warning when using .syns
 - Use lru_cache to optimize bluepy query
 - Add CHANGELOG