### PR TITLE
py-neurodamus: remove scipy dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -29,7 +29,6 @@ class PyNeurodamus(PythonPackage):
     depends_on('py-docopt',        type='run')
     depends_on('py-lazy-property', type='run', when='@:1.0.0')
     depends_on('py-six',           type='run', when='@:1.0.0')
-    depends_on('py-scipy',         type='run', when='@1.2.0:')
 
     @run_after('install')
     def install_scripts(self):


### PR DESCRIPTION
The ```scipy``` dependency was added in ```neurodamus-py``` to calculate a scale factor for the synapse "U" parameter using ```scipy.optimize.fsolve```. Later the calculation was improved and ```fsolve``` has already been removed in the code.
Therefore, we can remove the ```scipy``` dependency from the spack recipe.