### PR TITLE
Adding neurodamus-hippocampus from new model 1.3

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -43,7 +43,7 @@ packages:
       - py-morph-tool@2.2.21
       - py-minis-validation@0.0.2
       - py-morphio@2.3.4
-      - py-neurodamus@2.2.0
+      - py-neurodamus@2.2.1
       - py-sonata-network-reduction@0.1.0 ^neuron%intel@19.0.4^py-ipython%gcc
 
   gnu-stable-serial-ophiophob:
@@ -173,9 +173,9 @@ packages:
     specs:
       - neurodamus-core@3.1.0~common
       - neurodamus-neocortex@1.2-3.1.0+coreneuron
-      - neurodamus-hippocampus@1.2-3.1.0+coreneuron
+      - neurodamus-hippocampus@1.3-3.1.0+coreneuron
       - neurodamus-thalamus@1.2-3.1.0+coreneuron
       - neurodamus-mousify@1.2-3.1.0+coreneuron
       - neurodamus-neocortex@1.2-3.1.0+coreneuron^coreneuron+knl
-      - neurodamus-hippocampus@1.2-3.1.0+coreneuron^coreneuron+knl
+      - neurodamus-hippocampus@1.3-3.1.0+coreneuron^coreneuron+knl
       - neurodamus-thalamus@1.2-3.1.0+coreneuron^coreneuron+knl

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -20,6 +20,7 @@ class NeurodamusHippocampus(NeurodamusModel):
     # IMPORTANT: Register versions (only) here to make them stable
     # Final version name is combined e.g. "1.0-3.0.1"
     model_core_dep_v = (
+        ('1.3', '3.1.0'),
         ('1.2', '3.1.0'),
         ('1.1', '3.0.2'),
     )

--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,7 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
-    version('2.2.0',   tag='2.2.0')
+    version('2.2.1',   tag='2.2.1')
     version('2.1.2',   tag='2.1.2')
     version('2.1.1',   tag='2.1.1')
     version('2.0.2',   tag='2.0.2')


### PR DESCRIPTION
Bumping neurodamus hippocampus model to 1.3 for the Range variables (instead of global)

Also, deploy neurodamus py 2.2.1 which updated the docs