### PR TITLE
CUDA fix : Add CUPTI libraries to LD_LIBRARY_PATH

### DIFF
--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -33,7 +33,7 @@ spack:
     - cli-tools
     - cmake@3.15.7
     - cuda@10.1.243
-    - cuda@11.1.0
+    - cuda@11.0.2
     - cudnn@7.3.0.29-9.0-linux-x64
     - darshan-runtime
     - darshan-util

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -122,6 +122,7 @@ class Cuda(Package):
 
     def setup_run_environment(self, env):
         env.set('CUDA_HOME', self.prefix)
+        env.append_path('LD_LIBRARY_PATH', self.prefix.extras.CUPTI.lib64)
 
     def install(self, spec, prefix):
         if os.path.exists('/tmp/cuda-installer.log'):


### PR DESCRIPTION
* In order to use pc_sampling feature with nvprof  or ncu, CUPTI must be in LD_LIBRARY_PATH
* This issue was debugged with Max Kartz from NVIDIA
* See https://github.com/spack/spack/pull/22704

Also, do not install CUDA 11.1 but either 11.0 or 11.2 for data centre deployments. See https://www.nvidia.com/Download/index.aspx.