### PR TITLE
Fix import_modules in py-bluepy and py-bglibpy

### DIFF
--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -33,7 +33,8 @@ class PyBglibpy(PythonPackage):
     depends_on('py-bluepy', type='run')
     depends_on('py-libsonata', type='run')
 
-    # skip import test, because neurodamus-core requirement is not satisfied
+    # skip import test, because bglibpy needs HOC_LIBRARY_PATH
+    # that could be provided by neurodamus-core
     import_modules = []
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -33,6 +33,9 @@ class PyBglibpy(PythonPackage):
     depends_on('py-bluepy', type='run')
     depends_on('py-libsonata', type='run')
 
+    # skip import test, because neurodamus-core requirement is not satisfied
+    import_modules = []
+
     def setup_run_environment(self, env):
         env.set('NEURON_INIT_MPI', "0")
         env.unset('PMI_RANK')

--- a/var/spack/repos/builtin/packages/py-bluepy/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepy/package.py
@@ -86,5 +86,6 @@ class PyBluepy(PythonPackage):
         if self.version < Version('2.0.0'):
             # don't run import tests on older versions
             return []
-        # exclude bluepy.index because it requires libFLATIndex, unavailable on spack
-        return [m for m in super(PyBluepy, self).import_modules if m != 'bluepy.index']
+        # bluepy.index requires libFLATIndex, unavailable on spack
+        modules = super(PyBluepy, self).import_modules
+        return [m for m in modules if m != 'bluepy.index']

--- a/var/spack/repos/builtin/packages/py-bluepy/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepy/package.py
@@ -80,3 +80,14 @@ class PyBluepy(PythonPackage):
         filter_file("'jsonschema>=2.3.0',", "", "setup.py")
         filter_file("'progressbar2>=3.18',", "", "setup.py")
         filter_file("'shapely>=1.3.2',", "", "setup.py")
+
+    @property
+    def import_modules(self):
+        if self.version < Version('2.0.0'):
+            # don't run import tests on older versions
+            return []
+        # bluepy.index is excluded because it depends on libFLATIndex
+        modules = ['bluepy', 'bluepy.impl', 'bluepy.utils', 'bluepy.geometry']
+        # TODO: remove .v2 tests once they are removed from BluePy
+        modules += ['bluepy.v2', 'bluepy.v2.impl']
+        return modules

--- a/var/spack/repos/builtin/packages/py-bluepy/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepy/package.py
@@ -86,8 +86,5 @@ class PyBluepy(PythonPackage):
         if self.version < Version('2.0.0'):
             # don't run import tests on older versions
             return []
-        # bluepy.index is excluded because it depends on libFLATIndex
-        modules = ['bluepy', 'bluepy.impl', 'bluepy.utils', 'bluepy.geometry']
-        # TODO: remove .v2 tests once they are removed from BluePy
-        modules += ['bluepy.v2', 'bluepy.v2.impl']
-        return modules
+        # exclude bluepy.index because it requires libFLATIndex, unavailable on spack
+        return [m for m in super(PyBluepy, self).import_modules if m != 'bluepy.index']


### PR DESCRIPTION
`import_modules` is used to test module imports,
and it can be overridden when some modules don't need to be tested.

Note: I didn't include the switch I mentioned in NSETM-1334, because at the moment we don't have a `+libflatindex` variant:

```
        if '+libflatindex' in self.spec:
            modules.append('bluepy.index')
```