### PR TITLE
Fix the branch for the develop version of IOR

### DIFF
--- a/var/spack/repos/builtin/packages/ior/package.py
+++ b/var/spack/repos/builtin/packages/ior/package.py
@@ -13,7 +13,7 @@ class Ior(AutotoolsPackage):
     homepage = "https://github.com/hpc/ior"
     url      = "https://github.com/hpc/ior/archive/3.2.1.tar.gz"
 
-    version('develop', git='https://github.com/hpc/ior.git', branch='master')
+    version('develop', git='https://github.com/hpc/ior.git', branch='main')
     version('3.3.0', sha256='701f2167f81ef963e227d4c036c4a947a98b5642b7c14c87c8ae657849891528', preferred=True)
     version('3.3.0rc1', sha256='0e42ebf5b5adae60625bf97989c8e2519d41ea2e3d18561d7d5b945625317aa5')
     version('3.2.1', sha256='ebcf2495aecb357370a91a2d5852cfd83bba72765e586bcfaf15fb79ca46d00e')


### PR DESCRIPTION
The master branch of IOR is called `main`, and not `master`. Thus, installing the `develop` version will fail using the current recipe.

See https://github.com/spack/spack/pull/24079 for further information.