### PR TITLE
hotfix: undo our modifications to the Python build system

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -212,13 +212,7 @@ class PythonPackage(PackageBase):
 
     def install_args(self, spec, prefix):
         """Arguments to pass to install."""
-        python_version = self.spec['python'].version.up_to(2)
-        python_string = 'python{0}'.format(python_version)
-        path_to_install_lib = os.path.join(
-            prefix, 'lib', python_string, 'site-packages')
-
-        args = ['--prefix={0}'.format(prefix),
-                '--install-lib={0}'.format(path_to_install_lib)]
+        args = ['--prefix={0}'.format(prefix)]
 
         # This option causes python packages (including setuptools) NOT
         # to create eggs or easy-install.pth files.  Instead, they
@@ -258,7 +252,7 @@ class PythonPackage(PackageBase):
                  '--install-purelib=%s' % pure_site_packages_dir,
                  '--install-platlib=%s' % plat_site_packages_dir,
                  '--install-scripts=bin',
-                 '--install-data=""',
+                 '--install-data=',
                  '--install-headers=%s' % inc_dir
                  ]
 


### PR DESCRIPTION
These changes clash with upstream modifications, leading to the prefix
being *twice* in the installation directories / nesting way too deep.

Thanks @olupton for the prod!
