### PR TITLE
Every neuron dependent package should use neuron%intel

### DIFF
--- a/deploy/environments/applications.yaml
+++ b/deploy/environments/applications.yaml
@@ -41,7 +41,7 @@ spack:
     - neurodamus-thalamus+coreneuron%intel^coreneuron+knl
     - parquet-converters
     - placement-algorithm
-    - psp-validation
+    - psp-validation%gcc ^neuron%intel
     - py-basalt@0.2.9
     - py-bbp-analysis-framework
     - py-bbp-workflow


### PR DESCRIPTION
  - by default packages are installed with gcc
  - if neuron is installed with gcc and then used with
    neurondamus%intel then it result into link errors
    due to different math libraries

See BSD-7 and BBPBGLIB-730