### PR TITLE
Update psp-validation to 0.3.3

### DIFF
--- a/var/spack/repos/builtin/packages/psp-validation/package.py
+++ b/var/spack/repos/builtin/packages/psp-validation/package.py
@@ -32,7 +32,7 @@ class PspValidation(PythonPackage):
     depends_on('py-numpy@1.10:', type='run')
     depends_on('py-tqdm@4.0:', type='run')
     depends_on('py-bglibpy@4.3.15:4.999', type='run')
-    depends_on('py-bluepy@0.16.0:2.999', type='run')
+    depends_on('py-bluepy@0.16.0:1.999', type='run')
     depends_on('py-efel@3.0.39:', type='run')
     depends_on('neuron+python@7.8:', when='@0.2.2:',type='run')
 

--- a/var/spack/repos/builtin/packages/psp-validation/package.py
+++ b/var/spack/repos/builtin/packages/psp-validation/package.py
@@ -13,6 +13,7 @@ class PspValidation(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/nse/psp-validation"
 
     version('develop', branch='master')
+    version('0.3.3', tag='psp-validation-v0.3.3')
     version('0.3.1', tag='psp-validation-v0.3.1')
     version('0.3.0', tag='psp-validation-v0.3.0')
     version('0.2.1', tag='psp-validation-v0.2.1')
@@ -25,13 +26,14 @@ class PspValidation(PythonPackage):
 
     depends_on('py-attrs', type='run')
     depends_on('py-click@7.0:7.999', type='run')
-    depends_on('py-future@0.16:', type='run')
-    depends_on('py-h5py~mpi@2.7:', type='run')
+    depends_on('py-future@0.16:', when='@:0.2.1', type='run')
+    depends_on('py-h5py~mpi@2.7:2.999', type='run')
     depends_on('py-joblib@0.13:', type='run')
     depends_on('py-numpy@1.10:', type='run')
     depends_on('py-tqdm@4.0:', type='run')
-    depends_on('py-bglibpy@4.3.15:', type='run')
-    depends_on('py-bluepy@0.14.3:', type='run')
+    depends_on('py-bglibpy@4.3.15:4.999', type='run')
+    depends_on('py-bluepy@0.16.0:2.999', type='run')
     depends_on('py-efel@3.0.39:', type='run')
+    depends_on('neuron+python@7.8:', when='@0.2.2:',type='run')
 
-    depends_on('py-mock@3.0.5', type='build')  # remove in 2020
+    depends_on('py-mock@3.0.5', when='@:0.3.1', type='build')  # remove in 2020

--- a/var/spack/repos/builtin/packages/psp-validation/package.py
+++ b/var/spack/repos/builtin/packages/psp-validation/package.py
@@ -34,6 +34,6 @@ class PspValidation(PythonPackage):
     depends_on('py-bglibpy@4.3.15:4.999', type='run')
     depends_on('py-bluepy@0.16.0:1.999', type='run')
     depends_on('py-efel@3.0.39:', type='run')
-    depends_on('neuron+python@7.8:', when='@0.2.2:',type='run')
+    depends_on('neuron+python@7.8:', when='@0.2.2:', type='run')
 
     depends_on('py-mock@3.0.5', when='@:0.3.1', type='build')  # remove in 2020


### PR DESCRIPTION
Update psp-validation to 0.3.3 just released.

Note: the build dependency py-mock is marked to be removed in 2020, but I'm not sure why it was needed and if it's safe to be removed now (spack install on BB5 was successful using this configuration, though).