### PR TITLE
Use prod partition instead of pre_prod

### DIFF
--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -725,7 +725,7 @@ EOF
     log "concretizing environment"
     spack -D "${HOME}/build_environment" concretize -f
     log "installing environment"
-    srun -N${BUILD_NODES:-1} --ntasks-per-node 4 -c12 -t24:0:0 -Aproj16 -Ccpu -pprod -ppre_prod -J"spack!" slurmspack "${HOME}/build_environment"
+    srun -N${BUILD_NODES:-1} --ntasks-per-node 4 -c12 -t24:0:0 -Aproj16 -Ccpu -pprod -J"spack!" slurmspack "${HOME}/build_environment"
 
     cat > "${HOME}/stack.xml" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
The srun command seems to use only the value of the last -p parameter and disregards any previous -p values => these jobs are using the pre_prod partition while the prod partition could be used now.