### PR TITLE
Adds missing dependency of py-trimesh on py-shapely [NSETM-1454]

### DIFF
--- a/var/spack/repos/builtin/packages/py-trimesh/package.py
+++ b/var/spack/repos/builtin/packages/py-trimesh/package.py
@@ -18,4 +18,5 @@ class PyTrimesh(PythonPackage):
 
     depends_on('py-networkx', type='run')
     depends_on('py-numpy', type='run')
+    depends_on('py-shapely', type='run')
     depends_on('py-scipy', type='run')


### PR DESCRIPTION
This pull request aims at addressing the following dependency problem:

```
[lguyot@r1i7n19 atlas-building-tools]$ spack install py-trimesh
[lguyot@r1i7n19 atlas-building-tools]$ spack load py-trimesh
[lguyot@r1i7n19 atlas-building-tools]$ python 
Python 3.8.3 (default, Jan  6 2021, 17:13:49) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import trimesh
shapely.geometry.Polygon not available!
Traceback (most recent call last):
  File "/gpfs/bbp.cscs.ch/home/lguyot/Documents/NSE/catalog/spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/py-trimesh-2.38.10-na32rm/lib/python3.8/site-packages/trimesh/creation.py", line 22, in <module>
    from shapely.geometry import Polygon
ModuleNotFoundError: No module named 'shapely'
>>> 
```

I observed this issue while testing the deployment of py-atlas-building-tools (hence the reference to NSETM-1454).

The fix consists in adding the dependency on py-shapely via a new `depends_on` line in py-trimesh/package.py. 
