### PR TITLE
Add flex and bison for deployment in external and generate modules

### DIFF
--- a/deploy/configs/externals/modules.yaml
+++ b/deploy/configs/externals/modules.yaml
@@ -28,6 +28,7 @@ modules:
     hash_length: 0
     whitelist:
       - arm-forge
+      - bison
       - blender
       - ccache
       - cli-tools
@@ -39,6 +40,7 @@ modules:
       - doxygen
       - emacs
       - environment-modules
+      - flex
       - ffmpeg
       - gdb
       - git

--- a/deploy/configs/packages.yaml
+++ b/deploy/configs/packages.yaml
@@ -9,11 +9,6 @@ packages:
     externals:
     - spec: automake@1.13.4
       prefix: /usr
-  bison:
-    version: [3.0.4]
-    externals:
-    - spec: bison@3.0.4
-      prefix: /usr
   boost:
     variants: +pic
   cuda:
@@ -27,11 +22,6 @@ packages:
     variants: +slurm
   eigen:
     variants: ~fftw~gmp~metis~mpfr~scotch
-  flex:
-    version: [2.5.37]
-    externals:
-    - spec: flex@2.5.37
-      prefix: /usr
   hadoop:
     version: [2.9.2]
   hdf5:

--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -25,6 +25,7 @@ spack:
     - nvhpc@20.9 install_type=network
     - nvhpc@21.2 install_type=network
     - arm-forge@20.2.0-Redhat-7.0-x86_64
+    - bison
     - blender
     - boost~mpi@1.73.0
     - bzip2
@@ -41,6 +42,7 @@ spack:
     - emacs
     - environment-modules@4.5.1
     - ffmpeg
+    - flex
     - freetype
     - gdb~python
     - git


### PR DESCRIPTION
  - flex & bison are dependency on neuron+coreneuron+nmodl and
    newer versions are required as module during development
  - note: flex/bison is currently coming from legacy tools directory
    and it should be removed

```
----------------------------------------------------------------------------------------- /gpfs/bbp.cscs.ch/apps/tools/modules/tcl/linux-rhel7-x86_64 -----------------------------------------------------------------------------------------
 bison/3.0.5        flex/2.6.3         hpctoolkit/master  likwid/4.3.0       matlab/r2018a      matlab/r2019b      stat/3.0.1         totalview/2018.2.6
```