### PR TITLE
steps: use bbpgitlab instead of github as clone URL

### DIFF
--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -10,7 +10,7 @@ class Steps(CMakePackage):
     """STochastic Engine for Pathway Simulation"""
 
     homepage = "https://groups.oist.jp/cnu/software"
-    git      = "git@github.com:CNS-OIST/HBP_STEPS.git"
+    git      = "git@bbpgitlab.epfl.ch:hpc/HBP_STEPS.git"
 
     version("develop", branch="master", submodules=True)
     version("3.6.0", submodules=True)


### PR DESCRIPTION
This change allows using bb5_map tag in GitLab CI.

It doesn't change anything from the user perspective since
GitHub repository is private already and OIST people can access
bbpgitlab.