### PR TITLE
Fix for Eigen URLs move to GitLab

### DIFF
--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -12,20 +12,22 @@ class Eigen(CMakePackage):
     """
 
     homepage = 'http://eigen.tuxfamily.org/'
-    url      = 'https://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2'
+    url      = 'https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz'
+    git      = 'https://gitlab.com/libeigen/eigen.git'
 
-    version('3.3.7', sha256='9f13cf90dedbe3e52a19f43000d71fdf72e986beb9a5436dddcd61ff9d77a3ce')
-    version('3.3.6', sha256='6019aff3c9c32bc72f1a82590e66d0efdcea0eb669b487e66e772c80f12d674d')
-    version('3.3.5', sha256='7352bff3ea299e4c7d7fbe31c504f8eb9149d7e685dec5a12fbaa26379f603e2')
-    version('3.3.4', sha256='dd254beb0bafc695d0f62ae1a222ff85b52dbaa3a16f76e781dce22d0d20a4a6')
-    version('3.3.3', sha256='a4143fc45e4454b4b98fcea3516b3a79b8cdb3bc7fadf996d088c6a0d805fea1')
-    version('3.3.2', sha256='3e1fa6e8c45635938193f84fee6c35a87fac26ee7c39c68c230e5080c4a8fe98')
-    version('3.3.1', sha256='a0b4cebaabd8f371d1b364f9723585fbcc7c9640ca60273b99835e6cf115f056')
-    version('3.3.0', sha256='e3cf8f9289de20540a79c9c5653bbe623cadd6202bfe9692e95c420b5adbb7e7')
-    version('3.2.10', sha256='760e6656426fde71cc48586c971390816f456d30f0b5d7d4ad5274d8d2cb0a6d')
-    version('3.2.9', sha256='4d1e036ec1ed4f4805d5c6752b76072d67538889f4003fadf2f6e00a825845ff')
-    version('3.2.8', sha256='722a63d672b70f39c271c5e2a4a43ba14d12015674331790414fcb167c357e55')
-    version('3.2.7', sha256='e58e1a11b23cf2754e32b3c5990f318a8461a3613c7acbf6035870daa45c2f3e')
+    version('develop', submodules=True)
+    version('3.3.7', sha256='d56fbad95abf993f8af608484729e3d87ef611dd85b3380a8bad1d5cbc373a57')
+    version('3.3.6', sha256='e7cd8c94d6516d1ada9893ccc7c9a400fcee99927c902f15adba940787104dba')
+    version('3.3.5', sha256='383407ab3d0c268074e97a2cbba84ac197fd24532f014aa2adc522355c1aa2d0')
+    version('3.3.4', sha256='c5ca6e3442fb48ae75159ca7568854d9ba737bc351460f27ee91b6f3f9fd1f3d')
+    version('3.3.3', sha256='fd72694390bd8e81586205717d2cf823e718f584b779a155db747d1e68481a2e')
+    version('3.3.2', sha256='8d7611247fba1236da4dee7a64607017b6fb9ca5e3f0dc44d480e5d33d5663a5')
+    version('3.3.1', sha256='50dd21a8997fce0857b27a126811ae8ee7619984ab5425ecf33510cec649e642')
+    version('3.3.0', sha256='de82e01f97e1a95f121bd3ace87aa1237818353c14e38f630a65f5ba2c92f0e1')
+    version('3.2.10', sha256='0920cb60ec38de5fb509650014eff7cc6d26a097c7b38c7db4b1aa5df5c85042')
+    version('3.2.9', sha256='f683b20259ad72c3d384c00278166dd2a42d99b78dcd589ed4a6ca74bbb4ca07')
+    version('3.2.8', sha256='64c54781cfe9eefef2792003ab04b271d4b2ec32eda6e9cdf120d7aad4ebb282')
+    version('3.2.7', sha256='0ea9df884873275bf39c2965d486fa2d112f3a64b97b60b45b8bc4bb034a36c1')
 
     variant('metis', default=False,
             description='Enables metis permutations in sparse algebra')

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -1,9 +1,7 @@
-# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from spack import *
 
 
 class Eigen(CMakePackage):
@@ -12,10 +10,8 @@ class Eigen(CMakePackage):
     """
 
     homepage = 'http://eigen.tuxfamily.org/'
-    url      = 'https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz'
-    git      = 'https://gitlab.com/libeigen/eigen.git'
+    url = 'https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz'
 
-    version('develop', submodules=True)
     version('3.3.7', sha256='d56fbad95abf993f8af608484729e3d87ef611dd85b3380a8bad1d5cbc373a57')
     version('3.3.6', sha256='e7cd8c94d6516d1ada9893ccc7c9a400fcee99927c902f15adba940787104dba')
     version('3.3.5', sha256='383407ab3d0c268074e97a2cbba84ac197fd24532f014aa2adc522355c1aa2d0')
@@ -28,34 +24,21 @@ class Eigen(CMakePackage):
     version('3.2.9', sha256='f683b20259ad72c3d384c00278166dd2a42d99b78dcd589ed4a6ca74bbb4ca07')
     version('3.2.8', sha256='64c54781cfe9eefef2792003ab04b271d4b2ec32eda6e9cdf120d7aad4ebb282')
     version('3.2.7', sha256='0ea9df884873275bf39c2965d486fa2d112f3a64b97b60b45b8bc4bb034a36c1')
+    version('3.2.6', sha256='e097b8dcc5ad30d40af4ad72d7052e3f78639469baf83cffaadc045459cda21f')
+    version('3.2.5', sha256='8068bd528a2ff3885eb55225c27237cf5cda834355599f05c2c85345db8338b4')
 
-    variant('metis', default=False,
-            description='Enables metis permutations in sparse algebra')
-    variant('scotch', default=False,
-            description='Enables scotch/pastix sparse factorization methods')
-    variant('fftw', default=False,
-            description='Enables FFTW backend for the FFT plugin')
-    variant('suitesparse', default=False,
-            description='Enables SuiteSparse sparse factorization methods')
-    variant('mpfr', default=False,
-            description='Enables the multi-precisions floating-point plugin')
+    # From http://eigen.tuxfamily.org/index.php?title=Main_Page#Requirements
+    # "Eigen doesn't have any dependencies other than the C++ standard
+    # library."
     variant('build_type', default='RelWithDebInfo',
             description='The build type to build',
             values=('Debug', 'Release', 'RelWithDebInfo'))
 
-    # TODO : dependency on googlehash, superlu, adolc missing
-    depends_on('metis@5:', when='+metis')
-    depends_on('scotch', when='+scotch')
-    depends_on('fftw', when='+fftw')
-    depends_on('suite-sparse', when='+suitesparse')
-    depends_on('mpfr@2.3.0:', when='+mpfr')
-    depends_on('gmp', when='+mpfr')
+    # TODO: latex and doxygen needed to produce docs with make doc
+    # TODO: Other dependencies might be needed to test this package
 
-    patch('find-ptscotch.patch', when='@3.3.4')
-
-    def setup_environment(self, spack_env, run_env):
-        run_env.prepend_path('CPATH',
-                             join_path(self.prefix, 'include', 'eigen3'))
+    def setup_run_environment(self, env):
+        env.prepend_path('CPATH', self.prefix.include.eigen3)
 
     @property
     def headers(self):


### PR DESCRIPTION
The URLs of the Eigen package [have recently moved to GitLab](http://eigen.tuxfamily.org/index.php?title=News:Eigen_is_now_on_GitLab.com). This commit updates the base URL for the `.tar.gz`, the hashes per package version, and also adds the `develop` branch to allow downloading the source code from the Git repository.