### PR TITLE
Bump py-importlib-metadata to next release 1.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
@@ -12,6 +12,7 @@ class PyImportlibMetadata(PythonPackage):
     homepage = "http://importlib-metadata.readthedocs.io/"
     url      = "https://pypi.io/packages/source/i/importlib_metadata/importlib_metadata-0.23.tar.gz"
 
+    version('1.0.0', sha256='a82ca8c109e194d7d6aee3f7531b0470dd4dd6b36ec14fd55087142a96bd55a7')
     version('0.23', sha256='aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26')
     version('0.19', sha256='23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8')
 


### PR DESCRIPTION
  - pytest and other packages are failing in production
  - bump py-importlib-metadata to retrigger deployment