### PR TITLE
Adding thalamocortex neurodamus package

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-thalamocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamocortex/package.py
@@ -1,0 +1,42 @@
+##############################################################################
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+from spack.pkg.builtin.neurodamus_model import NeurodamusModel, \
+    version_from_model_core_deps
+
+
+class NeurodamusThalamocortex(NeurodamusModel):
+    """Neurodamus with built-in neocortex model
+    """
+    homepage = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
+    git      = "ssh://bbpcode.epfl.ch/sim/models/neocortex"
+
+    resource(
+        name="thalamus",
+        git="ssh://bbpcode.epfl.ch/sim/models/thalamus",
+    )
+    resource(
+        name="mousify",
+        git="ssh://bbpcode.epfl.ch/sim/models/mousify",
+    )
+
+    # IMPORTANT: Register versions (only) here to make them stable
+    # Final version name is combined e.g. "1.0-3.0.1"
+    model_core_dep_v = (
+        ('1.3', '3.2.0'),
+    )
+    version_from_model_core_deps(model_core_dep_v)
+
+    mech_name = "thalamocortex"
+
+    @run_before('build_model')
+    def prepare_mods(self):
+        copy_all('mousify/mod', 'mod', make_link)
+        copy_all('thalamus/mod', 'mod', make_link)
+        copy_all('mod/v5', 'mod', make_link)
+        copy_all('mod/v6', 'mod', make_link)
+        force_remove('mod/optimized')
+

--- a/var/spack/repos/builtin/packages/neurodamus-thalamocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamocortex/package.py
@@ -17,10 +17,12 @@ class NeurodamusThalamocortex(NeurodamusModel):
     resource(
         name="thalamus",
         git="ssh://bbpcode.epfl.ch/sim/models/thalamus",
+        tag="1.3"
     )
     resource(
         name="mousify",
         git="ssh://bbpcode.epfl.ch/sim/models/mousify",
+        tag="1.3"
     )
 
     # IMPORTANT: Register versions (only) here to make them stable
@@ -39,4 +41,3 @@ class NeurodamusThalamocortex(NeurodamusModel):
         copy_all('mod/v5', 'mod', make_link)
         copy_all('mod/v6', 'mod', make_link)
         force_remove('mod/optimized')
-


### PR DESCRIPTION
**This PR**
Create package to install a version suitable for multi-circuit Thalamo-Cortex simulations.
User will be able to `spack load neurodamus-thalamocortex`

**Details**
Instead of further customization of variants, this package is so specialized that it was decided to create an entire new one and avoid polluting neocortex. Version os the package will follow that of neocortex, given it's the main driver