### PR TITLE
Adding MorphIO 3.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/morphio/package.py
+++ b/var/spack/repos/builtin/packages/morphio/package.py
@@ -14,6 +14,7 @@ class Morphio(CMakePackage):
     git      = "https://github.com/BlueBrain/MorphIO.git"
 
     version('develop', git=url, submodules=True)
+    version('3.0.2', tag='v3.0.2', submodules=True)
     version('2.3.9', tag='v2.3.9', submodules=True)
     version('2.3.4', tag='v2.3.4', submodules=True)
     version('2.2.1', tag='v2.2.1', submodules=True)


### PR DESCRIPTION
This new version does not add dependencies that s why the changes are so small for a major bump. 