### PR TITLE
py-h5py: deploy module with mpi.

### DIFF
--- a/deploy/configs/libraries/modules.yaml
+++ b/deploy/configs/libraries/modules.yaml
@@ -39,7 +39,7 @@ modules:
       - py-flake8
       - py-mpi4py%gcc
       - python-dev
-      - py-h5py~mpi%gcc
+      - py-h5py+mpi%gcc
       - py-numpy%gcc
       - py-poisson-recon-pybind
       - py-rtree

--- a/deploy/environments/libraries.yaml
+++ b/deploy/environments/libraries.yaml
@@ -17,7 +17,6 @@ spack:
             ospray@1.8.5,
             python,
             py-h5py,
-            py-h5py~mpi,
             py-mpi4py,
             py-numpy,
             py-pandas


### PR DESCRIPTION
See BSD-210.
