### PR TITLE
Bump NEURON/CoreNEURON/NMODL versions.

### DIFF
--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -68,7 +68,7 @@ class Coreneuron(CMakePackage):
     depends_on('tau', when='+profile')
 
     # nmodl specific dependency
-    depends_on('nmodl@0.3:', when='@1.0.0:+nmodl')
+    depends_on('nmodl@0.3.0:', when='@1.0.0:+nmodl')
     depends_on('nmodl@0.3b', when='@0.17:1.0b+nmodl')
     depends_on('nmodl@0.3a', when='@0:0.16+nmodl')
     depends_on('eigen@3.3.4:', when='+nmodl')

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -19,7 +19,9 @@ class Coreneuron(CMakePackage):
     git      = "https://github.com/BlueBrain/CoreNeuron"
 
     version('develop', branch='master')
-    version('1.0b', tag="1.0b", submodules=True, preferred=True)
+    # 1.0.0 > 1.0b > 1.0 as far as Spack is concerned
+    version('1.0.0', tag='1.0', preferred=True)
+    version('1.0b', tag="1.0b", submodules=True)
     version('1.0a', commit="857551a", submodules=True)
     version('0.23b', commit="be131ec", submodules=True)
     version('0.22', tag='0.22', submodules=True)
@@ -57,7 +59,8 @@ class Coreneuron(CMakePackage):
 
     depends_on('boost', when='+tests')
     depends_on('cuda', when='+gpu')
-    depends_on('flex', type='build')
+    depends_on('flex', type='build', when='~nmodl')
+    depends_on('flex@2.6:', type='build', when='+nmodl')
     depends_on('mpi', when='+mpi')
     depends_on('reportinglib', when='+report')
     depends_on('libsonata-report', when='+report')
@@ -65,7 +68,8 @@ class Coreneuron(CMakePackage):
     depends_on('tau', when='+profile')
 
     # nmodl specific dependency
-    depends_on('nmodl@0.3b:', when='@0.17:+nmodl')
+    depends_on('nmodl@0.3:', when='@1.0.0:+nmodl')
+    depends_on('nmodl@0.3b', when='@0.17:1.0b+nmodl')
     depends_on('nmodl@0.3a', when='@0:0.16+nmodl')
     depends_on('eigen@3.3.4:', when='+nmodl')
     depends_on('ispc', when='+ispc')

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -20,6 +20,7 @@ class Coreneuron(CMakePackage):
 
     version('develop', branch='master')
     # 1.0.0 > 1.0b > 1.0 as far as Spack is concerned
+    version('1.0.1', commit='251ee12', preferred=True)
     version('1.0.0', tag='1.0', preferred=True)
     version('1.0b', tag="1.0b", submodules=True)
     version('1.0a', commit="857551a", submodules=True)

--- a/var/spack/repos/builtin/packages/libsonata-report/package.py
+++ b/var/spack/repos/builtin/packages/libsonata-report/package.py
@@ -17,7 +17,7 @@ class LibsonataReport(CMakePackage):
     git = "https://github.com/BlueBrain/libsonatareport.git"
 
     version('develop', branch='master', submodules=False, get_full_repo=True)
-    version('0.1', tag='0.1', submodules=False)
+    version('0.1.0', tag='0.1', submodules=False)
     version('0.1b', tag='0.1b', submodules=False)
     version('0.1a', tag='0.1a', submodules=False)
 

--- a/var/spack/repos/builtin/packages/libsonata-report/package.py
+++ b/var/spack/repos/builtin/packages/libsonata-report/package.py
@@ -17,6 +17,7 @@ class LibsonataReport(CMakePackage):
     git = "https://github.com/BlueBrain/libsonatareport.git"
 
     version('develop', branch='master', submodules=False, get_full_repo=True)
+    version('0.1', tag='0.1', submodules=False)
     version('0.1b', tag='0.1b', submodules=False)
     version('0.1a', tag='0.1a', submodules=False)
 

--- a/var/spack/repos/builtin/packages/neurodamus-core/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-core/package.py
@@ -20,6 +20,7 @@ class NeurodamusCore(SimModel):
     git      = "ssh://bbpcode.epfl.ch/sim/neurodamus-core"
 
     version('develop', branch='master', get_full_repo=False)
+    version('3.3.0',  tag='3.3.0', get_full_repo=False)
     version('3.2.2',  tag='3.2.2', get_full_repo=False)
     version('3.2.0',  tag='3.2.0', get_full_repo=False)
     version('3.1.0',  tag='3.1.0', get_full_repo=False)

--- a/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-hippocampus/package.py
@@ -20,7 +20,7 @@ class NeurodamusHippocampus(NeurodamusModel):
     # IMPORTANT: Register versions (only) here to make them stable
     # Final version name is combined e.g. "1.0-3.0.1"
     model_core_dep_v = (
-        ('1.5', '3.2.2'),
+        ('1.5', '3.3.0'),
         ('1.4.1', '3.2.0'),
         ('1.3', '3.1.0'),
         ('1.2', '3.1.0'),

--- a/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-mousify/package.py
@@ -20,7 +20,7 @@ class NeurodamusMousify(NeurodamusModel):
     # IMPORTANT: Register versions (only) here to make them stable
     # Final version name is combined e.g. "1.0-3.0.1"
     model_core_dep_v = (
-        ('1.4', '3.2.2'),
+        ('1.4', '3.3.0'),
         ('1.3', '3.2.0'),
         ('1.2', '3.1.0'),
         ('1.1', '3.0.2'),

--- a/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-neocortex/package.py
@@ -17,7 +17,7 @@ class NeurodamusNeocortex(NeurodamusModel):
     # IMPORTANT: Register versions (only) here to make them stable
     # Final version name is combined e.g. "1.0-3.0.1"
     model_core_dep_v = (
-        ('1.4', '3.2.2'),
+        ('1.4', '3.3.0'),
         ('1.3', '3.2.0'),
         ('1.2', '3.1.0'),
         ('1.1', '3.0.2'),

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -19,7 +19,7 @@ class NeurodamusThalamus(NeurodamusModel):
     # IMPORTANT: Register versions (only) here to make them stable
     # Final version name is combined e.g. "1.0-3.0.1"
     model_core_dep_v = (
-        ('1.4', '3.2.2'),
+        ('1.4', '3.3.0'),
         ('1.3', '3.2.0'),
         ('1.2', '3.1.0'),
         ('1.1', '3.0.2'),

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -32,7 +32,8 @@ class Neuron(CMakePackage):
     patch("fix_brew_py_18e97a2d.patch", when="@7.8.0c")
 
     version("develop", branch="master")
-    version("8.0b",  commit="eb8d038", preferred=True)
+    version("8.0.0", tag="8.0.0", preferred=True)
+    version("8.0b",  commit="eb8d038")
     version("8.0a",  tag="8.0a")
     version("7.9.0b",  commit="94147e5")
     version("7.9.0a",  commit="fc74b85")
@@ -113,7 +114,7 @@ class Neuron(CMakePackage):
     depends_on("tau",         when="+profile")
     depends_on("coreneuron+legacy-unit", when="+coreneuron+legacy-unit")
     depends_on("coreneuron~legacy-unit", when="+coreneuron~legacy-unit")
-    depends_on("py-pytest-cov", when="+tests@develop:")
+    depends_on("py-pytest-cov", when="+tests@8.0b:")
 
     conflicts("+cmake",   when="@0:7.8.0b,2018-10")
     conflicts("~shared",  when="+python")

--- a/var/spack/repos/builtin/packages/nmodl/package.py
+++ b/var/spack/repos/builtin/packages/nmodl/package.py
@@ -14,6 +14,7 @@ class Nmodl(CMakePackage):
     git      = "https://github.com/BlueBrain/nmodl.git"
 
     version('develop', branch='master', submodules=True)
+    version('0.3', tag='0.3', preferred=True)
     version('0.3b', commit="c30ea06", submodules=True)
     version('0.3a', commit="86fc52d", submodules=True)
     version('0.2', tag='0.2', submodules=True)

--- a/var/spack/repos/builtin/packages/nmodl/package.py
+++ b/var/spack/repos/builtin/packages/nmodl/package.py
@@ -14,7 +14,8 @@ class Nmodl(CMakePackage):
     git      = "https://github.com/BlueBrain/nmodl.git"
 
     version('develop', branch='master', submodules=True)
-    version('0.3', tag='0.3', preferred=True)
+    # 0.3.0 > 0.3b > 0.3 as far as Spack is concerned
+    version('0.3.0', tag='0.3', preferred=True)
     version('0.3b', commit="c30ea06", submodules=True)
     version('0.3a', commit="86fc52d", submodules=True)
     version('0.2', tag='0.2', submodules=True)


### PR DESCRIPTION
Add new releases:
- NEURON v8.0.0
- CoreNEURON v1.0.0 (branded as v1.0 elsewhere)
- NMODL v0.3.0 (branded as v0.3 elsewhere)

And tweak the specification of NEURON's dependency on `py-pytest-cov`.

The CoreNEURON and NMODL version numbers have the extra `.0` so that Spack's version comparison considers the new releases to be newer than their alpha/beta versions (`1.0a`, `1.0b`, `0.3a`, `0.3b`).