### PR TITLE
Update Spykfunc package to latest master

### DIFF
--- a/deploy/configs/applications/modules.yaml
+++ b/deploy/configs/applications/modules.yaml
@@ -93,7 +93,6 @@ modules:
       - '%pgi'
     projections:
       all: '{name}/{version}'
-      ^spark@3.0.0: '{name}/{version}-spark3.0'
       ^coreneuron+knl: '{name}-knl/{version}'
       +common: '{name}/{version}-commonmods'
     all:

--- a/deploy/environments/applications.yaml
+++ b/deploy/environments/applications.yaml
@@ -72,7 +72,6 @@ spack:
     - reportinglib%intel
     - spatial-index
     - spykfunc
-    - spykfunc@0.16.0 ^spark@3.0.0 ^py-pyspark@3.0.0
     - steps+petsc
     - synapsetool
     - touchdetector

--- a/var/spack/repos/builtin/packages/parquet-converters/package.py
+++ b/var/spack/repos/builtin/packages/parquet-converters/package.py
@@ -14,6 +14,7 @@ class ParquetConverters(CMakePackage):
     git      = "git@bbpgitlab.epfl.ch:hpc/circuit-building/parquet-converters.git"
 
     version('develop', submodules=True)
+    version('0.6.0', tag='v0.6.0', submodules=True)
     version('0.5.7', tag='v0.5.7', submodules=True)
     version('0.5.6', tag='v0.5.6', submodules=True)
     version('0.5.5', tag='v0.5.5', submodules=True)

--- a/var/spack/repos/builtin/packages/spykfunc/package.py
+++ b/var/spack/repos/builtin/packages/spykfunc/package.py
@@ -16,6 +16,7 @@ class Spykfunc(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/building/Spykfunc"
 
     version('develop', submodules=True, get_full_repo=True)
+    version('0.16.0.20210624', commit='ff56d9', submodules=True, get_full_repo=True)
     version('0.16.0', tag='v0.16.0', submodules=True, get_full_repo=True)
     version('0.15.9', tag='v0.15.9', submodules=True, get_full_repo=True)
     version('0.15.7', tag='v0.15.7', submodules=True, get_full_repo=True)
@@ -32,7 +33,7 @@ class Spykfunc(PythonPackage):
     depends_on('boost', type=('build', 'link'), when='@0.15.4:')
     depends_on('morpho-kit', type=('build', 'link'), when='@0.15.4:')
 
-    depends_on('py-mvdtool~mpi', type=('build', 'run'), when='@0.14.4:0.16.0')
+    depends_on('py-mvdtool~mpi', type=('build', 'run'), when='@0.14.4:0.16.0.0')
 
     depends_on('python@3.6:')
     depends_on('py-cython', type='run', when='@:0.15.3')
@@ -46,7 +47,7 @@ class Spykfunc(PythonPackage):
     depends_on('py-funcsigs', type=('build', 'run'))
     # h5py needed for morphologies before, and to supplement libSONATA due
     # to missing API functionality
-    depends_on('py-h5py', type=('build', 'run'), when='@:0.15.1,0.17:')
+    depends_on('py-h5py', type=('build', 'run'))
     depends_on('py-hdfs', type=('build', 'run'))
     depends_on('py-jprops', type=('build', 'run'))
     depends_on('py-lazy-property', type=('build', 'run'))
@@ -65,7 +66,7 @@ class Spykfunc(PythonPackage):
 
     patch('setup-spark3.patch', when='@:0.15.6 ^spark@3:')
     patch('properties-spark3.patch', when='@:0.15.6 ^spark@3:')
-    patch('bogus-h5py.patch', when='@0.15.2:0.15.9')
+    patch('bogus-h5py.patch', when='@0.15.2:0.16.1')
 
     def patch(self):
         if self.spec.satisfies('@:0.16.0'):

--- a/var/spack/repos/builtin/packages/spykfunc/package.py
+++ b/var/spack/repos/builtin/packages/spykfunc/package.py
@@ -66,7 +66,7 @@ class Spykfunc(PythonPackage):
 
     patch('setup-spark3.patch', when='@:0.15.6 ^spark@3:')
     patch('properties-spark3.patch', when='@:0.15.6 ^spark@3:')
-    patch('bogus-h5py.patch', when='@0.15.2:0.16.1')
+    patch('bogus-h5py.patch', when='@0.15.2:0.16.0.0')
 
     def patch(self):
         if self.spec.satisfies('@:0.16.0'):

--- a/var/spack/repos/builtin/packages/spykfunc/package.py
+++ b/var/spack/repos/builtin/packages/spykfunc/package.py
@@ -66,7 +66,7 @@ class Spykfunc(PythonPackage):
 
     patch('setup-spark3.patch', when='@:0.15.6 ^spark@3:')
     patch('properties-spark3.patch', when='@:0.15.6 ^spark@3:')
-    patch('bogus-h5py.patch', when='@0.15.2:0.16.0.0')
+    patch('bogus-h5py.patch', when='@0.15.2:0.15.9')
 
     def patch(self):
         if self.spec.satisfies('@:0.16.0'):


### PR DESCRIPTION
The recent changes in Spykfunc are required in order to fix certain out-of-memory and timeout errors, among others. This is also related to https://github.com/BlueBrain/spack/pull/1205.

**Important note:** Until an official tag release is defined in Spykfunc, the Spack version would remain as temporary (i.e., using a reference date, following CoreNEURON's new naming convention).