### PR TITLE
Create and deploy py-poisson-recon-pybind [NSETM-1396]

### DIFF
--- a/deploy/configs/libraries/modules.yaml
+++ b/deploy/configs/libraries/modules.yaml
@@ -41,6 +41,7 @@ modules:
       - python-dev
       - py-h5py~mpi%gcc
       - py-numpy%gcc
+      - py-poisson-recon-pybind
       - py-rtree
       - py-scikit-learn
       - py-virtualenv

--- a/deploy/environments/libraries.yaml
+++ b/deploy/environments/libraries.yaml
@@ -105,6 +105,7 @@ spack:
     - py-pip
     - py-plotly
     - py-ply
+    - py-poisson-recon-pybind
     - py-pre-commit
     - py-progress
     - py-py4j

--- a/var/spack/repos/builtin/packages/py-poisson-recon-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-poisson-recon-pybind/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPoissonReconPybind(PythonPackage):
+    """Internal Python bindings for PoissonRecon's surface reconstruction algorithm"""
+
+    homepage = "https://bbpgitlab.epfl.ch/nse/poisson-recon-pybind"
+    git      = "git@bbpgitlab.epfl.ch:nse/poisson-recon-pybind.git"
+
+    version('0.1.0', tag='poisson_recon_pybind-v0.1.0', submodules=True)
+
+    depends_on('py-setuptools', type='build')
+    depends_on('boost@1.50:')
+    depends_on('cmake', type='build')
+    depends_on('eigen')
+    depends_on('py-numpy@1.12:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-poisson-recon-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-poisson-recon-pybind/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class PyPoissonReconPybind(PythonPackage):
     """
-    Internal Python bindings for PoissonRecon's surface reconstruction 
+    Internal Python bindings for PoissonRecon's surface reconstruction
     algorithm
     """
 

--- a/var/spack/repos/builtin/packages/py-poisson-recon-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-poisson-recon-pybind/package.py
@@ -7,7 +7,10 @@ from spack import *
 
 
 class PyPoissonReconPybind(PythonPackage):
-    """Internal Python bindings for PoissonRecon's surface reconstruction algorithm"""
+    """
+    Internal Python bindings for PoissonRecon's surface reconstruction 
+    algorithm
+    """
 
     homepage = "https://bbpgitlab.epfl.ch/nse/poisson-recon-pybind"
     git      = "git@bbpgitlab.epfl.ch:nse/poisson-recon-pybind.git"


### PR DESCRIPTION
This spack package makes the python bindings of PoissonRecon surface reconstruction algorithm
(source: https://github.com/intel-isl/Open3D-PoissonRecon) available for nse/atlas-building-tools.

This circumvents the full packaging and installation of Open3D
as explained in https://bbpteam.epfl.ch/project/issues/browse/NSETM-1396.