### PR TITLE
Bump neurodamus for most recent patches

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -41,7 +41,7 @@ packages:
       - py-simwriter@1.0.1
       - py-morph-tool@0.2.5
       - py-morphio@2.3.4
-      - py-neurodamus@2.0.1
+      - py-neurodamus@2.0.2
       - py-sonata-network-reduction@0.1.0 ^neuron%intel@19.0.4^py-ipython%gcc
 
   gnu-stable-serial-ophiophob:

--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -41,8 +41,7 @@ packages:
       - py-simwriter@1.0.1
       - py-morph-tool@0.2.5
       - py-morphio@2.3.4
-      - py-neurodamus@1.3.2
-      - py-neurodamus@2.0.0
+      - py-neurodamus@2.0.1
       - py-sonata-network-reduction@0.1.0 ^neuron%intel@19.0.4^py-ipython%gcc
 
   gnu-stable-serial-ophiophob:
@@ -138,8 +137,7 @@ packages:
       - architecture
       - compiler
     specs:
-      - neurodamus-core+common@2.11.1
-      - neurodamus-core+common@3.0.0
+      - neurodamus-core+common@3.0.1
       - ultraliser
 
   intel-stable:
@@ -170,7 +168,7 @@ packages:
       - mpi
       - python
     specs:
-      - neurodamus-core~common@3.0.0
+      - neurodamus-core~common@3.0.1
       - neurodamus-neocortex+coreneuron@1.0
       - neurodamus-hippocampus+coreneuron@1.0
       - neurodamus-thalamus+coreneuron@1.0

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -20,6 +20,7 @@ class NeurodamusCore(SimModel):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', branch='master', get_full_repo=False)
+    version('3.0.1',  tag='3.0.1', get_full_repo=False)
     version('3.0.0',  tag='3.0.0', get_full_repo=False)
     version('2.11.1', tag='2.11.1', get_full_repo=False)
     version('2.11.0', tag='2.11.0', get_full_repo=False)

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
+    version('2.0.1',   tag='2.0.1')
     version('2.0.0',   tag='2.0.0')
     version('1.3.2',   tag='1.3.2')
     version('1.3.1',   tag='1.3.1')

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,7 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
-    version('2.0.1',   tag='2.0.1')
+    version('2.0.2',   tag='2.0.2')
     version('2.0.0',   tag='2.0.0')
     version('1.3.2',   tag='1.3.2')
     version('1.3.1',   tag='1.3.1')


### PR DESCRIPTION
Since release 3.0 neurodamus received a few important fixes. 
Including them as a new patch version still in this month archive.

Bump neurodamus-py 2.0.0 to 2.0.2:
 - Fixing replay to work with multiple populations
 - Ensure data dir when skipping model build
 - Fix skipping synapse creation when weight is 0 (BBPBGLIB-673)
 - Fix deadlock when an exception is thrown from NEURON (BBPBGLIB-678)
 - Logging colors only for tty

Bump neurodamus-core 3.0.0 to 3.0.1:
 - Avoid getting nilSecRef from objects (HPCTM-1381)