### PR TITLE
py-rtree: set environment variables SPATIALINDEX_LIBRARY_* [NSETM-1396]

### DIFF
--- a/var/spack/repos/builtin/packages/py-rtree/package.py
+++ b/var/spack/repos/builtin/packages/py-rtree/package.py
@@ -22,3 +22,6 @@ class PyRtree(PythonPackage):
                 join_path(lib, 'libspatialindex.%s'   % dso_suffix))
         env.set('SPATIALINDEX_C_LIBRARY',
                 join_path(lib, 'libspatialindex_c.%s' % dso_suffix))
+
+    def setup_run_environment(self, env):
+        self.setup_build_environment(env)


### PR DESCRIPTION
This change sets the two environment variables SPATIALINDEX_LIBRARY and SPATIALINDEX_C_LIBRARY
when py-rtree is loaded via the command `module load py-rtree`.

This is required to use rtree as a python module.