### PR TITLE
Add missing dependencies to neuron and py-cmake-format and fix py-mpi4py%nvhpc.

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -102,6 +102,7 @@ class Neuron(CMakePackage):
     depends_on("gettext")
 
     depends_on("mpi",         when="+mpi")
+    depends_on("py-mpi4py",   when="+mpi+python+tests")
     depends_on("ncurses",     when="~cross-compile")
     depends_on("python@2.6:", when="+python", type=("build", "link", "run"))
     depends_on("py-pytest",   when="+python+tests")

--- a/var/spack/repos/builtin/packages/py-cmake-format/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake-format/package.py
@@ -22,3 +22,4 @@ class PyCmakeFormat(PythonPackage):
 
     depends_on('py-setuptools',  type=('build', 'run'))
     depends_on('py-six@1.13.0:', type=('build', 'run'))
+    depends_on('py-pyyaml', type=('run'))

--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -31,6 +31,15 @@ class PyMpi4py(PythonPackage):
     def build_args(self, spec, prefix):
         return ['--mpicc=%s -shared' % spec['mpi'].mpicc]
 
+    def setup_build_environment(self, env):
+        # Python is not built with NVHPC, but the compiler flags that were used
+        # to build Python are inherited by the build of py-mpi4py and passed to
+        # NVHPC. This can lead to errors, but by injecting this extra flag we
+        # can demote those errors to warnings.
+        if self.spec.compiler.name == 'nvhpc':
+            env.append_flags('SPACK_CFLAGS', '-noswitcherror')
+            env.append_flags('SPACK_CXXFLAGS', '-noswitcherror')
+
     @property
     def headers(self):
         headers = find_all_headers(self.prefix.lib)


### PR DESCRIPTION
- Add py-pyyaml dependency in py-cmake-format.
- Add py-mpi4py dependency in neuron (cc: @pramodk)