### PR TITLE
Adding py-neurodamus 2.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-neurodamus/package.py
+++ b/var/spack/repos/builtin/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-py"
 
     version('develop', branch='master')
+    version('2.5.0',   tag='2.5.0')
     version('2.4.0',   tag='2.4.0')
     version('2.3.1',   tag='2.3.1')
     version('2.3.0',   tag='2.3.0')


### PR DESCRIPTION
Version includes a number of major additions, including:

 * 1fc7995 Support for Multi-Circuit
 * ca29fd0 Checks for connection configurations blocks
 * 6f891c5 Initial NGV support
 * 123d4e8 Implementing reading src/dst population from edges meta
 * Latest fixes...