### PR TITLE
Add C-Reduce and dependencies.

### DIFF
--- a/var/spack/repos/builtin/packages/creduce/package.py
+++ b/var/spack/repos/builtin/packages/creduce/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class Creduce(CMakePackage):
+    """C-Reduce is a tool that takes a large C, C++, or OpenCL file that has a
+    property of interest (such as triggering a compiler bug) and automatically
+    produces a much smaller C/C++ file that has the same property. It is
+    intended for use by people who discover and report bugs in compilers and
+    other tools that process source code."""
+
+    homepage = "https://embed.cs.utah.edu/creduce/"
+    url      = "https://github.com/csmith-project/creduce"
+    git      = "https://github.com/csmith-project/creduce"
+    maintainers = ['olupton']
+
+    version('develop', branch='master')
+    version('2.10.0', tag='creduce-2.10.0')
+
+    depends_on('flex')
+    depends_on('libxml2')
+    depends_on('llvm@8.0.0', when='@:2.10.999')
+    depends_on('perl')
+    depends_on('perl-exporter-lite')
+    depends_on('perl-file-which')
+    depends_on('perl-getopt-tabular')
+    depends_on('perl-regexp-common')
+    depends_on('perl-termreadkey')
+    depends_on('zlib')

--- a/var/spack/repos/builtin/packages/perl-exporter-lite/package.py
+++ b/var/spack/repos/builtin/packages/perl-exporter-lite/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PerlExporterLite(PerlPackage):
+    """Exporter::Lite is an alternative to Exporter, intended to provide a
+    lightweight subset of the most commonly-used functionality. It supports
+    import(), @EXPORT and @EXPORT_OK and not a whole lot else."""
+    homepage = "https://metacpan.org/pod/Exporter::Lite"
+    url      = "https://cpan.metacpan.org/authors/id/N/NE/NEILB/Exporter-Lite-0.08.tar.gz"
+
+    version('0.08', sha256='c05b3909af4cb86f36495e94a599d23ebab42be7a18efd0d141fc1586309dac2')

--- a/var/spack/repos/builtin/packages/perl-getopt-tabular/package.py
+++ b/var/spack/repos/builtin/packages/perl-getopt-tabular/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PerlGetoptTabular(PerlPackage):
+    """Getopt::Tabular is a Perl 5 module for table-driven argument parsing,
+    vaguely inspired by John Ousterhout's Tk_ParseArgv."""
+    homepage = "https://metacpan.org/pod/Getopt::Tabular"
+    url      = "https://cpan.metacpan.org/authors/id/G/GW/GWARD/Getopt-Tabular-0.3.tar.gz"
+
+    version('0.3', sha256='9bdf067633b5913127820f4e8035edc53d08372faace56ba6bfa00c968a25377')


### PR DESCRIPTION
This PR adds a recipe for C-Reduce: https://embed.cs.utah.edu/creduce/
> C-Reduce is a tool that takes a large C, C++, or OpenCL file that has a property of interest (such as triggering a compiler bug) and automatically produces a much smaller C/C++ file that has the same property. It is intended for use by people who discover and report bugs in compilers and other tools that process source code.

It also adds recipes for some Perl dependencies:
- `perl-exporter-lite`
- `perl-getopt-tabular`

This is the content of spack/spack#25109.