### PR TITLE
Merge upstream changes to the compiler wrapper.

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -125,7 +125,7 @@ case "$command" in
         comp="FC"
         lang_flags=F
         ;;
-    f77|xlf|xlf_r|pgf77|frt|flang)
+    f77|xlf|xlf_r|pgf77)
         command="$SPACK_F77"
         language="Fortran 77"
         comp="F77"
@@ -284,7 +284,7 @@ while [ -n "$1" ]; do
     case "$1" in
         -isystem*)
             arg="${1#-isystem}"
-	    isystem_was_used=true
+            isystem_was_used=true
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             if system_dir "$arg"; then
                 isystem_system_includes+=("$arg")
@@ -320,9 +320,13 @@ while [ -n "$1" ]; do
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             if [[ "$arg" = -rpath=* ]]; then
                 rp="${arg#-rpath=}"
+            elif [[ "$arg" = --rpath=* ]]; then
+                rp="${arg#--rpath=}"
             elif [[ "$arg" = -rpath,* ]]; then
                 rp="${arg#-rpath,}"
-            elif [[ "$arg" = -rpath ]]; then
+            elif [[ "$arg" = --rpath,* ]]; then
+                rp="${arg#--rpath,}"
+            elif [[ "$arg" =~ ^-?-rpath$ ]]; then
                 shift; arg="$1"
                 if [[ "$arg" != -Wl,* ]]; then
                     die "-Wl,-rpath was not followed by -Wl,*"
@@ -339,7 +343,9 @@ while [ -n "$1" ]; do
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             if [[ "$arg" = -rpath=* ]]; then
                 rp="${arg#-rpath=}"
-            elif [[ "$arg" = -rpath ]]; then
+            elif [[ "$arg" = --rpath=* ]]; then
+                rp="${arg#--rpath=}"
+            elif [[ "$arg" = -rpath  ]] || [[ "$arg" = --rpath ]]; then
                 shift; arg="$1"
                 if [[ "$arg" != -Xlinker,* ]]; then
                     die "-Xlinker,-rpath was not followed by -Xlinker,*"
@@ -434,7 +440,7 @@ then
         ld)
             flags=("${flags[@]}" -headerpad_max_install_names) ;;
         ccld)
-            flags=("${flags[@]}" -Wl,-headerpad_max_install_names) ;;
+            flags=("${flags[@]}" "-Wl,-headerpad_max_install_names") ;;
     esac
 fi
 
@@ -491,19 +497,19 @@ args+=("${flags[@]}")
 # Insert include directories just prior to any system include directories
 
 for dir in "${includes[@]}";         do args+=("-I$dir"); done
-for dir in "${isystem_includes[@]}";         do args+=("-isystem$dir"); done
+for dir in "${isystem_includes[@]}";         do args+=("-isystem" "$dir"); done
 
 IFS=':' read -ra spack_include_dirs <<< "$SPACK_INCLUDE_DIRS"
 if [[ $mode == cpp || $mode == cc || $mode == as || $mode == ccld ]]; then
     if [[ "$isystem_was_used" == "true" ]] ; then
-	for dir in "${spack_include_dirs[@]}";  do args+=("-isystem$dir"); done
+        for dir in "${spack_include_dirs[@]}";  do args+=("-isystem" "$dir"); done
     else
-	for dir in "${spack_include_dirs[@]}";  do args+=("-I$dir"); done
+        for dir in "${spack_include_dirs[@]}";  do args+=("-I$dir"); done
     fi
 fi
 
 for dir in "${system_includes[@]}";  do args+=("-I$dir"); done
-for dir in "${isystem_system_includes[@]}";  do args+=("-isystem$dir"); done
+for dir in "${isystem_system_includes[@]}";  do args+=("-isystem" "$dir"); done
 
 # Library search paths
 for dir in "${libdirs[@]}";          do args+=("-L$dir"); done
@@ -512,12 +518,12 @@ for dir in "${system_libdirs[@]}";   do args+=("-L$dir"); done
 # RPATHs arguments
 case "$mode" in
     ccld)
-        if [ ! -z "$dtags_to_add" ] ; then args+=("$linker_arg$dtags_to_add") ; fi
+        if [ -n "$dtags_to_add" ] ; then args+=("$linker_arg$dtags_to_add") ; fi
         for dir in "${rpaths[@]}";        do args+=("$rpath$dir"); done
         for dir in "${system_rpaths[@]}"; do args+=("$rpath$dir"); done
         ;;
     ld)
-        if [ ! -z "$dtags_to_add" ] ; then args+=("$dtags_to_add") ; fi
+        if [ -n "$dtags_to_add" ] ; then args+=("$dtags_to_add") ; fi
         for dir in "${rpaths[@]}";        do args+=("-rpath" "$dir"); done
         for dir in "${system_rpaths[@]}"; do args+=("-rpath" "$dir"); done
         ;;

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -28,6 +28,7 @@ test_args = [
     '-Wl,--end-group',
     '-Xlinker', '-rpath', '-Xlinker', '/third/rpath',
     '-Xlinker', '-rpath', '-Xlinker', '/fourth/rpath',
+    '-Wl,--rpath,/fifth/rpath', '-Wl,--rpath', '-Wl,/sixth/rpath',
     '-llib3', '-llib4',
     'arg5', 'arg6']
 
@@ -45,11 +46,13 @@ test_library_paths = [
 
 test_wl_rpaths = [
     '-Wl,-rpath,/first/rpath', '-Wl,-rpath,/second/rpath',
-    '-Wl,-rpath,/third/rpath', '-Wl,-rpath,/fourth/rpath']
+    '-Wl,-rpath,/third/rpath', '-Wl,-rpath,/fourth/rpath',
+    '-Wl,-rpath,/fifth/rpath', '-Wl,-rpath,/sixth/rpath']
 
 test_rpaths = [
     '-rpath', '/first/rpath', '-rpath', '/second/rpath',
-    '-rpath', '/third/rpath', '-rpath', '/fourth/rpath']
+    '-rpath', '/third/rpath', '-rpath', '/fourth/rpath',
+    '-rpath', '/fifth/rpath', '-rpath', '/sixth/rpath']
 
 test_args_without_paths = [
     'arg1',
@@ -347,15 +350,15 @@ def test_ccld_deps_isystem():
     with set_env(SPACK_INCLUDE_DIRS='xinc:yinc:zinc',
                  SPACK_RPATH_DIRS='xlib:ylib:zlib',
                  SPACK_LINK_DIRS='xlib:ylib:zlib'):
-        mytest_args = test_args + ['-isystemfooinc']
+        mytest_args = test_args + ['-isystem', 'fooinc']
         check_args(
             cc, mytest_args,
             [real_cc] +
             test_include_paths +
-            ['-isystemfooinc',
-             '-isystemxinc',
-             '-isystemyinc',
-             '-isystemzinc'] +
+            ['-isystem', 'fooinc',
+             '-isystem', 'xinc',
+             '-isystem', 'yinc',
+             '-isystem', 'zinc'] +
             test_library_paths +
             ['-Lxlib',
              '-Lylib',
@@ -429,20 +432,20 @@ def test_ccld_with_system_dirs_isystem():
                  SPACK_RPATH_DIRS='xlib:ylib:zlib',
                  SPACK_LINK_DIRS='xlib:ylib:zlib'):
 
-        sys_path_args = ['-isystem/usr/include',
+        sys_path_args = ['-isystem', '/usr/include',
                          '-L/usr/local/lib',
                          '-Wl,-rpath,/usr/lib64',
-                         '-isystem/usr/local/include',
+                         '-isystem', '/usr/local/include',
                          '-L/lib64/']
         check_args(
             cc, sys_path_args + test_args,
             [real_cc] +
             test_include_paths +
-            ['-isystemxinc',
-             '-isystemyinc',
-             '-isystemzinc'] +
-            ['-isystem/usr/include',
-             '-isystem/usr/local/include'] +
+            ['-isystem', 'xinc',
+             '-isystem', 'yinc',
+             '-isystem', 'zinc'] +
+            ['-isystem', '/usr/include',
+             '-isystem', '/usr/local/include'] +
             test_library_paths +
             ['-Lxlib',
              '-Lylib',


### PR DESCRIPTION
Most notably this includes a fix to include a space after `-isystem`, which keeps `nvhpc` compilers happy.

This commit includes upstream commits spack/spack@984ae7e6952072982d3197a570b18765ab264c70 through spack/spack@15645147ed55ee5c77ed3b9672d97d8d4988a880.

With this change then CoreNEURON and dependencies (including `hdf5`) build with NVHPC 21.2.

cc: @pramodk 