### PR TITLE
Deploy nvhpc 21.1 instead of 21.2

### DIFF
--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -22,8 +22,7 @@ spack:
       variants: +mpi~cuda~cupti+caliper~gperftools~python
   specs:
     - llvm@11.0.0 +python
-    - nvhpc@20.9 install_type=network
-    - nvhpc@21.2 install_type=network
+    - nvhpc@21.1 install_type=network
     - arm-forge@20.2.0-Redhat-7.0-x86_64
     - blender
     - boost~mpi@1.73.0


### PR DESCRIPTION
 - rational for removing 21.2 is that "module load nvhpc"
   will load 21.2 and it's incompatible with default CUDA
   11.0 unless we specify -ta=cuda flag

@olupton : do I remember above correctly?