### PR TITLE
Deploy py-atlas-building-tools [NSETM-1454]

### DIFF
--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -50,6 +50,7 @@ modules:
       - placement-algorithm
       - py-region-grower
       - psp-validation
+      - py-atlas-building-tools
       - py-basalt
       - py-bbp-analysis-framework
       - py-bbp-workflow

--- a/deploy/environments/applications.yaml
+++ b/deploy/environments/applications.yaml
@@ -43,6 +43,7 @@ spack:
     - placement-algorithm
     - py-region-grower
     - psp-validation%gcc ^neuron%intel
+    - py-atlas-building-tools
     - py-basalt@0.2.9
     - py-bbp-analysis-framework
     - py-bbp-workflow

--- a/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
+++ b/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
@@ -7,35 +7,35 @@ from spack import *
 
 
 class PyAtlasBuildingTools(PythonPackage):
-    """Python tools to build brain region atlases."""
+    """BBP Python tools to build brain region atlases."""
     homepage = "https://bbpcode.epfl.ch/browse/code/nse/atlas-building-tools/tree/"
     git      = "ssh://bbpcode.epfl.ch/nse/atlas-building-tools"
 
-    version('0.1.0', commit='4d2ca679e34d08c76f96f15ccd3cdeccd2044696')
+    version('0.1.1', tag='atlas_building_tools-v0.1.1')
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('py-cgal-pybind', type=('build', 'run'))
-    depends_on('py-click@3.0:', type=('build', 'run'))
-    depends_on('py-networkx@2.5:', type=('build', 'run'))
-    depends_on('py-nptyping@1.0.1', type=('build', 'run'))
-    depends_on('py-numba@0.48.0:', type=('build', 'run'))
+    depends_on('py-cgal-pybind@0.1.0:', type=('build', 'run'))
+    depends_on('py-click@7.0:', type=('build', 'run'))
+    depends_on('py-networkx@2.4:', type=('build', 'run'))
+    depends_on('py-nptyping@1.0.1:', type=('build', 'run'))
+    depends_on('py-numba@0.48.0', type=('build', 'run'))
     depends_on('py-numpy@1.15.0:', type=('build', 'run'))
     # numpy-quaternion version is capped because of an issue similar to
     # https://stackoverflow.com/questions/20518632/importerror-numpy-core-multiarray-failed-to-import
     depends_on('py-numpy-quaternion@2017.10.14.11.11.56:2019.12.11.22.25.52', type=('build', 'run'))
-    depends_on('py-openpyxl@3.0.5:', type=('build', 'run'))
+    depends_on('py-openpyxl@3.0.3:', type=('build', 'run'))
     depends_on('py-pandas@1.0.3:', type=('build', 'run'))
-    depends_on('py-pillow@1.7.2:', type=('build', 'run'))
-    depends_on('py-poisson-recon-pybind', type=('build', 'run'))
+    depends_on('py-pillow@7.1.2:', type=('build', 'run'))
+    depends_on('py-poisson-recon-pybind@0.1.0:', type=('build', 'run'))
     depends_on('py-pynrrd@0.4.0:', type=('build', 'run'))
     depends_on('py-pyyaml@5.3.1:', type=('build', 'run'))
-    depends_on('py-rtree@0.9.4:', type=('build', 'run'))
+    depends_on('py-rtree@0.8.3:', type=('build', 'run'))
     depends_on('py-scipy@1.4.1:', type=('build', 'run'))
     depends_on('py-scikit-image@0.17.2:', type=('build', 'run'))
     depends_on('py-tqdm@4.44.1:', type=('build', 'run'))
-    depends_on('py-trimesh@3.6.18:', type=('build', 'run'))
+    depends_on('py-trimesh@2.38.10:', type=('build', 'run'))
     depends_on('py-voxcell@3.0.0', type=('run', 'build'))
     depends_on('py-xlrd@1.0.0:', type=('build', 'run'))
     depends_on('regiodesics@0.1.0:', type='run')
-    depends_on('ultraliser@0.2.0', type='run')
+    depends_on('ultraliser@0.2.0:', type='run')

--- a/var/spack/repos/builtin/packages/py-numpy-quaternion/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy-quaternion/package.py
@@ -15,6 +15,7 @@ class PyNumpyQuaternion(PythonPackage):
     maintainers = ['moble']
 
     version('2020.11.2.17.0.49', sha256='f65547201fdfa41590b72cfd6ed573e1e9201ca15f19dad429efb8e70e0a4d39')
+    version('2019.12.11.22.25.52', sha256='21d7bfbc08ad7ba882a05262fc67daf96e9e394fe442d1b62a4b8829259d6688')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy', type=('build', 'run'))


### PR DESCRIPTION
This change deploys py-atlas-building-tools.
It is the conclusion of the ticket https://bbpteam.epfl.ch/project/issues/browse/NSETM-1454.

This pull-request supersedes the previous one (https://github.com/BlueBrain/spack/pull/1152) which has been closed due to several misuses of git (messy rebase-merge-revert operations).
