### PR TITLE
ubuntu20: add freetype to be installed

### DIFF
--- a/sysconfig/ubuntu-20.04/packages
+++ b/sysconfig/ubuntu-20.04/packages
@@ -10,6 +10,7 @@ gfortran
 git
 libboost-all-dev
 libbz2-dev
+libfreetype-dev
 libhdf5-dev
 libhdf5-openmpi-dev
 libmlpack-dev


### PR DESCRIPTION
Required to compile matplotlib, as found out by @pafonta.