### PR TITLE
Bump morphio to 2.4.1

### DIFF
--- a/var/spack/repos/builtin/packages/morphio/package.py
+++ b/var/spack/repos/builtin/packages/morphio/package.py
@@ -14,6 +14,7 @@ class Morphio(CMakePackage):
     git      = "https://github.com/BlueBrain/MorphIO.git"
 
     version('develop', git=url, submodules=True)
+    version('2.4.1', tag='v2.4.1', submodules=True)
     version('2.3.9', tag='v2.3.9', submodules=True)
     version('2.3.4', tag='v2.3.4', submodules=True)
     version('2.2.1', tag='v2.2.1', submodules=True)

--- a/var/spack/repos/builtin/packages/py-morphio/package.py
+++ b/var/spack/repos/builtin/packages/py-morphio/package.py
@@ -14,6 +14,7 @@ class PyMorphio(PythonPackage):
 
     version('develop', branch='master', submodules=True, get_full_repo=True)
     version('unifurcation', branch='unifurcation', submodules=True, get_full_repo=True)
+    version('2.4.1', tag='v2.4.1', submodules=True, get_full_repo=True)
     version('2.3.10', tag='v2.3.10', submodules=True, get_full_repo=True)
     version('2.3.4', tag='v2.3.4', submodules=True, get_full_repo=True)
     version('2.2.1', tag='v2.2.1', submodules=True, get_full_repo=True)


### PR DESCRIPTION
Among others, it brings updated highfive submodule which works with hdf5 1.12