### PR TITLE
Support codegen --opt-ionvar-copy in coreneuron recipe

### DIFF
--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -41,6 +41,7 @@ class Coreneuron(CMakePackage):
 
     # nmodl specific options
     variant('nmodl', default=False, description="Use NMODL instead of MOD2C")
+    variant('codegenopt', default=True, description="Use NMODL with codedgen ionvar copies optimizations")
     variant('sympy', default=False, description="Use NMODL with SymPy to solve ODEs")
     variant('sympyopt', default=False, description="Use NMODL with SymPy Optimizations")
     variant('ispc', default=False, description="Enable ISPC backend")
@@ -74,10 +75,13 @@ class Coreneuron(CMakePackage):
     depends_on('neurodamus-base@plasticity', when='@plasticity')
     depends_on('neurodamus-base@hippocampus', when='@hippocampus')
 
-    # sympy and ispc options are only usable with nmodl
+    
+
+    # sympy, codegen and ispc options are only usable with nmodl
     conflicts('+sympyopt', when='~sympy')
     conflicts('+sympy', when='~nmodl')
     conflicts('+sympy', when='coreneuron@0.17')  # issue with include directories
+    conflicts('~codegenopt', when='~nmodl') 
     conflicts('+ispc', when='~nmodl')
 
     # raise conflict when trying to install '+gpu' without PGI compiler
@@ -153,6 +157,9 @@ class Coreneuron(CMakePackage):
 
         nmodl_options = 'codegen --force'
 
+        if spec.satisfies('~codegenopt'):
+            nmodl_options += ' --opt-ionvar-copy=FALSE'
+
         if spec.satisfies('+ispc'):
             options.append('-DCORENRN_ENABLE_ISPC=ON')
             if '+knl' in spec:
@@ -213,6 +220,9 @@ class Coreneuron(CMakePackage):
                                      spec['eigen'].prefix.include.eigen3)
 
         nmodl_options = 'codegen --force passes --verbatim-rename --inline'
+
+        if spec.satisfies('~codegenopt'):
+            nmodl_options += ' --opt-ionvar-copy=FALSE'
 
         if spec.satisfies('+ispc'):
             options.append('-DENABLE_ISPC_TARGET=ON')

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -75,13 +75,11 @@ class Coreneuron(CMakePackage):
     depends_on('neurodamus-base@plasticity', when='@plasticity')
     depends_on('neurodamus-base@hippocampus', when='@hippocampus')
 
-    
-
     # sympy, codegen and ispc options are only usable with nmodl
     conflicts('+sympyopt', when='~sympy')
     conflicts('+sympy', when='~nmodl')
     conflicts('+sympy', when='coreneuron@0.17')  # issue with include directories
-    conflicts('~codegenopt', when='~nmodl') 
+    conflicts('~codegenopt', when='~nmodl')
     conflicts('+ispc', when='~nmodl')
 
     # raise conflict when trying to install '+gpu' without PGI compiler

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -41,7 +41,7 @@ class Coreneuron(CMakePackage):
 
     # nmodl specific options
     variant('nmodl', default=False, description="Use NMODL instead of MOD2C")
-    variant('codegenopt', default=True, description="Use NMODL with codedgen ionvar copies optimizations")
+    variant('codegenopt', default=False, description="Use NMODL with codedgen ionvar copies optimizations")
     variant('sympy', default=False, description="Use NMODL with SymPy to solve ODEs")
     variant('sympyopt', default=False, description="Use NMODL with SymPy Optimizations")
     variant('ispc', default=False, description="Enable ISPC backend")
@@ -79,7 +79,7 @@ class Coreneuron(CMakePackage):
     conflicts('+sympyopt', when='~sympy')
     conflicts('+sympy', when='~nmodl')
     conflicts('+sympy', when='coreneuron@0.17')  # issue with include directories
-    conflicts('~codegenopt', when='~nmodl')
+    conflicts('+codegenopt', when='~nmodl')
     conflicts('+ispc', when='~nmodl')
 
     # raise conflict when trying to install '+gpu' without PGI compiler
@@ -155,8 +155,8 @@ class Coreneuron(CMakePackage):
 
         nmodl_options = 'codegen --force'
 
-        if spec.satisfies('~codegenopt'):
-            nmodl_options += ' --opt-ionvar-copy=FALSE'
+        if spec.satisfies('+codegenopt'):
+            nmodl_options += ' --opt-ionvar-copy=TRUE'
 
         if spec.satisfies('+ispc'):
             options.append('-DCORENRN_ENABLE_ISPC=ON')
@@ -219,8 +219,8 @@ class Coreneuron(CMakePackage):
 
         nmodl_options = 'codegen --force passes --verbatim-rename --inline'
 
-        if spec.satisfies('~codegenopt'):
-            nmodl_options += ' --opt-ionvar-copy=FALSE'
+        if spec.satisfies('+codegenopt'):
+            nmodl_options += ' --opt-ionvar-copy=TRUE'
 
         if spec.satisfies('+ispc'):
             options.append('-DENABLE_ISPC_TARGET=ON')


### PR DESCRIPTION
CLI Nmodl options are passed to coreneuron during spack install.
There is a new option: codegen --opt-ionvar-copy=TRUE/FALSE.

New way to set that option to false (true by default):
spack install coreneuron@develop~codegenopt