### PR TITLE
Update CoreNEURON recipe with explicit dependency on python

### DIFF
--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -19,7 +19,7 @@ class Coreneuron(CMakePackage):
     git      = "https://github.com/BlueBrain/CoreNeuron"
 
     version('develop', branch='master', submodules=True)
-    version('0.21a', commit="bf3c823", preferred=True)
+    version('0.21a', commit="bf3c823", submodules=True, preferred=True)
     version('0.20', tag='0.20', submodules=True)
     version('0.19', tag='0.19', submodules=True)
     version('0.18', tag='0.18', submodules=True)
@@ -49,6 +49,7 @@ class Coreneuron(CMakePackage):
     depends_on('bison', type='build')
     depends_on('cmake@3:', type='build')
     depends_on('flex', type='build')
+    depends_on('python', type='build')
 
     depends_on('boost', when='+tests')
     depends_on('cuda', when='+gpu')
@@ -144,7 +145,8 @@ class Coreneuron(CMakePackage):
              % ('ON' if '+openmp' in spec else 'OFF'),
              '-DCORENRN_ENABLE_UNIT_TESTS=%s'
              % ('ON' if '+tests' in spec else 'OFF'),
-             '-DCORENRN_ENABLE_TIMEOUT=OFF'
+             '-DCORENRN_ENABLE_TIMEOUT=OFF',
+             '-DPYTHON_EXECUTABLE=%s' % spec["python"].command.path
              ]
 
         if spec.satisfies('+nmodl'):


### PR DESCRIPTION
To add some context, this PR is fixing some issues encountered while installing CoreNEURON on MacOS. 
Some submodules were not being found and there was a conflict between python2/3 versions.

Below are the changes.

* switched on submodules for version 0.21a
* added explicit dependency on python
* modified cmake arguments to pick up correct python version

Co-authored-by: Pramod Kumbhar <pramod.kumbhar@epfl.ch>

