### PR TITLE
Bump psp-validation to 0.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/psp-validation/package.py
+++ b/var/spack/repos/builtin/packages/psp-validation/package.py
@@ -13,27 +13,17 @@ class PspValidation(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/nse/psp-validation"
 
     version('develop', branch='master')
-    version('0.3.3', tag='psp-validation-v0.3.3')
-    version('0.3.1', tag='psp-validation-v0.3.1')
-    version('0.3.0', tag='psp-validation-v0.3.0')
-    version('0.2.1', tag='psp-validation-v0.2.1')
-    version('0.2.0', tag='psp-validation-v0.2.0')
-    version('0.1.19', tag='psp-validation-v0.1.19')
-    version('0.1.14', tag='psp-validation-v0.1.14')
-    version('0.1.12', tag='psp-validation-v0.1.12')
+    version('0.4.0', tag='psp-validation-v0.4.0')
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('py-attrs', type='run')
+    depends_on('py-attrs@20.3.0:', type='run')
     depends_on('py-click@7.0:7.999', type='run')
-    depends_on('py-future@0.16:', when='@:0.2.1', type='run')
-    depends_on('py-h5py~mpi@2.7:2.999', type='run')
-    depends_on('py-joblib@0.13:', type='run')
+    depends_on('py-h5py~mpi@3:3.999', type='run')
+    depends_on('py-joblib@0.16:', type='run')
     depends_on('py-numpy@1.10:', type='run')
     depends_on('py-tqdm@4.0:', type='run')
-    depends_on('py-bglibpy@4.3.15:4.4.20', type='run')
-    depends_on('py-bluepy@0.16.0:1.999', type='run')
+    depends_on('py-bglibpy@4.4.27:4.999', type='run')
+    depends_on('py-bluepy@2.1:2.999', type='run')
     depends_on('py-efel@3.0.39:', type='run')
-    depends_on('neuron+python@7.8:', when='@0.2.2:', type='run')
-
-    depends_on('py-mock@3.0.5', when='@:0.3.1', type='build')  # remove in 2020
+    depends_on('neuron+python@7.8:', type='run')


### PR DESCRIPTION
This version requires `bluepy` >= 2.1.

I removed the old versions of `psp-validation` because:
- some of them have some memory leaks.
- they can still be installed from the old archives if really needed.
- I didn't find other spack packages depending on them.
- the dependencies can be simplified.

Please advice if I'm missing any reason to keep the old versions.

This PR depends on https://github.com/BlueBrain/spack/pull/1055 and https://github.com/BlueBrain/spack/pull/1054 and the CI should fail until they are approved and merged.