### PR TITLE
compilers: various environment fixes

### DIFF
--- a/deploy/Jenkinsfile
+++ b/deploy/Jenkinsfile
@@ -83,7 +83,7 @@ def run_stages() {
 
 pipeline {
     agent {
-        label 'bb5-full'
+        label 'bb5'
     }
 
     options {

--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -94,3 +94,39 @@ modules:
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'
+    gcc:
+      environment:
+        set:
+          MPICC_CC: 'gcc'
+          MPICXX_CXX: 'g++'
+          MPIF90_F90: 'gfortran'
+    intel-parallel-studio:
+      environment:
+        set:
+          MPICC_CC: 'icc'
+          MPICXX_CXX: 'icpc'
+          MPIF90_F90: 'ifort'
+    intel:
+      environment:
+        set:
+          MPICC_CC: 'icc'
+          MPICXX_CXX: 'icpc'
+          MPIF90_F90: 'ifort'
+    pgi:
+      environment:
+        set:
+          MPICC_CC: 'pgcc'
+          MPICXX_CXX: 'pgc++'
+          MPIF90_F90: 'pgfortran'
+    llvm:
+      environment:
+        set:
+          MPICC_CC: 'clang'
+          MPICXX_CXX: 'clang++'
+          MPIF90_F90: 'gfortran'
+    nvhpc:
+      environment:
+        set:
+          MPICC_CC: 'nvc'
+          MPICXX_CXX: 'nvc++'
+          MPIF90_F90: 'nvfortran'

--- a/deploy/configs/externals/modules.yaml
+++ b/deploy/configs/externals/modules.yaml
@@ -69,3 +69,39 @@ modules:
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'
+    gcc:
+      environment:
+        set:
+          MPICC_CC: 'gcc'
+          MPICXX_CXX: 'g++'
+          MPIF90_F90: 'gfortran'
+    intel-parallel-studio:
+      environment:
+        set:
+          MPICC_CC: 'icc'
+          MPICXX_CXX: 'icpc'
+          MPIF90_F90: 'ifort'
+    intel:
+      environment:
+        set:
+          MPICC_CC: 'icc'
+          MPICXX_CXX: 'icpc'
+          MPIF90_F90: 'ifort'
+    pgi:
+      environment:
+        set:
+          MPICC_CC: 'pgcc'
+          MPICXX_CXX: 'pgc++'
+          MPIF90_F90: 'pgfortran'
+    llvm:
+      environment:
+        set:
+          MPICC_CC: 'clang'
+          MPICXX_CXX: 'clang++'
+          MPIF90_F90: 'gfortran'
+    nvhpc:
+      environment:
+        set:
+          MPICC_CC: 'nvc'
+          MPICXX_CXX: 'nvc++'
+          MPIF90_F90: 'nvfortran'

--- a/deploy/configs/libraries/modules.yaml
+++ b/deploy/configs/libraries/modules.yaml
@@ -57,3 +57,39 @@ modules:
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'
+    gcc:
+      environment:
+        set:
+          MPICC_CC: 'gcc'
+          MPICXX_CXX: 'g++'
+          MPIF90_F90: 'gfortran'
+    intel-parallel-studio:
+      environment:
+        set:
+          MPICC_CC: 'icc'
+          MPICXX_CXX: 'icpc'
+          MPIF90_F90: 'ifort'
+    intel:
+      environment:
+        set:
+          MPICC_CC: 'icc'
+          MPICXX_CXX: 'icpc'
+          MPIF90_F90: 'ifort'
+    pgi:
+      environment:
+        set:
+          MPICC_CC: 'pgcc'
+          MPICXX_CXX: 'pgc++'
+          MPIF90_F90: 'pgfortran'
+    llvm:
+      environment:
+        set:
+          MPICC_CC: 'clang'
+          MPICXX_CXX: 'clang++'
+          MPIF90_F90: 'gfortran'
+    nvhpc:
+      environment:
+        set:
+          MPICC_CC: 'nvc'
+          MPICXX_CXX: 'nvc++'
+          MPIF90_F90: 'nvfortran'

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -352,6 +352,11 @@ configure_compilers() {
         cmd=${cmd/load/unload}
         echo "${cmd}"
         ${cmd}
+
+        cmd=${cmd/unload/show/}
+        full_module_path="$(${cmd}|&sed -ne '2{s/:$// p}')"
+
+        sed '/modules: \[\]/ d;s/\( *\)spec: '"${spec/llvm/clang}"'/&\n\1modules: ['"${full_module_path}"']/' ${HOME}/.spack/compilers.yaml
     done
 
     sed  -i 's#.*f\(77\|c\): null#      f\1: /usr/bin/gfortran#' ${HOME}/.spack/compilers.yaml

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -330,11 +330,6 @@ configure_compilers() {
                     log "updated ${f} with newer GCC"
                 fi
             done
-            INTEL_LIB="$(readlink -f "${INTEL_DIR}/lib/intel64")"
-            env_mods="
-    environment:
-      append_path:
-        LD_LIBRARY_PATH: ${INTEL_LIB}"
         elif [[ ${line} = *"pgi"* || ${line} = *"nvhpc"* ]]; then
             #update pgi modules for network installation
             PGI_DIR=$(dirname $(which makelocalrc))
@@ -375,7 +370,7 @@ configure_compilers() {
             /^\s*Target:.\s*$/ d;
             /^\s*$/ d;
             s#spec: .clang#spec: clang#
-            s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']'"${env_mods}"'#' ${HOME}/.spack/compilers.yaml
+            s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
     done
 
     sed  -i 's#.*f\(77\|c\): null#      f\1: /usr/bin/gfortran#' ${HOME}/.spack/compilers.yaml

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -355,10 +355,15 @@ configure_compilers() {
 
         cmd=${cmd/unload/show/}
         full_module_path="$(${cmd}|&sed -ne '2{s/:$// p}')"
-        spec=${spec/llvm/.clang}
-        spec=${spec/20.0.2/19.1.2.254}
+        spec=${spec%%[+ ]*}             # truncate variants
+        spec=${spec/llvm/.clang}        # LLVM identifies as clang with some garbage in front
+        spec=${spec/20.0.2/19.1.2.254}  # Intel identifies as an older version
         echo sed -i -e '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'.*$#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
-        sed -i -e '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
+        sed -i -e '
+            /modules: \[\]/ d;
+            /^\s*Target:.\s*$/ d;
+            /^\s*$/ d;
+            s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
     done
 
     sed  -i 's#.*f\(77\|c\): null#      f\1: /usr/bin/gfortran#' ${HOME}/.spack/compilers.yaml

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -356,7 +356,7 @@ configure_compilers() {
         cmd=${cmd/unload/show/}
         full_module_path="$(${cmd}|&sed -ne '2{s/:$// p}')"
 
-        sed '/modules: \[\]/ d;s#( *\)spec: '"${spec/llvm/clang}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
+        sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec/llvm/clang}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
     done
 
     sed  -i 's#.*f\(77\|c\): null#      f\1: /usr/bin/gfortran#' ${HOME}/.spack/compilers.yaml

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -358,11 +358,17 @@ configure_compilers() {
         spec=${spec%%[+ ]*}             # truncate variants
         spec=${spec/llvm/.clang}        # LLVM identifies as clang with some garbage in front
         spec=${spec/20.0.2/19.1.2.254}  # Intel identifies as an older version
-        echo sed -i -e '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'.*$#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
+        # Remove empty module definitions, as they may appear anywhere
+        # under the compiler key. Further, purge some garbage where clang's
+        # spec spans multiple lines with a quote in front.
+        #
+        # After removing all unnecessary stuff, re-add the appropriate
+        # module definition with a full path.
         sed -i -e '
             /modules: \[\]/ d;
             /^\s*Target:.\s*$/ d;
             /^\s*$/ d;
+            s#spec: .clang#spec: clang#
             s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
     done
 

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -356,6 +356,7 @@ configure_compilers() {
         cmd=${cmd/unload/show/}
         full_module_path="$(${cmd}|&sed -ne '2{s/:$// p}')"
 
+        echo sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec/llvm/clang}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
         sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec/llvm/clang}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
     done
 

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -356,7 +356,7 @@ configure_compilers() {
         cmd=${cmd/unload/show/}
         full_module_path="$(${cmd}|&sed -ne '2{s/:$// p}')"
         spec=${spec%%[+ ]*}             # truncate variants
-        spec=${spec/llvm/.clang}        # LLVM identifies as clang with some garbage in front
+        spec=${spec/llvm/clang}         # LLVM identifies as clang
         spec=${spec/20.0.2/19.1.2.254}  # Intel identifies as an older version
         # Remove empty module definitions, as they may appear anywhere
         # under the compiler key. Further, purge some garbage where clang's

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -356,8 +356,10 @@ configure_compilers() {
         cmd=${cmd/unload/show/}
         full_module_path="$(${cmd}|&sed -ne '2{s/:$// p}')"
 
-        echo sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec/llvm/clang}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
-        sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec/llvm/clang}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
+        spec=${spec/llvm/'clang}
+        spec=${spec/20.0.2/19.1.2.254}
+        echo sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'.*$#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
+        sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
     done
 
     sed  -i 's#.*f\(77\|c\): null#      f\1: /usr/bin/gfortran#' ${HOME}/.spack/compilers.yaml

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -276,6 +276,7 @@ configure_compilers() {
         sha="${line%% *}"  # Remove everything after and including the first space
         spec="${line#* }"  # Remove everything up to and including the first space
         set +o nounset
+        env_mods=""
 
 
         # Skip all but compilers. Compiler variants need to be specified
@@ -329,6 +330,11 @@ configure_compilers() {
                     log "updated ${f} with newer GCC"
                 fi
             done
+            INTEL_LIB="$(readlink -f "${INTEL_DIR}/lib/intel64")"
+            env_mods="
+    environment:
+      append_path:
+        LD_LIBRARY_PATH: ${INTEL_LIB}"
         elif [[ ${line} = *"pgi"* || ${line} = *"nvhpc"* ]]; then
             #update pgi modules for network installation
             PGI_DIR=$(dirname $(which makelocalrc))
@@ -369,7 +375,7 @@ configure_compilers() {
             /^\s*Target:.\s*$/ d;
             /^\s*$/ d;
             s#spec: .clang#spec: clang#
-            s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
+            s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']'"${env_mods}"'#' ${HOME}/.spack/compilers.yaml
     done
 
     sed  -i 's#.*f\(77\|c\): null#      f\1: /usr/bin/gfortran#' ${HOME}/.spack/compilers.yaml

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -356,7 +356,7 @@ configure_compilers() {
         cmd=${cmd/unload/show/}
         full_module_path="$(${cmd}|&sed -ne '2{s/:$// p}')"
 
-        spec=${spec/llvm/'clang}
+        spec=${spec/llvm/.clang}
         spec=${spec/20.0.2/19.1.2.254}
         echo sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'.*$#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
         sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -355,11 +355,10 @@ configure_compilers() {
 
         cmd=${cmd/unload/show/}
         full_module_path="$(${cmd}|&sed -ne '2{s/:$// p}')"
-
         spec=${spec/llvm/.clang}
         spec=${spec/20.0.2/19.1.2.254}
-        echo sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'.*$#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
-        sed '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
+        echo sed -i -e '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'.*$#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
+        sed -i -e '/modules: \[\]/ d;s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
     done
 
     sed  -i 's#.*f\(77\|c\): null#      f\1: /usr/bin/gfortran#' ${HOME}/.spack/compilers.yaml

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -356,7 +356,7 @@ configure_compilers() {
         cmd=${cmd/unload/show/}
         full_module_path="$(${cmd}|&sed -ne '2{s/:$// p}')"
 
-        sed '/modules: \[\]/ d;s/\( *\)spec: '"${spec/llvm/clang}"'/&\n\1modules: ['"${full_module_path}"']/' ${HOME}/.spack/compilers.yaml
+        sed '/modules: \[\]/ d;s#( *\)spec: '"${spec/llvm/clang}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
     done
 
     sed  -i 's#.*f\(77\|c\): null#      f\1: /usr/bin/gfortran#' ${HOME}/.spack/compilers.yaml

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -80,10 +80,10 @@ class _IndexBase(object):
         except TypeError:
             import llnl.util.tty as tty
             tty.warn(
-                'detected non-concretized specs for provider of {0}'
+                'detected "weird" specs for provider of {0}'
                 .format(virtual_spec.name)
             )
-            return sorted(s.copy() for s in result if s.concrete)
+            return sorted(s.copy() for s in result if all(s._cmp_key()))
 
     def __contains__(self, name):
         return name in self.providers

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -86,7 +86,7 @@ class _IndexBase(object):
             clones = []
             for s in result:
                 clone = s.clone()
-                if clone._cmp_key()[1] is not None:
+                if clone._cmp_key()[0][1] is not None:
                     clones.append(clone)
             return sorted(clones)
 

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -83,7 +83,12 @@ class _IndexBase(object):
                 'detected "weird" specs for provider of {0}'
                 .format(virtual_spec.name)
             )
-            return sorted(s.copy() for s in result if all(s._cmp_key()))
+            clones = []
+            for s in result:
+                clone = s.clone()
+                if clone._cmp_key()[1] is not None:
+                    clones.append(clone)
+            return sorted(clones)
 
     def __contains__(self, name):
         return name in self.providers

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -78,6 +78,11 @@ class _IndexBase(object):
         try:
             return sorted(s.copy() for s in result)
         except TypeError:
+            import llnl.util.tty as tty
+            tty.warn(
+                'detected non-concretized specs for provider of {0}'
+                .format(virtual_spec.name)
+            )
             return sorted(s.copy() for s in result if s.concrete)
 
     def __contains__(self, name):

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -79,6 +79,7 @@ class _IndexBase(object):
             return sorted(s.copy() for s in result)
         except TypeError:
             for res in result:
+                print(res.concrete)
                 print(res._cmp_key())
                 print(res.copy()._cmp_key())
             raise

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -75,6 +75,19 @@ class _IndexBase(object):
                     result.update(spec_set)
 
         # Return providers in order. Defensively copy.
+        #
+        # Some BlueBrain additions here:
+        #
+        # Sometimes the provider index contains seemingly unconcretized
+        # specs, and the sorting crashes with
+        #
+        # unorderable types: str() < NoneType()
+        #
+        # Here we go through the provided "specs" and weed out everything
+        # that has a None value in the comparison key to prevent this.
+        # Debug output shows that this seems to happen for "elfutils" and
+        # that there are normally two unconcretized entries, and two
+        # concretized ones.
         try:
             return sorted(s.copy() for s in result)
         except TypeError:
@@ -86,7 +99,8 @@ class _IndexBase(object):
             clones = []
             for s in result:
                 clone = s.clone()
-                if clone._cmp_key()[0][1] is not None:
+                spec_key, _ = clone._cmp_key)
+                if spec_key[1] is not None:
                     clones.append(clone)
             return sorted(clones)
 

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -78,11 +78,7 @@ class _IndexBase(object):
         try:
             return sorted(s.copy() for s in result)
         except TypeError:
-            for res in result:
-                print(res.concrete)
-                print(res._cmp_key())
-                print(res.copy()._cmp_key())
-            raise
+            return sorted(s.copy() for s in result if s.concrete)
 
     def __contains__(self, name):
         return name in self.providers

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -96,13 +96,13 @@ class _IndexBase(object):
                 'detected "weird" specs for provider of {0}'
                 .format(virtual_spec.name)
             )
-            clones = []
+            duplicates = []
             for s in result:
-                clone = s.clone()
-                spec_key, _ = clone._cmp_key()
+                duplicate = s.copy()
+                spec_key, _ = duplicate._cmp_key()
                 if spec_key[1] is not None:
-                    clones.append(clone)
-            return sorted(clones)
+                    duplicates.append(duplicate)
+            return sorted(duplicates)
 
     def __contains__(self, name):
         return name in self.providers

--- a/lib/spack/spack/provider_index.py
+++ b/lib/spack/spack/provider_index.py
@@ -99,7 +99,7 @@ class _IndexBase(object):
             clones = []
             for s in result:
                 clone = s.clone()
-                spec_key, _ = clone._cmp_key)
+                spec_key, _ = clone._cmp_key()
                 if spec_key[1] is not None:
                     clones.append(clone)
             return sorted(clones)

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -53,9 +53,14 @@ def module(*args):
         # dump SPACKIGNORE as a placeholder for parsing if LD_LIBRARY_PATH null
         module_cmd += 'echo "${SPACK_NEW_LD_LIBRARY_PATH:-SPACKIGNORE}"'
 
+        environ = dict(os.environ)
+        if "BASH_FUNC_module()" not in environ:
+            environ["BASH_FUNC_module()"] = "() { eval `modulecmd bash $*`\n}"
+
         module_p  = subprocess.Popen(module_cmd,
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT,
+                                     env=environ,
                                      shell=True,
                                      executable="/bin/bash")
 
@@ -80,10 +85,15 @@ def module(*args):
             os.environ['LD_LIBRARY_PATH'] = new_ld_library_path
 
     else:
+        environ = dict(os.environ)
+        if "BASH_FUNC_module()" not in environ:
+            environ["BASH_FUNC_module()"] = "() { eval `modulecmd bash $*`\n}"
+
         # Simply execute commands that don't change state and return output
         module_p = subprocess.Popen(module_cmd,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT,
+                                    env=environ,
                                     shell=True,
                                     executable="/bin/bash")
         # Decode and str to return a string object in both python 2 and 3

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -53,6 +53,13 @@ def module(*args):
         # dump SPACKIGNORE as a placeholder for parsing if LD_LIBRARY_PATH null
         module_cmd += 'echo "${SPACK_NEW_LD_LIBRARY_PATH:-SPACKIGNORE}"'
 
+        # Bash allows to export functions into the environment, and
+        # subprocesses executing Bash can make use of these.
+        #
+        # If the user runs a different shell, emulate the exported module
+        # function to have the module commands work properly.
+        #
+        # Added caveat: `modulecmd` needs to be in PATH.
         environ = dict(os.environ)
         if "BASH_FUNC_module()" not in environ:
             environ["BASH_FUNC_module()"] = "() { eval `modulecmd bash $*`\n}"
@@ -85,6 +92,7 @@ def module(*args):
             os.environ['LD_LIBRARY_PATH'] = new_ld_library_path
 
     else:
+        # See note above
         environ = dict(os.environ)
         if "BASH_FUNC_module()" not in environ:
             environ["BASH_FUNC_module()"] = "() { eval `modulecmd bash $*`\n}"

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -96,9 +96,6 @@ class Nvhpc(Package):
                                   'Linux_%s' % self.spec.target.family,
                                   self.version, 'compilers'))
 
-        # pgi/nvc doesn't support -isystem flag
-        env.set('DUMB_COMPILER', 'absolutely')
-
         env.set('CC',  join_path(prefix.bin, 'nvc'))
         env.set('CXX', join_path(prefix.bin, 'nvc++'))
         env.set('F77', join_path(prefix.bin, 'nvfortran'))


### PR DESCRIPTION
Add common environment variables to all module generating configs. This
should set MPI_C* for all modules, even user-generated ones, since the
application stage configuration is propagated to the end user.

Following the official Spack documentation, we should actually populate
the `modules` key of the `compilers.yaml`. For this, remove all empty
lines, and append fresh ones to matching specs (account for LLVM
changing to clang).

See also https://spack.readthedocs.io/en/latest/getting_started.html#compilers-requiring-modules
