### PR TITLE
A package for bbpcode.epfl.ch/common/cgal-pybind [NSETM-1035]

### DIFF
--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -13,7 +13,6 @@ class PyCgalPybind(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/common/cgal-pybind"
 
     version('develop', submodules=True)
-    version('0.0.1', commit='4805c2e4c82957eb1792290941d8253394a887a4', submodules=True)
     version('0.0.2', commit='7aa1382d1628ccd51f692750a2b145b1df0694d9', submodules=True)
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -4,15 +4,16 @@ from spack import *
 class PyCgalPybind(PythonPackage):
     """Internal Python bindgins for CGAL"""
 
-    homepage = "example.com"
+    homepage = "https://bbpcode.epfl.ch/browse/code/common/cgal-pybind/tree/"
     git      = "ssh://bbpcode.epfl.ch/common/cgal-pybind"
 
-    version('develop', submodules=True)
+    version('0.0.1', commit='4805c2e4c82957eb1792290941d8253394a887a4', submodules=True)
+    version('0.0.2', commit='7aa1382d1628ccd51f692750a2b145b1df0694d9', submodules=True)
 
+    depends_on('py-setuptools', type='build')
     depends_on('boost@1.50:')
     depends_on('cmake', type='build')
     depends_on('cgal')
     depends_on('eigen')
     depends_on('py-pybind11')
     depends_on('py-numpy@1.12:', type=('build', 'run'))
-

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -1,3 +1,8 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -1,0 +1,18 @@
+from spack import *
+
+
+class PyCgalPybind(PythonPackage):
+    """Internal Python bindgins for CGAL"""
+
+    homepage = "example.com"
+    git      = "ssh://bbpcode.epfl.ch/common/cgal-pybind"
+
+    version('develop', submodules=True)
+
+    depends_on('boost@1.50:')
+    depends_on('cmake', type='build')
+    depends_on('cgal')
+    depends_on('eigen')
+    depends_on('py-pybind11')
+    depends_on('py-numpy@1.12:', type=('build', 'run'))
+

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -7,11 +7,12 @@ from spack import *
 
 
 class PyCgalPybind(PythonPackage):
-    """Internal Python bindgins for CGAL"""
+    """Internal Python bindings for CGAL"""
 
     homepage = "https://bbpcode.epfl.ch/browse/code/common/cgal-pybind/tree/"
     git      = "ssh://bbpcode.epfl.ch/common/cgal-pybind"
 
+    version('develop', submodules=True)
     version('0.0.1', commit='4805c2e4c82957eb1792290941d8253394a887a4', submodules=True)
     version('0.0.2', commit='7aa1382d1628ccd51f692750a2b145b1df0694d9', submodules=True)
 


### PR DESCRIPTION
This change adds var/spack/repos/builtin/packages/py-cgal-pybind.

The file py-cgal-pybind/package.py has been extracted from the branch
https://github.com/BlueBrain/spack/tree/cgal-pybind.

This change is to be merged into spack/tree/develop so that
cgal-pybind can be used directly (without branch switch) by
atlas-building-tools.