### PR TITLE
freetype, poppler: move to externals

### DIFF
--- a/deploy/environments/applications.yaml
+++ b/deploy/environments/applications.yaml
@@ -45,10 +45,10 @@ spack:
     - py-basalt@0.2.9
     - py-bbp-analysis-framework
     - py-bbp-workflow
-    - py-bglibpy%gcc ^neuron%intel^freetype%gcc
+    - py-bglibpy%gcc ^neuron%intel
     - py-bluepy
     - py-bluepyefe
-    - py-bluepymm%gcc ^neuron%intel^freetype%gcc
+    - py-bluepymm%gcc ^neuron%intel
     - py-bluepyopt%gcc ^neuron%intel
     - py-bluepysnap
     - py-currentscape
@@ -62,7 +62,7 @@ spack:
     - py-notebook
     - py-pytouchreader
     - py-simwriter
-    - py-sonata-network-reduction%gcc ^neuron%intel^py-ipython%gcc^freetype%gcc
+    - py-sonata-network-reduction%gcc ^neuron%intel^py-ipython%gcc
     - regiodesics
     - reportinglib%intel
     - spatial-index

--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -40,6 +40,7 @@ spack:
     - emacs
     - environment-modules@4.5.1
     - ffmpeg
+    - freetype
     - gdb~python
     - git
     - glew
@@ -61,6 +62,7 @@ spack:
     - ninja
     - openblas
     - optix
+    - poppler
     - python
     - qhull@2015.2
     - qt@5.14.2


### PR DESCRIPTION
Truncate the dependency tree. I don't think we should have a hard dependency on any freetype specifics. It'll help with concretization conflicts we have when mixing compilers.
