### PR TITLE
NEURON and CoreNEURON should use legacy units for BBP/HBP deployment

### DIFF
--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -150,6 +150,9 @@ class Coreneuron(CMakePackage):
              '-DPYTHON_EXECUTABLE=%s' % spec["python"].command.path
              ]
 
+        if spec.satisfies('@0.23:'):
+            options.append('-DCORENRN_ENABLE_LEGACY_UNITS=ON')
+
         if spec.satisfies('+nmodl'):
             options.append('-DCORENRN_ENABLE_NMODL=ON')
             options.append('-DCORENRN_NMODL_DIR=%s' % spec['nmodl'].prefix)

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -144,6 +144,8 @@ class Neuron(CMakePackage):
             args.append("-DNRN_ENABLE_MOD_COMPATIBILITY:BOOL=ON")
         if "+binary" in self.spec:
             args.append("-DNRN_ENABLE_BINARY_SPECIAL=ON")
+        if self.spec.satisfies('@7.9.0b:'):
+            args.append('-DNRN_DYNAMIC_UNITS_USE_LEGACY=ON')
 
         return args
 


### PR DESCRIPTION
See https://github.com/neuronsimulator/nrn/pull/805/

@ferdonline @alexsavulescu @iomaganaris : FYI. BBP/HBP should use legacy units by default (until we sync with scientific teams).