### PR TITLE
Workaround Spack erasing RPATH entry for libcupti.

### DIFF
--- a/deploy/environments/libraries.yaml
+++ b/deploy/environments/libraries.yaml
@@ -25,6 +25,7 @@ spack:
     - assimp
     - boost+python@1.70.0
     - boost+python@1.73.0
+    - caliper+cuda cuda_arch=70
     - catch2
     - deflect
     - easyloggingpp

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -126,6 +126,11 @@ class Caliper(CMakePackage, CudaPackage):
             args.append('-DMPI_CXX_COMPILER=%s' % spec['mpi'].mpicxx)
 
         if '+cuda' in spec:
+            # this avoids the CMake install step erasing the RPATH entry
+            # pointing to /path/to/cuda/extras/CUPTI/lib64, which is correctly
+            # added by Caliper's CMake but is not known to Spack. See upstream
+            # Spack issue: https://github.com/spack/spack/issues/24724
+            args.append('-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=On')
             args.append('-DCUDA_TOOLKIT_ROOT_DIR=%s' % spec['cuda'].prefix)
             # technically only works with cuda 10.2+, otherwise cupti is in
             # ${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI


### PR DESCRIPTION
I described the problem upstream: https://github.com/spack/spack/issues/24724

This is a workaround that gives a correctly-RPATH'd `libcaliper.so` on BB5.