### PR TITLE
Small fixes related to NEURON-CoreNEURON integration

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -235,14 +235,14 @@ if [ -n "{nrnivmodlcore_call}" ]; then
     done
     {nrnivmodlcore_call} _core_mods
     libpath=$(dirname */libcorenrnmech*)
-    extra_loadflags="-L $(pwd)/$libpath -lcorenrnmech -Wl,-rpath=\\$ORIGIN"
+    extra_loadflags="-L $(pwd)/$libpath -lcorenrnmech -Wl,-rpath=$(pwd)/$libpath"
 
     echo "Your build supports CoreNeuron. However in some systems
         the coreneuron mods might not be loadable without a location hint.
         In case you get an error such as
             'libcorenrnmech.so: cannot open shared object file
         please run the command:
-            export LD_LIBRARY_PATH=$libpath:\\$LD_LIBRARY_PATH"
+            export LD_LIBRARY_PATH=$(pwd)/$libpath:\\$LD_LIBRARY_PATH"
 fi
 
 '{nrnivmodl}' -incflags '{incflags} '"$2" -loadflags \

--- a/var/spack/repos/builtin/packages/neurodamus-model/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-model/package.py
@@ -235,7 +235,8 @@ if [ -n "{nrnivmodlcore_call}" ]; then
     done
     {nrnivmodlcore_call} _core_mods
     libpath=$(dirname */libcorenrnmech*)
-    extra_loadflags="-L $(pwd)/$libpath -lcorenrnmech -Wl,-rpath=$(pwd)/$libpath"
+    extra_loadflags="-L $(pwd)/$libpath -lcorenrnmech \\
+            -Wl,-rpath=$(pwd)/$libpath"
 
     echo "Your build supports CoreNeuron. However in some systems
         the coreneuron mods might not be loadable without a location hint.

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -463,11 +463,11 @@ class Neuron(CMakePackage):
             filter_file(env["CXX"], cxx_compiler, nrniv_makefile, **kwargs)
 
         # Filter compiler in the nrnivmodl_core_makefile
-        if self.spec.satisfies("+coreneuron"):
-            nrnmakefile = join_path(self.prefix,
+        if self.spec.satisfies("+coreneuron") and self.spec.satisfies("@7.9:"):
+            corenrn_makefile = join_path(self.prefix,
                                     'share/coreneuron/nrnivmodl_core_makefile')
-            filter_file(env['CC'],  self.compiler.cc, nrnmakefile, **kwargs)
-            filter_file(env['CXX'], self.compiler.cxx, nrnmakefile, **kwargs)
+            filter_file(env['CC'], self.compiler.cc, corenrn_makefile, **kwargs)
+            filter_file(env['CXX'], self.compiler.cxx, corenrn_makefile, **kwargs)
 
     # Added because the bin and lib directories are inside x86_64 dir in the
     # installation directory of autotools installation

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -464,10 +464,17 @@ class Neuron(CMakePackage):
 
         # Filter compiler in the nrnivmodl_core_makefile
         if self.spec.satisfies("+coreneuron") and self.spec.satisfies("@7.9:"):
-            corenrn_makefile = join_path(self.prefix,
-                                    'share/coreneuron/nrnivmodl_core_makefile')
-            filter_file(env['CC'], self.compiler.cc, corenrn_makefile, **kwargs)
-            filter_file(env['CXX'], self.compiler.cxx, corenrn_makefile, **kwargs)
+            corenrn_makefile = \
+                join_path(self.prefix,
+                          'share/coreneuron/nrnivmodl_core_makefile')
+            filter_file(env['CC'],
+                        self.compiler.cc,
+                        corenrn_makefile,
+                        **kwargs)
+            filter_file(env['CXX'],
+                        self.compiler.cxx,
+                        corenrn_makefile,
+                        **kwargs)
 
     # Added because the bin and lib directories are inside x86_64 dir in the
     # installation directory of autotools installation

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -462,6 +462,13 @@ class Neuron(CMakePackage):
             filter_file(env["CC"], cc_compiler, nrniv_makefile, **kwargs)
             filter_file(env["CXX"], cxx_compiler, nrniv_makefile, **kwargs)
 
+        # Filter compiler in the nrnivmodl_core_makefile
+        if self.spec.satisfies("+coreneuron"):
+            nrnmakefile = join_path(self.prefix,
+                                    'share/coreneuron/nrnivmodl_core_makefile')
+            filter_file(env['CC'],  self.compiler.cc, nrnmakefile, **kwargs)
+            filter_file(env['CXX'], self.compiler.cxx, nrnmakefile, **kwargs)
+
     # Added because the bin and lib directories are inside x86_64 dir in the
     # installation directory of autotools installation
     @when("~cmake")


### PR DESCRIPTION
- Fixes linking of `libcorenrnmech.so` with `libnrnmech.so` to avoid errors like:
```
dlopen failed -
libcorenrnmech.so: cannot open shared object file: No such file or directory
```
- This may make `x86_64` non relocatable but this is something already happening because of the absolute path passed for the linking of the library because of issue described in https://github.com/BlueBrain/spack/pull/1025/commits/67d9407a09926ce98e07fc9a05cb16f642194d90
- All of the above should go away after deploying `CoreNEURON` with `NEURON` in bb5 and avoid using the `build_neurodamus.sh` script
- Fix `CC/CXX` variable in `nrnivmodl_core_makefile` when `CoreNEURON` is installed with `neuron+coreneuron` through spack