### PR TITLE
update bluepymm to 0.7.65

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -127,7 +127,7 @@ packages:
       - py-bluepyefe@0.3.13
       - py-bglibpy@4.4.10 ^neuron%intel@19.0.4
       - py-bluepy@0.14.15
-      - py-bluepymm@0.7.49 ^neuron%intel@19.0.4
+      - py-bluepymm@0.7.65 ^neuron%intel@19.0.4
       - py-bluepyopt@1.9.27 ^neuron%intel@19.0.4
       - py-currentscape@0.0.2
 

--- a/var/spack/repos/builtin/packages/py-bluepymm/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepymm/package.py
@@ -12,7 +12,7 @@ class PyBluepymm(PythonPackage):
     homepage = "https://github.com/BlueBrain/BluePyMM"
     url = "https://pypi.io/packages/source/b/bluepymm/bluepymm-0.7.49.tar.gz"
 
-    version('0.7.49', sha256='ccc17a1d9ef2315888e31c8b97cc6c12e5556a95d5f9eb365a52010cc471847d')
+    version('0.7.65', sha256='024b009decd8d967b3b885421196d53670e3c0a6b75aaaa55559f148b0b0d7d4')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-bluepyopt', type='run')


### PR DESCRIPTION
I noticed neuron isn't getting loaded upon loading py-bluepymm.
I expect the change in `depends_on('neuron+python', type='run')` to fix it.
Also the version got updated.