### PR TITLE
Bglibpy 4.4.10

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -124,7 +124,7 @@ packages:
       - nest@2.18.0
       - py-efel@3.0.80
       - py-bluepyefe@0.3.13
-      - py-bglibpy@4.4 ^neuron%intel@19.0.4
+      - py-bglibpy@4.4.6 ^neuron%intel@19.0.4
       - py-bluepy@0.14.14
       - py-bluepymm@0.7.49 ^neuron%intel@19.0.4
       - py-bluepyopt@1.9.27 ^neuron%intel@19.0.4

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -124,7 +124,7 @@ packages:
       - nest@2.18.0
       - py-efel@3.0.80
       - py-bluepyefe@0.3.13
-      - py-bglibpy@4.4.6 ^neuron%intel@19.0.4
+      - py-bglibpy@4.4.10 ^neuron%intel@19.0.4
       - py-bluepy@0.14.14
       - py-bluepymm@0.7.49 ^neuron%intel@19.0.4
       - py-bluepyopt@1.9.27 ^neuron%intel@19.0.4

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -14,6 +14,7 @@ class PyBglibpy(PythonPackage):
 
     version('develop', branch='master')
 
+    version('4.4.6', commit='18e211153025535ebecb7e0a9868033b1462bec1')
     version('4.4', commit='4597bf81374f4041f689a4e73e4319bf5c13947b')
     version('4.3.19', commit='bce00a1ddedb605a5ed5225989192eb5f7e133ae')
     version('4.3.15', commit='dccd717a2570d32776de824d864fba9dfdbf56f6')

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -14,6 +14,7 @@ class PyBglibpy(PythonPackage):
 
     version('develop', branch='master')
 
+    version('4.4.10', commit='53db9eee6f0b4e025f19c271b3235831f86c866e')
     version('4.4.6', commit='18e211153025535ebecb7e0a9868033b1462bec1')
     version('4.4', commit='4597bf81374f4041f689a4e73e4319bf5c13947b')
     version('4.3.19', commit='bce00a1ddedb605a5ed5225989192eb5f7e133ae')


### PR DESCRIPTION
The additional dependencies of bglibpy that are not mentioned in the spack package are removed in this version. They were not directly required by bglibpy in the first place.
