### PR TITLE
Fix /simplify Neuron archdir detection

### DIFF
--- a/lib/spack/spack/test/python_version.py
+++ b/lib/spack/spack/test/python_version.py
@@ -89,7 +89,7 @@ def pyfiles(search_paths, exclude=()):
                     yield os.path.join(root, filename)
 
 
-def check_python_versions(files, warn_only_py26=False):
+def check_python_versions(files):
     """Check that a set of Python files works with supported Ptyhon versions"""
     # This is a dict dict mapping:
     #   version -> filename -> reasons
@@ -97,7 +97,6 @@ def check_python_versions(files, warn_only_py26=False):
     # Reasons are tuples of (lineno, string), where the string is the
     # cause for a version incompatibility.
     all_issues = {}
-    non_fatal_issue_count = 0
 
     # Parse files and run pyqver on each file.
     for path in files:
@@ -108,9 +107,6 @@ def check_python_versions(files, warn_only_py26=False):
         for ver, reasons in versions.items():
             if ver <= spack_min_supported:
                 continue
-
-            if ver == (2, 7) and warn_only_py26:
-                non_fatal_issue_count += 1
 
             # Record issues. Mark exceptions with '# nopyqver' comment
             for lineno, cause in reasons:
@@ -146,8 +142,8 @@ def check_python_versions(files, warn_only_py26=False):
         for msg in messages:
             print(fmt % msg)
 
-    # Fail this test if there were no fatal issues.
-    assert len(all_issues) == non_fatal_issue_count
+    # Fail this test if there were issues.
+    assert not all_issues
 
 
 @pytest.mark.maybeslow
@@ -160,5 +156,4 @@ def test_core_module_compatibility():
 @pytest.mark.maybeslow
 def test_package_module_compatibility():
     """Test that all spack packages work with supported Python versions."""
-    check_python_versions(pyfiles([spack.paths.packages_path]),
-                          warn_only_py26=True)
+    check_python_versions(pyfiles([spack.paths.packages_path]))

--- a/var/spack/repos/builtin/packages/libsonata-report/package.py
+++ b/var/spack/repos/builtin/packages/libsonata-report/package.py
@@ -34,6 +34,7 @@ class LibsonataReport(CMakePackage):
         result = [
             '-DEXTLIB_FROM_SUBMODULES=ON',
             '-DREPORTS_ONLY=ON',
+            '-DCMAKE_CXX_FLAGS=-DFMT_HEADER_ONLY=1'
         ]
         if self.spec.satisfies('+mpi'):
             result.extend([

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -371,7 +371,7 @@ class Neuron(CMakePackage):
         return subprocess.Popen(
             ['awk', '-F=', '$1 == "MODSUBDIR" { print $2; exit; }',
              str(self.prefix.bin.nrnivmodl)],
-             stdout=subprocess.PIPE
+            stdout=subprocess.PIPE
         ).communicate()[0].decode().strip()
 
     @property

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -368,23 +368,10 @@ class Neuron(CMakePackage):
         neuron"s configure we dynamically find the architecture-
         specific directory by looking for a specific binary.
         """
-        if self.spec.satisfies("+cmake"):
-            # TODO : fix this when neuron provides an easy way to
-            # detect arch directory
-            neuron_arch = subprocess.Popen(["uname", "-p"],
-                                           stdout=subprocess.PIPE) \
-                .communicate()[0].decode('UTF-8').rstrip()
-        else:
-            file_list = find(self.prefix, "*/bin/nrniv_makefile")
-            # check needed as when initially evaluated the prefix is empty
-            if file_list:
-                neuron_arch = \
-                    os.path.basename(
-                        os.path.dirname(os.path.dirname(file_list[0]))
-                    )
-            else:
-                neuron_arch = ""
-        return neuron_arch
+        return subprocess.check_output(
+            ['awk', '-F=', '$1 == "MODSUBDIR" { print $2; exit; }',
+             str(self.prefix.bin.nrnivmodl)]
+        ).decode().strip()
 
     @property
     def basedir(self):

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -368,10 +368,11 @@ class Neuron(CMakePackage):
         neuron"s configure we dynamically find the architecture-
         specific directory by looking for a specific binary.
         """
-        return subprocess.check_output(
+        return subprocess.Popen(
             ['awk', '-F=', '$1 == "MODSUBDIR" { print $2; exit; }',
-             str(self.prefix.bin.nrnivmodl)]
-        ).decode().strip()
+             str(self.prefix.bin.nrnivmodl)],
+             stdout=subprocess.PIPE
+        ).communicate()[0].decode().strip()
 
     @property
     def basedir(self):


### PR DESCRIPTION
Instead of relying on build system dependent, we use (parse)
nrnivmodl to get the exact same
This was affecting mac users, as well as the FMT lib