### PR TITLE
update to bluepyopt-1.10.38

### DIFF
--- a/var/spack/repos/builtin/packages/py-bluepyopt/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepyopt/package.py
@@ -13,6 +13,7 @@ class PyBluepyopt(PythonPackage):
     url = "https://pypi.io/packages/source/b/bluepyopt/bluepyopt-1.9.27.tar.gz"
 
     # NOTE : while adding new release check pmi_rank.patch compatibility
+    version('1.9.38', sha256='fb1411c6a8fbfac52d36b837225bae882fd6524acfb4d0580189312ef3c1cfcc')
     version('1.9.37', sha256='4399af71de48b288832e92f0de73c431bf88d6e76e2c4ea250c3b38fb38a45a8')
     version('1.9.27', sha256='4cce15b92b32311c808cae5e005b664deb6e8dc5df4ca13ea7b59252ae346522')
     version('1.8.68', sha256='b9d432840aab89d4863c935d3dc604816441eba02d731422b92056cee751ca9c')
@@ -30,7 +31,7 @@ class PyBluepyopt(PythonPackage):
     depends_on('py-numpy', type='run')
     depends_on('py-efel', type='run')
     depends_on('py-deap', type='run')
-    depends_on('py-scoop@0.7:', type='run')
+    depends_on('py-scoop@0.7:', type='run', when='@:1.9.37')
     depends_on('py-ipyparallel', type='run')
     depends_on('py-pickleshare', type='run')
     depends_on('py-future', type='run')

--- a/var/spack/repos/builtin/packages/py-bluepyopt/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepyopt/package.py
@@ -13,7 +13,7 @@ class PyBluepyopt(PythonPackage):
     url = "https://pypi.io/packages/source/b/bluepyopt/bluepyopt-1.9.27.tar.gz"
 
     # NOTE : while adding new release check pmi_rank.patch compatibility
-    version('1.9.38', sha256='fb1411c6a8fbfac52d36b837225bae882fd6524acfb4d0580189312ef3c1cfcc')
+    version('1.10.38', sha256='fb1411c6a8fbfac52d36b837225bae882fd6524acfb4d0580189312ef3c1cfcc')
     version('1.9.37', sha256='4399af71de48b288832e92f0de73c431bf88d6e76e2c4ea250c3b38fb38a45a8')
     version('1.9.27', sha256='4cce15b92b32311c808cae5e005b664deb6e8dc5df4ca13ea7b59252ae346522')
     version('1.8.68', sha256='b9d432840aab89d4863c935d3dc604816441eba02d731422b92056cee751ca9c')


### PR DESCRIPTION
* no longer need scoop; https://github.com/BlueBrain/BluePyOpt/pull/375/