### PR TITLE
Add an NVHPC build of [Core]NEURON

### DIFF
--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -85,6 +85,7 @@ modules:
       - '%gcc'
       - '%intel'
       - '%clang'
+      - '%nvhpc'
       - '%pgi'
     projections:
       all: '{name}/{version}'

--- a/deploy/configs/externals/modules.yaml
+++ b/deploy/configs/externals/modules.yaml
@@ -62,6 +62,7 @@ modules:
       - '%gcc'
       - '%intel'
       - '%clang'
+      - '%nvhpc'
       - '%pgi'
     projections:
       all: '{name}/{version}'

--- a/deploy/configs/libraries/modules.yaml
+++ b/deploy/configs/libraries/modules.yaml
@@ -50,6 +50,7 @@ modules:
       - '%gcc'
       - '%intel'
       - '%clang'
+      - '%nvhpc'
       - '%pgi'
     projections:
       all: '{name}/{version}'

--- a/deploy/environments/libraries.yaml
+++ b/deploy/environments/libraries.yaml
@@ -41,6 +41,7 @@ spack:
     - morpho-kit
     - mvdtool+mpi
     - neuron+mpi~debug%intel
+    - neuron+coreneuron~legacy-unit%nvhpc ^coreneuron+gpu~legacy-unit~report ^py-numpy%gcc
     - nlohmann-json +single_header
     - omega-h+trilinos
     - omega-h+gmsh+trilinos

--- a/deploy/environments/libraries.yaml
+++ b/deploy/environments/libraries.yaml
@@ -41,7 +41,7 @@ spack:
     - morpho-kit
     - mvdtool+mpi
     - neuron+mpi~debug%intel
-    - neuron+coreneuron~legacy-unit%nvhpc ^coreneuron+gpu~legacy-unit~report ^py-numpy%gcc
+    - neuron+coreneuron~legacy-unit%nvhpc ^coreneuron+gpu~legacy-unit~report ^py-cython%gcc ^py-numpy%gcc
     - nlohmann-json +single_header
     - omega-h+trilinos
     - omega-h+gmsh+trilinos


### PR DESCRIPTION
This should:
 - speed up the CoreNEURON CI, which currently re-builds some dependencies with `%nvhpc`
 - make sure we notice if `nvhpc` deployment fails