### PR TITLE
py-packaging: depend on setuptools

### DIFF
--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -30,4 +30,4 @@ class PyPackaging(PythonPackage):
     # fallback on distutils.core instead. Don't add a setuptools dependency
     # or we won't be able to bootstrap setuptools.
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-packaging/package.py
+++ b/var/spack/repos/builtin/packages/py-packaging/package.py
@@ -30,4 +30,4 @@ class PyPackaging(PythonPackage):
     # fallback on distutils.core instead. Don't add a setuptools dependency
     # or we won't be able to bootstrap setuptools.
 
-    # depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Barring the stupid phase when setuptools did not vendor this dependency, this should work. We're way past those versions.

This should be a dependency to get the PYTHONPATH set properly with the newest versions of setuptools, otherwise an egg is installed without a good way to load it.