### PR TITLE
Deploy the version 0.1.1 of py-cgal-pybind [BBPP82-614]

### DIFF
--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -25,5 +25,7 @@ class PyCgalPybind(PythonPackage):
     depends_on("py-numpy@1.12:", type=("build", "run"))
     depends_on('py-pytest', type='test')
 
+    @run_after('install')
+    @on_package_attributes(run_tests=True)
     def test_install(self):
         python("-m", "pytest", "tests")

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -25,6 +25,5 @@ class PyCgalPybind(PythonPackage):
     depends_on("py-numpy@1.12:", type=("build", "run"))
     depends_on('py-pytest', type='test')
 
-
     def test_install(self):
         python("-m", "pytest", "tests")

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -13,6 +13,7 @@ class PyCgalPybind(PythonPackage):
     git = "git@bbpgitlab.epfl.ch:nse/cgal-pybind.git"
 
     version("develop", submodules=True)
+    version("0.1.1", tag="cgal-pybind-v0.1.1", submodules=True)
     version("0.1.0", tag="cgal_pybind-v0.1.0", submodules=True)
 
     depends_on("py-setuptools", type="build")
@@ -22,3 +23,8 @@ class PyCgalPybind(PythonPackage):
     depends_on("eigen")
     depends_on("py-pybind11")
     depends_on("py-numpy@1.12:", type=("build", "run"))
+    depends_on('py-pytest', type='test')
+
+
+    def test_install(self):
+        python("-m", "pytest", "tests")


### PR DESCRIPTION
A volume slicer was added to py-cgal-pybind in order to solve the issue described in BBPP82-614.
This deployment is required to make the feature available to atlas-building-tools where mtype volumetric density files are computed.

Note: an "install" test has been added to py-cgal-pybind/package.yaml. 