### PR TITLE
build tests: put an upper bound on the GCC version

### DIFF
--- a/.github/workflows/linux_build_tests.yaml
+++ b/.github/workflows/linux_build_tests.yaml
@@ -30,7 +30,7 @@ jobs:
         package:
         - lz4  # MakefilePackage
         - mpich~fortran  # AutotoolsPackage
-        - tut  # WafPackage
+        - 'tut%gcc@:10.99.99'  # WafPackage
         - py-setuptools  # PythonPackage
         - openjpeg  # CMakePackage
         - r-rcpp  # RPackage

--- a/var/spack/repos/builtin/packages/tut/package.py
+++ b/var/spack/repos/builtin/packages/tut/package.py
@@ -20,6 +20,10 @@ class Tut(WafPackage):
     # https://github.com/mrzechonek/tut-framework/issues/18
     depends_on('python@:3.6', type='build')
 
+    # Tut is used for smoke build tests in CI, and started failing as
+    # soon as gcc@11 was introduced in the environment
+    conflicts('%gcc@11:')
+
     def build_args(self):
         args = []
 


### PR DESCRIPTION
Backport of https://github.com/spack/spack/pull/23630, original message:
 - build tests: put an upper bound on the version of GCC being used