### PR TITLE
Add pybind11 variant to nmodl recipe

### DIFF
--- a/var/spack/repos/builtin/packages/nmodl/package.py
+++ b/var/spack/repos/builtin/packages/nmodl/package.py
@@ -19,7 +19,7 @@ class Nmodl(CMakePackage):
     version('0.2', tag='0.2', submodules=True)
 
     variant("legacy-unit", default=True, description="Enable legacy units")
-    variant("pybind11", default=False, description="Enable python bindings")
+    variant("python", default=False, description="Enable python bindings")
 
     depends_on('bison@3.0:3.4.99', when='@:0.3', type='build')
     depends_on('bison@3.0.5:', when='@0.3.1:', type='build')
@@ -35,7 +35,7 @@ class Nmodl(CMakePackage):
         spec = self.spec
         options = []
 
-        if "+pybind11" in spec:
+        if "+python" in spec:
             options.append('-DNMODL_ENABLE_PYTHON_BINDINGS=ON')
         else:
             options.append('-DNMODL_ENABLE_PYTHON_BINDINGS=OFF')

--- a/var/spack/repos/builtin/packages/nmodl/package.py
+++ b/var/spack/repos/builtin/packages/nmodl/package.py
@@ -40,7 +40,6 @@ class Nmodl(CMakePackage):
         else:
             options.append('-DNMODL_ENABLE_PYTHON_BINDINGS=OFF')
 
-
         # installation with pgi fails when debug symbols are added
         if '%pgi' in spec:
             options.append('-DCMAKE_BUILD_TYPE=Release')

--- a/var/spack/repos/builtin/packages/nmodl/package.py
+++ b/var/spack/repos/builtin/packages/nmodl/package.py
@@ -19,6 +19,7 @@ class Nmodl(CMakePackage):
     version('0.2', tag='0.2', submodules=True)
 
     variant("legacy-unit", default=True, description="Enable legacy units")
+    variant("pybind11", default=False, description="Enable python bindings")
 
     depends_on('bison@3.0:3.4.99', when='@:0.3', type='build')
     depends_on('bison@3.0.5:', when='@0.3.1:', type='build')
@@ -33,6 +34,12 @@ class Nmodl(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         options = []
+
+        if "+pybind11" in spec:
+            options.append('-DNMODL_ENABLE_PYTHON_BINDINGS=ON')
+        else:
+            options.append('-DNMODL_ENABLE_PYTHON_BINDINGS=OFF')
+
 
         # installation with pgi fails when debug symbols are added
         if '%pgi' in spec:


### PR DESCRIPTION
To simplify nmodl build we remove python bindings from
standard nmodl build. 

You can still get them with: +pybind11