### PR TITLE
Adding BluePyEfe to the whitelist

### DIFF
--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -54,6 +54,7 @@ modules:
       - py-bbp-workflow
       - py-bglibpy
       - py-bluepy
+      - py-bluepyefe
       - py-bluepymm
       - py-bluepyopt
       - py-bluepysnap


### PR DESCRIPTION
BluePyEfe was not available because it was not in the whitelist in pull request https://github.com/BlueBrain/spack/pull/874/files