### PR TITLE
Set geos path for deployment [NSETM-1454]

### DIFF
--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -68,5 +68,4 @@ class PyShapely(PythonPackage):
         python('-m', 'pytest')
 
     def setup_run_environment(self, env):
-        env.set('GEOS_CONFIG',
-                join_path(self.spec['geos'].prefix.bin, 'geos-config'))
+        self.setup_build_environment(env)

--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -67,5 +67,7 @@ class PyShapely(PythonPackage):
     def test_install(self):
         python('-m', 'pytest')
 
-    def setup_run_environment(self, env):
-        self.setup_build_environment(env)
+    setup_run_environment = setup_build_environment
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)


### PR DESCRIPTION
This pull request consists in a tentative fix for the deployment issue described in the comment of May the 27th of https://bbpteam.epfl.ch/project/issues/browse/NSETM-1454:

```
[lguyot@r1i7n19 spack]$ module load unstable py-atlas-building-tools
[lguyot@r1i7n19 spack]$ atlas-building-tools --help
WARNING:trimesh:shapely.geometry.Polygon not available!
Traceback (most recent call last):
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/applications/2021-01-06/linux-rhel7-x86_64/gcc-9.3.0/py-trimesh-2.38.10-emudx3/lib/python3.8/site-packages/trimesh/creation.py", line 22, in <module>
    from shapely.geometry import Polygon
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/applications/2021-01-06/linux-rhel7-x86_64/gcc-9.3.0/py-shapely-1.7.1-inujdo/lib/python3.8/site-packages/shapely/geometry/__init__.py", line 4, in <module>
    from .base import CAP_STYLE, JOIN_STYLE
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/applications/2021-01-06/linux-rhel7-x86_64/gcc-9.3.0/py-shapely-1.7.1-inujdo/lib/python3.8/site-packages/shapely/geometry/base.py", line 19, in <module>
    from shapely.coords import CoordinateSequence
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/applications/2021-01-06/linux-rhel7-x86_64/gcc-9.3.0/py-shapely-1.7.1-inujdo/lib/python3.8/site-packages/shapely/coords.py", line 8, in <module>
    from shapely.geos import lgeos
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/applications/2021-01-06/linux-rhel7-x86_64/gcc-9.3.0/py-shapely-1.7.1-inujdo/lib/python3.8/site-packages/shapely/geos.py", line 87, in <module>
    _lgeos = load_dll('geos_c', fallbacks=alt_paths)
  File "/gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/applications/2021-01-06/linux-rhel7-x86_64/gcc-9.3.0/py-shapely-1.7.1-inujdo/lib/python3.8/site-packages/shapely/geos.py", line 60, in load_dll
    raise OSError(
OSError: Could not find lib geos_c or load any of its variants ['libgeos_c.so.1', 'libgeos_c.so'].
```
The expected result is that the path to the geos C library (dependency of shapely) will be added to LD_LIBRARY_PATH when loading py-atlas-building-tools with `module load unstable py-atlas-building-tools`.
