### PR TITLE
BGLibPy update to 4.4.20

### DIFF
--- a/deploy/packages/bbp-packages.yaml
+++ b/deploy/packages/bbp-packages.yaml
@@ -125,7 +125,7 @@ packages:
       - nest@2.18.0
       - py-efel@3.0.80
       - py-bluepyefe@0.3.13
-      - py-bglibpy@4.4.18 ^neuron%intel@19.0.4
+      - py-bglibpy@4.4.20 ^neuron%intel@19.0.4
       - py-bluepy@0.14.15
       - py-bluepymm@0.7.65 ^neuron%intel@19.0.4
       - py-bluepyopt@1.9.27 ^neuron%intel@19.0.4

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -14,6 +14,7 @@ class PyBglibpy(PythonPackage):
 
     version('develop', branch='master')
 
+    version('4.4.20', commit='59cd13df919e60c272f1f90d178eea687206f13f')
     version('4.4.18', commit='cbfb1c214d44eaab0a1cef3d3bbafa097469fe85')
     version('4.4.10', commit='53db9eee6f0b4e025f19c271b3235831f86c866e')
     version('4.4.6', commit='18e211153025535ebecb7e0a9868033b1462bec1')


### PR DESCRIPTION
* has this change -> a0c609c: Read synapse locations from SONATA field and round synapse delays to timestep