### PR TITLE
Fix freetype dependency for psp-validation

### DIFF
--- a/deploy/environments/applications.yaml
+++ b/deploy/environments/applications.yaml
@@ -41,7 +41,7 @@ spack:
     - neurodamus-thalamus+coreneuron%intel^coreneuron+knl
     - parquet-converters
     - placement-algorithm
-    - psp-validation%gcc ^neuron%intel
+    - psp-validation%gcc ^neuron%intel^freetype%gcc
     - py-basalt@0.2.9
     - py-bbp-analysis-framework
     - py-bbp-workflow


### PR DESCRIPTION
It should fix the latest errors in spack deployments in https://bbpcode.epfl.ch/ci/blue/organizations/jenkins/hpc.spack-deployment/detail/hpc.spack-deployment/3194/pipeline

```
04:40:20  ==> Error: Conflicts in concretized spec "psp-validation@0.3.3%gcc@9.3.0 arch=linux-rhel7-x86_64/2lh5dqa"
04:40:20  
04:40:20  List of matching conflicts for spec:
04:40:20  
04:40:20      freetype@2.10.1%intel@19.1.2.254 arch=linux-rhel7-x86_64
04:40:20          ^bzip2@1.0.8%intel@19.1.2.254+shared arch=linux-rhel7-x86_64
04:40:20          ^libpng@1.6.37%gcc@9.3.0 arch=linux-rhel7-x86_64
04:40:20              ^zlib@1.2.11%gcc@9.3.0+optimize+pic+shared arch=linux-rhel7-x86_64
04:40:20          ^pkgconf@1.7.3%intel@19.1.2.254 arch=linux-rhel7-x86_64
04:40:20  
04:40:20  1. "%intel" conflicts with "freetype@2.8:" [freetype-2.8 and above cannot be built with icc (does not support __builtin_shuffle)]
```
