### PR TITLE
Add version 0.1.0 to py-cgal-pybind/package.py [NSETM-1454]

### DIFF
--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -9,21 +9,12 @@ from spack import *
 class PyCgalPybind(PythonPackage):
     """Internal Python bindings for CGAL"""
 
-    homepage = "https://bbpcode.epfl.ch/browse/code/common/cgal-pybind/tree/"
+    homepage = "https://bbpgitlab.epfl.ch/nse/cgal-pybind"
+    git = "git@bbpgitlab.epfl.ch:nse/cgal-pybind.git"
 
     version("develop", submodules=True)
-    version(
-        "0.1.0",
-        tag="cgal_pybind-v0.1.0",
-        submodules=True,
-        git="git@bbpgitlab.epfl.ch:nse/cgal-pybind.git",  # migration to gitlab
-    )
-    version(
-        "0.0.2",
-        commit="7aa1382d1628ccd51f692750a2b145b1df0694d9",
-        submodules=True,
-        git="ssh://bbpcode.epfl.ch/common/cgal-pybind",
-    )
+    version("0.1.0", commit="e705d703b18e9bc1207b9ac2c0eb32af9ef66306", submodules=True)
+    version("0.0.2", commit="7aa1382d1628ccd51f692750a2b145b1df0694d9", submodules=True)
 
     depends_on("py-setuptools", type="build")
     depends_on("boost@1.50:")

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -11,23 +11,25 @@ class PyCgalPybind(PythonPackage):
 
     homepage = "https://bbpcode.epfl.ch/browse/code/common/cgal-pybind/tree/"
 
-    version('develop', submodules=True)
-    version('0.0.2',
-        commit='7aa1382d1628ccd51f692750a2b145b1df0694d9',
+    version("develop", submodules=True)
+    version(
+        "0.0.2",
+        commit="7aa1382d1628ccd51f692750a2b145b1df0694d9",
         submodules=True,
-        git="ssh://bbpcode.epfl.ch/common/cgal-pybind"
+        git="ssh://bbpcode.epfl.ch/common/cgal-pybind",
     )
 
-    version('0.1.0',
-        tag='cgal_pybind-v0.1.0',
+    version(
+        "0.1.0",
+        tag="cgal_pybind-v0.1.0",
         submodules=True,
-        git="git@bbpgitlab.epfl.ch:nse/cgal-pybind.git"  # migration to gitlab
+        git="git@bbpgitlab.epfl.ch:nse/cgal-pybind.git",  # migration to gitlab
     )
 
-    depends_on('py-setuptools', type='build')
-    depends_on('boost@1.50:')
-    depends_on('cmake', type='build')
-    depends_on('cgal')
-    depends_on('eigen')
-    depends_on('py-pybind11')
-    depends_on('py-numpy@1.12:', type=('build', 'run'))
+    depends_on("py-setuptools", type="build")
+    depends_on("boost@1.50:")
+    depends_on("cmake", type="build")
+    depends_on("cgal")
+    depends_on("eigen")
+    depends_on("py-pybind11")
+    depends_on("py-numpy@1.12:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -10,10 +10,19 @@ class PyCgalPybind(PythonPackage):
     """Internal Python bindings for CGAL"""
 
     homepage = "https://bbpcode.epfl.ch/browse/code/common/cgal-pybind/tree/"
-    git      = "ssh://bbpcode.epfl.ch/common/cgal-pybind"
 
     version('develop', submodules=True)
-    version('0.0.2', commit='7aa1382d1628ccd51f692750a2b145b1df0694d9', submodules=True)
+    version('0.0.2',
+        commit='7aa1382d1628ccd51f692750a2b145b1df0694d9',
+        submodules=True,
+        git="ssh://bbpcode.epfl.ch/common/cgal-pybind"
+    )
+
+    version('0.1.0',
+        tag='cgal_pybind-v0.1.0',
+        submodules=True,
+        git="git@bbpgitlab.epfl.ch:nse/cgal-pybind.git"  # migration to gitlab
+    )
 
     depends_on('py-setuptools', type='build')
     depends_on('boost@1.50:')

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -13,8 +13,7 @@ class PyCgalPybind(PythonPackage):
     git = "git@bbpgitlab.epfl.ch:nse/cgal-pybind.git"
 
     version("develop", submodules=True)
-    version("0.1.0", commit="e705d703b18e9bc1207b9ac2c0eb32af9ef66306", submodules=True)
-    version("0.0.2", commit="7aa1382d1628ccd51f692750a2b145b1df0694d9", submodules=True)
+    version("0.1.0", tag="cgal_pybind-v0.1.0", submodules=True)
 
     depends_on("py-setuptools", type="build")
     depends_on("boost@1.50:")

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -13,17 +13,16 @@ class PyCgalPybind(PythonPackage):
 
     version("develop", submodules=True)
     version(
-        "0.0.2",
-        commit="7aa1382d1628ccd51f692750a2b145b1df0694d9",
-        submodules=True,
-        git="ssh://bbpcode.epfl.ch/common/cgal-pybind",
-    )
-
-    version(
         "0.1.0",
         tag="cgal_pybind-v0.1.0",
         submodules=True,
         git="git@bbpgitlab.epfl.ch:nse/cgal-pybind.git",  # migration to gitlab
+    )
+    version(
+        "0.0.2",
+        commit="7aa1382d1628ccd51f692750a2b145b1df0694d9",
+        submodules=True,
+        git="ssh://bbpcode.epfl.ch/common/cgal-pybind",
     )
 
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
This new version of py-cgal-pybind has no install dependency on trimesh anymore
but only an extra dependency named "tests".

This allows consumers of the cgal-pybind API like atlas-building-tools
to lower the required version of trimesh so that it matches the versions
available in BBP's py-trimesh/package.py, currently trimesh==2.38.10.

See https://github.com/BlueBrain/spack/pull/1152 for full context.