### PR TITLE
Remove connectome-tools 0.3.4

### DIFF
--- a/deploy/environments/applications.yaml
+++ b/deploy/environments/applications.yaml
@@ -22,8 +22,7 @@ spack:
     - brion@3.3.0 +python
     - brion@3.3.1 +python
     - circuit-build
-    - connectome-tools@0.3.4
-    - connectome-tools@0.4.0
+    - connectome-tools
     - emsim
     - functionalizer@3.12.2
     - meshball ^brion@3.1.0

--- a/var/spack/repos/builtin/packages/connectome-tools/package.py
+++ b/var/spack/repos/builtin/packages/connectome-tools/package.py
@@ -13,8 +13,7 @@ class ConnectomeTools(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/nse/connectome-tools"
 
     version('develop', branch='master')
-    version('0.4.0', tag='connectome-tools-v0.4.0', preferred=True)
-    version('0.3.4', tag='connectome-tools-v0.3.4')
+    version('0.4.0', tag='connectome-tools-v0.4.0')
 
     depends_on('py-setuptools', type=('build', 'run'))
 
@@ -27,8 +26,5 @@ class ConnectomeTools(PythonPackage):
     depends_on('py-psutil@5.7.2:', type='run')
     depends_on('py-pyyaml@5.3.1:', type='run')
 
-    depends_on('py-bluepy@2.0:2.999', when='@0.4.0:', type='run')
-    depends_on('py-voxcell@3.0:3.999', when='@0.4.0:', type='run')
-
-    depends_on('py-bluepy@0.13.3:1.999', when='@:0.3.4', type='run')
-    depends_on('py-voxcell@2.5.6:2.999', when='@:0.3.4', type='run')
+    depends_on('py-bluepy@2.0:2.999', type='run')
+    depends_on('py-voxcell@3.0:3.999', type='run')


### PR DESCRIPTION
Following https://github.com/BlueBrain/spack/pull/1041, connectome-tools 0.3.4 is available on BB5 (`unstable` and later `archive/2021-02`) and it can be removed from the spack configuration.