### PR TITLE
Deployment of py-atlas-building-tools 0.1.2 [BBPP82-614]

### DIFF
--- a/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
+++ b/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
@@ -11,6 +11,7 @@ class PyAtlasBuildingTools(PythonPackage):
     homepage = "https://bbpcode.epfl.ch/browse/code/nse/atlas-building-tools/tree/"
     git      = "ssh://bbpcode.epfl.ch/nse/atlas-building-tools"
 
+    version('0.1.2', tag='atlas_building_tools-v0.1.2')
     version('0.1.1', tag='atlas_building_tools-v0.1.1')
 
     depends_on('py-setuptools', type=('build', 'run'))
@@ -39,3 +40,9 @@ class PyAtlasBuildingTools(PythonPackage):
     depends_on('py-xlrd@1.0.0:', type=('build', 'run'))
     depends_on('regiodesics@0.1.0:', type='run')
     depends_on('ultraliser@0.2.0:', type='run')
+    depends_on('py-pytest', type='test')
+
+    @run_after('install')
+    @on_package_attributes(run_tests=True)
+    def test_install(self):
+        python("-m", "pytest", "tests/app/test_flatmap.py")

--- a/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
+++ b/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
@@ -11,7 +11,7 @@ class PyAtlasBuildingTools(PythonPackage):
     homepage = "https://bbpcode.epfl.ch/browse/code/nse/atlas-building-tools/tree/"
     git      = "ssh://bbpcode.epfl.ch/nse/atlas-building-tools"
 
-    version('0.1.2', tag='atlas_building_tools-v0.1.2')
+    version('0.1.2', tag='atlas-building-tools-v0.1.2')
     version('0.1.1', tag='atlas_building_tools-v0.1.1')
 
     depends_on('py-setuptools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
+++ b/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
@@ -16,7 +16,8 @@ class PyAtlasBuildingTools(PythonPackage):
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('py-cgal-pybind@0.1.0:', type=('build', 'run'))
+    depends_on('py-cgal-pybind@0.1.1:', type=('build', 'run'), when='@0.1.2:')
+    depends_on('py-cgal-pybind@0.1.0', type=('build', 'run'), when='@0.1.1')
     depends_on('py-click@7.0:', type=('build', 'run'))
     depends_on('py-networkx@2.4:', type=('build', 'run'))
     depends_on('py-nptyping@1.0.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-svgpath/package.py
+++ b/var/spack/repos/builtin/packages/py-svgpath/package.py
@@ -5,8 +5,8 @@
 
 
 class PySvgpath(PythonPackage):
-    """svg.path is a collection of objects that implement the different path commands in SVG,
-    and a parser for SVG path definitions.
+    """svg.path is a collection of objects that implement the different path commands
+    in SVG, and a parser for SVG path definitions.
     """
 
     homepage = "https://github.com/regebro/svg.path"
@@ -15,4 +15,3 @@ class PySvgpath(PythonPackage):
 
     version('4.1', sha256='7e6847ba690ff620e20f152818d52e1685b993aacbc41b321f8fee3d1cb427db')
     depends_on('py-setuptools', type='build')
-

--- a/var/spack/repos/builtin/packages/py-svgpath/package.py
+++ b/var/spack/repos/builtin/packages/py-svgpath/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PySvgpath(PythonPackage):
+    """svg.path is a collection of objects that implement the different path commands in SVG,
+    and a parser for SVG path definitions.
+    """
+
+    homepage = "https://github.com/regebro/svg.path"
+    url      = "https://pypi.io/packages/source/s/svg.path/svg.path-4.1.tar.gz"
+    git      = "https://github.com/regebro/svg.path.git"
+
+    version('4.1', sha256='7e6847ba690ff620e20f152818d52e1685b993aacbc41b321f8fee3d1cb427db')
+    depends_on('py-setuptools', type='build')
+

--- a/var/spack/repos/builtin/packages/py-svgpath/package.py
+++ b/var/spack/repos/builtin/packages/py-svgpath/package.py
@@ -5,8 +5,8 @@
 
 
 class PySvgpath(PythonPackage):
-    """svg.path is a collection of objects that implement the different path commands
-    in SVG, and a parser for SVG path definitions.
+    """svg.path is a collection of objects that implement the different path
+    commands in SVG, and a parser for SVG path definitions.
     """
 
     homepage = "https://github.com/regebro/svg.path"

--- a/var/spack/repos/builtin/packages/py-trimesh/package.py
+++ b/var/spack/repos/builtin/packages/py-trimesh/package.py
@@ -20,3 +20,5 @@ class PyTrimesh(PythonPackage):
     depends_on('py-numpy', type='run')
     depends_on('py-shapely', type='run')
     depends_on('py-scipy', type='run')
+    depends_on('py-svgpath', type='run')
+    depends_on('py-lxml', type='run')


### PR DESCRIPTION
This pull-request adds the version 0.1.2 to py-atlas-building-tools/package.py.
The version 0.1.2 depends on the release of cgal-pybind 0.1.1 (py-cgal-pybind).

A test has been added  to py-atlas-building-tools/package.py.
A fix of py-trimesh/package.py was also required:

```
[lguyot@r2i6n10 packages]$ atlas-building-tools --help
WARNING:trimesh:SVG path loading unavailable!
Traceback (most recent call last):
  File "/gpfs/bbp.cscs.ch/home/lguyot/Documents/NSE/catalog/spack/opt/spack/linux-rhel7-x86_64/gcc-9.3.0/py-trimesh-2.38.10-et7oll/lib/python3.8/site-packages/trimesh/path/exchange/svg_io.py", line 19, in <module>
    from lxml import etree
ModuleNotFoundError: No module named 'lxml'
```

A similar message was obtained because of a missing dependency of py-trimesh on svg.path.

The fix consists in adding a new spack package for svg.path (py-svgpath) and in specifying the dependencies of py-trimesh on both py-svgpath an py-lxml (alread existing).