### PR TITLE
Fix py-deprecation dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-deprecation/package.py
+++ b/var/spack/repos/builtin/packages/py-deprecation/package.py
@@ -17,4 +17,4 @@ class PyDeprecation(PythonPackage):
     version('2.0.7', sha256='c0392f676a6146f0238db5744d73e786a43510d54033f80994ef2f4c9df192ed')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-packaging', type='build')
+    depends_on('py-packaging', type=('build', 'run'))


### PR DESCRIPTION
After `py-morph-tool` has been updated to 2.4.0 in https://github.com/BlueBrain/spack/pull/1106 and it started to depend on `py-deprecation@2.1.0:`, `pip check` fails with the error:
```
deprecation 2.1.0 requires packaging, which is not installed.
```
This PR adds `type='run'` to the `py-packaging` dependency, because according to https://github.com/briancurtin/deprecation/blob/2.0.7/setup.py and https://github.com/briancurtin/deprecation/blob/2.1.0/setup.py,  `deprecation` requires `packaging`.