### PR TITLE
Better align [Core]NEURON%NVHPC with the CI build.

### DIFF
--- a/deploy/environments/libraries.yaml
+++ b/deploy/environments/libraries.yaml
@@ -41,7 +41,7 @@ spack:
     - morpho-kit
     - mvdtool+mpi
     - neuron+mpi~debug%intel
-    - neuron+coreneuron~legacy-unit%nvhpc ^coreneuron+gpu~legacy-unit~report ^py-cython%gcc ^py-numpy%gcc
+    - neuron+coreneuron+debug~legacy-unit+tests%nvhpc ^coreneuron+gpu~legacy-unit~report+tests ^py-cython%gcc ^py-numpy%gcc
     - nlohmann-json +single_header
     - omega-h+trilinos
     - omega-h+gmsh+trilinos

--- a/var/spack/repos/builtin/packages/coreneuron/package.py
+++ b/var/spack/repos/builtin/packages/coreneuron/package.py
@@ -20,6 +20,7 @@ class Coreneuron(CMakePackage):
 
     version('develop', branch='master')
     # 1.0.1 > 1.0.0.20210519 > 1.0 as far as Spack is concerned
+    version('1.0.0.20210525', commit='711d2b8efa8f369c4af77be202ace1887f261489')
     version('1.0.0.20210519', commit='c938e4f')
     version('1.0', tag='1.0')
     version('0.22', tag='0.22', submodules=True)


### PR DESCRIPTION
Missed a variant, so https://github.com/BlueBrain/spack/pull/1165 helped less than it should have done.