### PR TITLE
Update dask-mpi to 2.21.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-dask-mpi/package.py
+++ b/var/spack/repos/builtin/packages/py-dask-mpi/package.py
@@ -10,10 +10,11 @@ class PyDaskMpi(PythonPackage):
     """Deploying Dask using MPI4Py."""
 
     homepage = "https://github.com/dask/dask-mpi"
-    url      = "https://pypi.io/packages/source/d/dask-mpi/dask-mpi-2.0.0.tar.gz"
+    url      = "https://pypi.io/packages/source/d/dask-mpi/dask-mpi-2.21.0.tar.gz"
 
     import_modules = ['dask_mpi']
 
+    version('2.21.0', sha256='76e153fc8c58047d898970b33ede0ab1990bd4e69cc130c6627a96f11b12a1a7')
     version('2.0.0', sha256='774cd2d69e5f7154e1fa133c22498062edd31507ffa2ea19f4ab4d8975c27bc3')
 
     depends_on('py-dask@2.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -14,6 +14,7 @@ class PyDask(PythonPackage):
 
     maintainers = ['skosukhin']
 
+    version('2.30.0', sha256='a1669022e25de99b227c3d83da4801f032415962dac431099bf0534648e41a54')
     version('2.19.0', sha256='e18035cebc2a32e9d483f76d7718f846e95a0f75e6b0fe192a21328c236a465b')
     version('2.16.0', sha256='2af5b0dcd48ce679ce0321cf91de623f4fe376262789b951fefa3c334002f350')
     version('1.2.2', sha256='5e7876bae2a01b355d1969b73aeafa23310febd8c353163910b73e93dc7e492c')

--- a/var/spack/repos/builtin/packages/py-distributed/package.py
+++ b/var/spack/repos/builtin/packages/py-distributed/package.py
@@ -10,8 +10,9 @@ class PyDistributed(PythonPackage):
     """Distributed scheduler for Dask"""
 
     homepage = "https://distributed.dask.org/"
-    url      = "https://pypi.io/packages/source/d/distributed/distributed-2.10.0.tar.gz"
+    url      = "https://pypi.io/packages/source/d/distributed/distributed-2.30.1.tar.gz"
 
+    version('2.30.1', sha256='1421d3b84a0885aeb2c4bdc9e8896729c0f053a9375596c9de8864e055e2ac8e')
     version('2.10.0', sha256='2f8cca741a20f776929cbad3545f2df64cf60207fb21f774ef24aad6f6589e8b')
     version('1.28.1', sha256='3bd83f8b7eb5938af5f2be91ccff8984630713f36f8f66097e531a63f141c48a')
 


### PR DESCRIPTION
Packages updated:
dask 2.30.0
distributed 2.30.1
dask-mpi 2.21.0

Reason: batch_size option was added to Client.map in distributed 2.15.0 (https://github.com/dask/distributed/blob/master/docs/source/changelog.rst)