### PR TITLE
libsonata-report: sort spikes properly

### DIFF
--- a/var/spack/repos/builtin/packages/libsonata-report/package.py
+++ b/var/spack/repos/builtin/packages/libsonata-report/package.py
@@ -16,7 +16,7 @@ class LibsonataReport(CMakePackage):
     homepage = "https://github.com/BlueBrain/libsonata"
     git = "https://github.com/BlueBrain/libsonata.git"
 
-    version('0.1.3', commit='ddaa7aba920247', submodules=True, get_full_repo=True)
+    version('0.1.4', commit='3881a52ad7fe8b', submodules=True, get_full_repo=True)
     version('develop', branch='master', submodules=False, get_full_repo=True)
 
     variant('mpi', default=True, description="Enable MPI backend")

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
+    version('report_flush', branch='sandbox/jblanco/reports_flush', preferred=True)
     version('2.1.1',   tag='2.1.1')
     version('2.0.2',   tag='2.0.2')
     version('2.0.0',   tag='2.0.0')


### PR DESCRIPTION
 - In some cases the communicator used to sort spikes was not correct