### PR TITLE
Bring latest LLVM 12.0 from upstream and enable GPU (CUDA/OpenMP support)

### DIFF
--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -21,7 +21,7 @@ spack:
     timemory:
       variants: +mpi~cuda~cupti+caliper~gperftools~python
   specs:
-    - llvm@11.0.0 +python
+    - llvm@12.0.0 +cuda cuda_arch=70 +omp_tsan +python ^cuda@11.0.2
     - nvhpc@20.9 install_type=network
     - nvhpc@21.2 install_type=network
     - arm-forge@20.2.0-Redhat-7.0-x86_64

--- a/var/spack/repos/builtin/packages/llvm/llvm7_intel.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm7_intel.patch
@@ -1,0 +1,50 @@
+diff --git a/llvm/include/llvm/ADT/StringExtras.h b/llvm/include/llvm/ADT/StringExtras.h
+index 71b0e7527cb..3304a378f37 100644
+--- a/llvm/include/llvm/ADT/StringExtras.h
++++ b/llvm/include/llvm/ADT/StringExtras.h
+@@ -369,7 +369,7 @@ inline size_t join_items_size(const A1 &A, Args &&... Items) {
+ template <typename IteratorT>
+ inline std::string join(IteratorT Begin, IteratorT End, StringRef Separator) {
+   using tag = typename std::iterator_traits<IteratorT>::iterator_category;
+-  return detail::join_impl(Begin, End, Separator, tag());
++  return llvm::detail::join_impl(Begin, End, Separator, tag());
+ }
+ 
+ /// Joins the strings in the range [R.begin(), R.end()), adding Separator
+diff --git a/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h b/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
+index 25b2efd33c9..40144d96044 100644
+--- a/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
++++ b/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
+@@ -186,8 +186,9 @@ public:
+   /// topological sort) and it's class is the same regardless of block type.
+   struct BlockNode {
+     using IndexType = uint32_t;
++    using IndexTypeLimits = std::numeric_limits<IndexType>;
+ 
+-    IndexType Index = std::numeric_limits<uint32_t>::max();
++    IndexType Index = IndexTypeLimits::max();
+ 
+     BlockNode() = default;
+     BlockNode(IndexType Index) : Index(Index) {}
+diff --git a/llvm/lib/ExecutionEngine/Orc/Core.cpp b/llvm/lib/ExecutionEngine/Orc/Core.cpp
+index 4325d57f73d..96e1e1d5503 100644
+--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
++++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
+@@ -1423,7 +1423,7 @@ VSO::lookupImpl(std::shared_ptr<AsynchronousSymbolQuery> &Q,
+     if (SymI->second.getAddress() != 0) {
+       Q->resolve(Name, SymI->second);
+       if (Q->isFullyResolved())
+-        ActionFlags |= NotifyFullyResolved;
++        ActionFlags = static_cast<LookupImplActionFlags>(ActionFlags | NotifyFullyResolved);
+     }
+ 
+     // If the symbol is lazy, get the MaterialiaztionUnit for it.
+@@ -1456,7 +1456,7 @@ VSO::lookupImpl(std::shared_ptr<AsynchronousSymbolQuery> &Q,
+       // continue.
+       Q->notifySymbolReady();
+       if (Q->isFullyReady())
+-        ActionFlags |= NotifyFullyReady;
++        ActionFlags = static_cast<LookupImplActionFlags>(ActionFlags | NotifyFullyReady);
+       continue;
+     }
+ 

--- a/var/spack/repos/builtin/packages/llvm/llvm_python_path.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm_python_path.patch
@@ -1,0 +1,14 @@
+diff --git a/compiler-rt/cmake/Modules/AddCompilerRT.cmake b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+index dab55707338..6f4c6791141 100644
+--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
++++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+@@ -612,6 +612,9 @@ macro(add_custom_libcxx name prefix)
+     CMAKE_OBJDUMP
+     CMAKE_STRIP
+     CMAKE_SYSROOT
++    PYTHON_EXECUTABLE
++    Python3_EXECUTABLE
++    Python2_EXECUTABLE
+     CMAKE_SYSTEM_NAME)
+   foreach(variable ${PASSTHROUGH_VARIABLES})
+     get_property(is_value_set CACHE ${variable} PROPERTY VALUE SET)

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -27,12 +27,16 @@ class Llvm(CMakePackage, CudaPackage):
     family = "compiler"  # Used by lmod
 
     # fmt: off
-    version('master', branch='master')
+    version('main', branch='main')
+    version('12.0.0', sha256='8e6c99e482bb16a450165176c2d881804976a2d770e0445af4375e78a1fbf19c')
+    version('11.1.0', sha256='53a0719f3f4b0388013cfffd7b10c7d5682eece1929a9553c722348d1f866e79')
+    version('11.0.1', sha256='9c7ad8e8ec77c5bde8eb4afa105a318fd1ded7dff3747d14f012758719d7171b')
     version('11.0.0', sha256='8ad4ddbafac4f2c8f2ea523c2c4196f940e8e16f9e635210537582a48622a5d5')
     version('10.0.1', sha256='c7ccb735c37b4ec470f66a6c35fbae4f029c0f88038f6977180b1a8ddc255637')
     version('10.0.0', sha256='b81c96d2f8f40dc61b14a167513d87c0d813aae0251e06e11ae8a4384ca15451')
     version('9.0.1', sha256='be7b034641a5fda51ffca7f5d840b1a768737779f75f7c4fd18fe2d37820289a')
     version('9.0.0', sha256='7807fac25330e24e9955ca46cd855dd34bbc9cc4fdba8322366206654d1036f2')
+    version('8.0.1', sha256='5b18f6111c7aee7c0933c355877d4abcfe6cb40c1a64178f28821849c725c841')
     version('8.0.0', sha256='d81238b4a69e93e29f74ce56f8107cbfcf0c7d7b40510b7879e98cc031e25167')
     version('7.1.0', sha256='71c93979f20e01f1a1cc839a247945f556fa5e63abf2084e8468b238080fd839')
     version('7.0.1', sha256='f17a6cd401e8fd8f811fbfbb36dcb4f455f898c9d03af4044807ad005df9f3c0')
@@ -61,6 +65,12 @@ class Llvm(CMakePackage, CudaPackage):
         "clang",
         default=True,
         description="Build the LLVM C/C++/Objective-C compiler frontend",
+    )
+    variant(
+        "flang",
+        default=False,
+        description="Build the LLVM Fortran compiler frontend "
+        "(experimental - parser only, needs GCC)",
     )
     variant(
         "omp_debug",
@@ -140,6 +150,7 @@ class Llvm(CMakePackage, CudaPackage):
     depends_on("cmake@3.4.3:", type="build")
     depends_on("python@2.7:2.8", when="@:4.999 ~python", type="build")
     depends_on("python", when="@5: ~python", type="build")
+    depends_on("pkgconfig", type="build")
 
     # Universal dependency
     depends_on("python@2.7:2.8", when="@:4.999+python")
@@ -161,7 +172,7 @@ class Llvm(CMakePackage, CudaPackage):
     depends_on("py-six", when="@5.0.0: +lldb +python")
 
     # gold support, required for some features
-    depends_on("binutils+gold", when="+gold")
+    depends_on("binutils+gold+ld+plugins", when="+gold")
 
     # polly plugin
     depends_on("gmp", when="@:3.6.999 +polly")
@@ -172,6 +183,9 @@ class Llvm(CMakePackage, CudaPackage):
     conflicts("+libcxx", when="~clang")
     conflicts("+internal_unwind", when="~clang")
     conflicts("+compiler-rt", when="~clang")
+    conflicts("+flang", when="~clang")
+    # Introduced in version 11 as a part of LLVM and not a separate package.
+    conflicts("+flang", when="@:10.999")
 
     # LLVM 4 and 5 does not build with GCC 8
     conflicts("%gcc@8:", when="@:5")
@@ -199,6 +213,11 @@ class Llvm(CMakePackage, CudaPackage):
             "system debug server",
     )
 
+    # LLVM bug https://bugs.llvm.org/show_bug.cgi?id=48234
+    # CMake bug: https://gitlab.kitware.com/cmake/cmake/-/issues/21469
+    # Fixed in upstream versions of both
+    conflicts('^cmake@3.19.0', when='@6.0.0:11.0.0')
+
     # Github issue #4986
     patch("llvm_gcc7.patch", when="@4.0.0:4.0.1+lldb %gcc@7.0:")
     # Backport from llvm master + additional fix
@@ -216,14 +235,21 @@ class Llvm(CMakePackage, CudaPackage):
     patch("thread-p9.patch", when="@develop+libcxx")
 
     # https://github.com/spack/spack/issues/19625,
-    # merged in llvm-11.0.0_rc2
-    patch("lldb_external_ncurses-10.patch", when="@10.0.0:10.99+lldb")
+    # merged in llvm-11.0.0_rc2, but not found in 11.0.1
+    patch("lldb_external_ncurses-10.patch", when="@10.0.0:11.0.1+lldb")
+
+    # https://github.com/spack/spack/issues/19908
+    # merged in llvm main prior to 12.0.0
+    patch("llvm_python_path.patch", when="@11.0.0")
+
+    # Workaround for issue https://github.com/spack/spack/issues/18197
+    patch('llvm7_intel.patch', when='@7 %intel@18.0.2,19.0.4')
 
     # The functions and attributes below implement external package
     # detection for LLVM. See:
     #
     # https://spack.readthedocs.io/en/latest/packaging_guide.html#making-a-package-discoverable-with-spack-external-find
-    executables = ['clang', 'ld.lld', 'lldb']
+    executables = ['clang', 'flang', 'ld.lld', 'lldb']
 
     @classmethod
     def filter_detected_exes(cls, prefix, exes_in_prefix):
@@ -242,11 +268,11 @@ class Llvm(CMakePackage, CudaPackage):
     def determine_version(cls, exe):
         version_regex = re.compile(
             # Normal clang compiler versions are left as-is
-            r'clang version ([^ )]+)-svn[~.\w\d-]*|'
+            r'clang version ([^ )\n]+)-svn[~.\w\d-]*|'
             # Don't include hyphenated patch numbers in the version
             # (see https://github.com/spack/spack/pull/14365 for details)
-            r'clang version ([^ )]+?)-[~.\w\d-]*|'
-            r'clang version ([^ )]+)|'
+            r'clang version ([^ )\n]+?)-[~.\w\d-]*|'
+            r'clang version ([^ )\n]+)|'
             # LLDB
             r'lldb version ([^ )\n]+)|'
             # LLD
@@ -276,6 +302,10 @@ class Llvm(CMakePackage, CudaPackage):
                 compilers['cxx'] = exe
             elif 'clang' in exe:
                 compilers['c'] = exe
+            elif 'flang' in exe:
+                variants.append('+flang')
+                compilers['fc'] = exe
+                compilers['f77'] = exe
             elif 'ld.lld' in exe:
                 lld_found = True
                 compilers['ld'] = exe
@@ -321,6 +351,28 @@ class Llvm(CMakePackage, CudaPackage):
             result = os.path.join(self.spec.prefix.bin, 'clang++')
         return result
 
+    @property
+    def fc(self):
+        msg = "cannot retrieve Fortran compiler [spec is not concrete]"
+        assert self.spec.concrete, msg
+        if self.spec.external:
+            return self.spec.extra_attributes['compilers'].get('fc', None)
+        result = None
+        if '+flang' in self.spec:
+            result = os.path.join(self.spec.prefix.bin, 'flang')
+        return result
+
+    @property
+    def f77(self):
+        msg = "cannot retrieve Fortran 77 compiler [spec is not concrete]"
+        assert self.spec.concrete, msg
+        if self.spec.external:
+            return self.spec.extra_attributes['compilers'].get('f77', None)
+        result = None
+        if '+flang' in self.spec:
+            result = os.path.join(self.spec.prefix.bin, 'flang')
+        return result
+
     @run_before('cmake')
     def codesign_check(self):
         if self.spec.satisfies("+code_signing"):
@@ -347,27 +399,44 @@ class Llvm(CMakePackage, CudaPackage):
                         'create this identity.'
                     )
 
-    def setup_build_environment(self, env):
-        env.append_flags("CXXFLAGS", self.compiler.cxx11_flag)
+    def flag_handler(self, name, flags):
+        if name == 'cxxflags':
+            flags.append(self.compiler.cxx11_flag)
+            return(None, flags, None)
+        elif name == 'ldflags' and self.spec.satisfies('%intel'):
+            flags.append('-shared-intel')
+            return(None, flags, None)
+        return(flags, None, None)
 
     def setup_run_environment(self, env):
         if "+clang" in self.spec:
             env.set("CC", join_path(self.spec.prefix.bin, "clang"))
             env.set("CXX", join_path(self.spec.prefix.bin, "clang++"))
+        if "+flang" in self.spec:
+            env.set("FC", join_path(self.spec.prefix.bin, "flang"))
+            env.set("F77", join_path(self.spec.prefix.bin, "flang"))
 
     root_cmakelists_dir = "llvm"
 
     def cmake_args(self):
         spec = self.spec
+        python = spec['python']
         cmake_args = [
             "-DLLVM_REQUIRES_RTTI:BOOL=ON",
             "-DLLVM_ENABLE_RTTI:BOOL=ON",
             "-DLLVM_ENABLE_EH:BOOL=ON",
             "-DCLANG_DEFAULT_OPENMP_RUNTIME:STRING=libomp",
-            "-DPYTHON_EXECUTABLE:PATH={0}".format(spec["python"].command.path),
+            "-DPYTHON_EXECUTABLE:PATH={0}".format(python.command.path),
             "-DLIBOMP_USE_HWLOC:BOOL=ON",
             "-DLIBOMP_HWLOC_INSTALL_DIR={0}".format(spec["hwloc"].prefix),
         ]
+
+        if python.version >= Version("3.0.0"):
+            cmake_args.append("-DPython3_EXECUTABLE={0}".format(
+                              python.command.path))
+        else:
+            cmake_args.append("-DPython2_EXECUTABLE={0}".format(
+                              python.command.path))
 
         projects = []
 
@@ -416,6 +485,8 @@ class Llvm(CMakePackage, CudaPackage):
             projects.append("clang")
             projects.append("clang-tools-extra")
             projects.append("openmp")
+        if "+flang" in spec:
+            projects.append("flang")
         if "+lldb" in spec:
             projects.append("lldb")
         if "+lld" in spec:
@@ -425,8 +496,6 @@ class Llvm(CMakePackage, CudaPackage):
         if "+libcxx" in spec:
             projects.append("libcxx")
             projects.append("libcxxabi")
-            if spec.satisfies("@3.9.0:"):
-                cmake_args.append("-DCLANG_DEFAULT_CXX_STDLIB=libc++")
         if "+mlir" in spec:
             projects.append("mlir")
         if "+internal_unwind" in spec:
@@ -481,7 +550,16 @@ class Llvm(CMakePackage, CudaPackage):
             cmake_args.append("-DLIBOMP_TSAN_SUPPORT=ON")
 
         if self.compiler.name == "gcc":
-            gcc_prefix = ancestor(self.compiler.cc, 2)
+            compiler = Executable(self.compiler.cc)
+            gcc_output = compiler('-print-search-dirs', output=str, error=str)
+
+            for line in gcc_output.splitlines():
+                if line.startswith("install:"):
+                    # Get path and strip any whitespace
+                    # (causes oddity with ancestor)
+                    gcc_prefix = line.split(":")[1].strip()
+                    gcc_prefix = ancestor(gcc_prefix, 4)
+                    break
             cmake_args.append("-DGCC_INSTALL_PREFIX=" + gcc_prefix)
 
         if spec.satisfies("@4.0.0:"):

--- a/var/spack/repos/builtin/packages/py-llvmlite/package.py
+++ b/var/spack/repos/builtin/packages/py-llvmlite/package.py
@@ -34,7 +34,8 @@ class PyLlvmlite(PythonPackage):
     depends_on('llvm@7.0:7.0.99', when='@0.27.0:0.28.99')
     depends_on('llvm@6.0:6.0.99', when='@0.23.0:0.26.99')
     depends_on('llvm@4.0:4.0.99', when='@0.17.0:0.20.99')
-    depends_on('binutils', type='build')
+    # as llvm requires +ld+plugin, use it here to avoid concretizer issue
+    depends_on('binutils+plugins+ld', type='build')
 
     def setup_build_environment(self, env):
         # Need to set PIC flag since this is linking statically with LLVM


### PR DESCRIPTION
 - update llvm package recipe and patches from upstream version 12.0
 - update deploy configs to enable GPU support (CUDA as well as OpenMP offload support)
 - Use NVIDIA GPU default arch 70 (for BB5 Volta GPUs)
 - Update binutils dependency in py-llvmlite with minimal changes to avoid concretiser issues 
    -  this is dependency of py-atlas-building-tools