### PR TITLE
Adding Neurodamus new series (3.0)

### DIFF
--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -19,7 +19,7 @@ class Coreneuron(CMakePackage):
     git      = "https://github.com/BlueBrain/CoreNeuron"
 
     version('develop', branch='master', submodules=True)
-    version('0.21a', commit="bf3c823", preferred=True)
+    version('0.21a', commit="bf3c823", submodules=True, preferred=True)
     version('0.20', tag='0.20', submodules=True)
     version('0.19', tag='0.19', submodules=True)
     version('0.18', tag='0.18', submodules=True)
@@ -49,6 +49,7 @@ class Coreneuron(CMakePackage):
     depends_on('bison', type='build')
     depends_on('cmake@3:', type='build')
     depends_on('flex', type='build')
+    depends_on('python', type='build')
 
     depends_on('boost', when='+tests')
     depends_on('cuda', when='+gpu')
@@ -144,7 +145,8 @@ class Coreneuron(CMakePackage):
              % ('ON' if '+openmp' in spec else 'OFF'),
              '-DCORENRN_ENABLE_UNIT_TESTS=%s'
              % ('ON' if '+tests' in spec else 'OFF'),
-             '-DCORENRN_ENABLE_TIMEOUT=OFF'
+             '-DCORENRN_ENABLE_TIMEOUT=OFF',
+             '-DPYTHON_EXECUTABLE=%s' % spec["python"].command.path
              ]
 
         if spec.satisfies('+nmodl'):

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -19,7 +19,8 @@ class Coreneuron(CMakePackage):
     git      = "https://github.com/BlueBrain/CoreNeuron"
 
     version('develop', branch='master', submodules=True)
-    version('0.21a', commit="bf3c823", submodules=True, preferred=True)
+    version('0.22', tag='0.22', submodules=True, preferred=True)
+    version('0.21a', commit="bf3c823", submodules=True)
     version('0.20', tag='0.20', submodules=True)
     version('0.19', tag='0.19', submodules=True)
     version('0.18', tag='0.18', submodules=True)

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -20,7 +20,8 @@ class NeurodamusCore(SimModel):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', branch='master', get_full_repo=False)
-    version('2.11.1', tag='2.11.1', get_full_repo=False, preferred=True)
+    version('3.0.0',  tag='3.0.0', get_full_repo=False)
+    version('2.11.1', tag='2.11.1', get_full_repo=False)
     version('2.11.0', tag='2.11.0', get_full_repo=False)
     version('2.10.1', tag='2.10.1', get_full_repo=False)
     version('2.10.0', tag='2.10.0', get_full_repo=False)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -17,6 +17,7 @@ class NeurodamusHippocampus(NeurodamusModel):
     mech_name = "hippocampus"
 
     version('develop', branch='master', submodules=True, get_full_repo=False)
+    version('1.0', tag='1.0', submodules=True, get_full_repo=False)
     version('0.4', tag='0.4-1', submodules=True, get_full_repo=False)
     version('0.3', tag='0.3', submodules=True, get_full_repo=False)
     version('0.2', tag='0.2', submodules=True, get_full_repo=False)

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -28,7 +28,7 @@ class NeurodamusModel(SimModel):
     # 'run' mode will load the same mpi module
     depends_on("mpi", type=('build', 'run'))
     depends_on('neurodamus-core', type=('build', 'run'))
-    depends_on('neurodamus-core@:3.0', type=('build', 'run'), when='@:1.0')
+    depends_on('neurodamus-core@:2.99', type=('build', 'run'), when='@:0.99')
     depends_on('neurodamus-core@develop', type=('build', 'run'), when='@develop')
     depends_on('hdf5+mpi')
     depends_on('reportinglib')

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -28,6 +28,7 @@ class NeurodamusModel(SimModel):
     # 'run' mode will load the same mpi module
     depends_on("mpi", type=('build', 'run'))
     depends_on('neurodamus-core', type=('build', 'run'))
+    depends_on('neurodamus-core@:3.0', type=('build', 'run'), when='@:1.0')
     depends_on('neurodamus-core@develop', type=('build', 'run'), when='@develop')
     depends_on('hdf5+mpi')
     depends_on('reportinglib')

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -17,6 +17,7 @@ class NeurodamusMousify(NeurodamusModel):
     mech_name = "mousify"
 
     version('develop', branch='master', submodules=True, get_full_repo=False)
-    version('0.3', git=git, tag='0.3-1', submodules=True, get_full_repo=False)
-    version('0.2', git=git, tag='0.2', submodules=True, get_full_repo=False)
-    version('0.1', git=git, tag='0.1', submodules=True, get_full_repo=False)
+    version('1.0', tag='1.0', submodules=True, get_full_repo=False)
+    version('0.3', tag='0.3-1', submodules=True, get_full_repo=False)
+    version('0.2', tag='0.2', submodules=True, get_full_repo=False)
+    version('0.1', tag='0.1', submodules=True, get_full_repo=False)

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -15,6 +15,7 @@ class NeurodamusNeocortex(NeurodamusModel):
     git      = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
 
     version('develop', branch='master', submodules=True, get_full_repo=True)
+    version('1.0', tag='1.0', submodules=True, get_full_repo=True)
     version('0.3', tag='0.3-1', submodules=True, get_full_repo=True)
     version('0.2', tag='0.2', submodules=True, get_full_repo=True)
     version('0.1', tag='0.1', submodules=True, get_full_repo=True)

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -16,6 +16,7 @@ class NeurodamusThalamus(NeurodamusModel):
     mech_name = "thalamus"
 
     version('develop', branch='master', submodules=True, get_full_repo=False)
+    version('1.0', tag='1.0', submodules=True, get_full_repo=False)
     version('0.3', tag='0.3-1', submodules=True, get_full_repo=False)
     version('0.2', tag='0.2', submodules=True, get_full_repo=False)
     version('0.1', tag='0.1', submodules=True, get_full_repo=False)

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
+    version('2.0.0',   tag='2.0.0')
     version('1.3.2',   tag='1.3.2')
     version('1.3.1',   tag='1.3.1')
     version('1.3.0',   tag='1.3.0')


### PR DESCRIPTION
Neurodamus-Core, -py and all models were bumped to latest version, a major one due to different behavior (eg RNG...) and incompat with old models (Delayed connections)

Brings:
 - neurodamus-core 3.0
 - neocortex, hippocampus, thalamus, mousify 1.0
 - neurodamus-py 2.0
 - coreneuron 0.22