### PR TITLE
Set JUPYTERLAB_DIR at runtime

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupyterlab/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab/package.py
@@ -25,3 +25,6 @@ class PyJupyterlab(PythonPackage):
     depends_on('py-requests', type='test')
     depends_on('py-wheel', type='test')
     depends_on('py-virtualenv', type='test')
+
+    def setup_run_environment(self, env):
+        env.prepend_path('JUPYTERLAB_DIR', self.prefix.share.jupyter.lab)


### PR DESCRIPTION
This fixes runtime errors like:
```
JupyterLab application assets not found in "/opt/local/Library/Frameworks/Python.framework/Versions/3.8/share/jupyter/lab"
```
that I encountered on macOS 10.15 (Catalina).

Note that the newest available release is 3.0.5, but I didn't bump the version for this PR.