### PR TITLE
Adds version 0.12.1 to py-tensorflow-addons/package.py [BBPP82-482]

### DIFF
--- a/var/spack/repos/builtin/packages/py-atlalign/lpips.patch
+++ b/var/spack/repos/builtin/packages/py-atlalign/lpips.patch
@@ -1,0 +1,65 @@
+commit d86b99e60c187e00732af082b3f79b6d46bbf585
+Author: Matthias Wolf <matthias.wolf@epfl.ch>
+Date:   Mon Aug 9 14:36:58 2021 +0200
+
+    dependencies: move lpips import into function
+    
+    This makes the lpips functionality somewhat optional by moving the
+    import from the module scope into the function where it is used.  Should
+    simplify installation.
+
+diff --git a/README.md b/README.md
+index e87f781..e7a29a0 100644
+--- a/README.md
++++ b/README.md
+@@ -80,7 +80,8 @@ All details related to installation and logic are described in the
+ 
+ Some of the functionalities of `atlalign` depend on the [TensorFlow implementation
+ of the Learned Perceptual Image Patch Similarity (LPIPS)](https://github.com/alexlee-gk/lpips-tensorflow). Unfortunately, the
+-package is not available on PyPI and must be installed manually as follows.
++package is not available on PyPI and must be installed manually as follows
++for full functionality.
+ ```shell script
+ pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
+ ```
+diff --git a/atlalign/metrics.py b/atlalign/metrics.py
+index 90563ac..4a0a6ed 100644
+--- a/atlalign/metrics.py
++++ b/atlalign/metrics.py
+@@ -38,18 +38,6 @@ from functools import wraps
+ 
+ import ants
+ 
+-try:
+-    import lpips_tf
+-except ModuleNotFoundError as err:
+-    raise ModuleNotFoundError(
+-        """
+-        LPIPS-TensorFlow required but not found.
+-
+-        Please install it by running the following command:
+-        $ pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
+-        """
+-    ) from err
+-
+ import numpy as np
+ import pandas as pd
+ import tensorflow as tf
+@@ -996,6 +984,17 @@ def perceptual_loss_img(y_true, y_pred, model="net-lin", net="vgg"):
+     We use the decorator just to make sure we do not run out of memory during a forward pass. Also,
+     its fully convolutional but if the images are too small then might run into issues.
+     """
++    try:
++        import lpips_tf
++    except ModuleNotFoundError as err:
++        raise ModuleNotFoundError(
++            """
++            LPIPS-TensorFlow required but not found.
++
++            Please install it by running the following command:
++            $ pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
++            """
++        ) from err
+     # gray2rgb
+     y_true = np.stack((y_true,) * 3, axis=-1)
+     y_pred = np.stack((y_pred,) * 3, axis=-1)

--- a/var/spack/repos/builtin/packages/py-atlalign/lpips.patch
+++ b/var/spack/repos/builtin/packages/py-atlalign/lpips.patch
@@ -1,4 +1,4 @@
-commit d86b99e60c187e00732af082b3f79b6d46bbf585
+commit b572a00eca1d3d300a362ba6e5ea83e4df53adb4
 Author: Matthias Wolf <matthias.wolf@epfl.ch>
 Date:   Mon Aug 9 14:36:58 2021 +0200
 
@@ -63,3 +63,44 @@ index 90563ac..4a0a6ed 100644
      # gray2rgb
      y_true = np.stack((y_true,) * 3, axis=-1)
      y_pred = np.stack((y_pred,) * 3, axis=-1)
+diff --git a/atlalign/ml_utils/losses.py b/atlalign/ml_utils/losses.py
+index eaf37a0..b34c905 100644
+--- a/atlalign/ml_utils/losses.py
++++ b/atlalign/ml_utils/losses.py
+@@ -22,18 +22,6 @@
+ import tensorflow.keras.backend as K
+ from tensorflow import keras
+ 
+-try:
+-    import lpips_tf
+-except ModuleNotFoundError as err:
+-    raise ModuleNotFoundError(
+-        """
+-        LPIPS-TensorFlow required but not found.
+-
+-        Please install it by running the following command:
+-        $ pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
+-        """
+-    ) from err
+-
+ import numpy as np
+ import tensorflow as tf
+ 
+@@ -157,6 +145,17 @@ class PerceptualLoss:
+ 
+     def loss(self, y_true, y_pred):
+         """Compute loss."""
++        try:
++            import lpips_tf
++        except ModuleNotFoundError as err:
++            raise ModuleNotFoundError(
++                """
++                LPIPS-TensorFlow required but not found.
++
++                Please install it by running the following command:
++                $ pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git#egg=lpips_tf
++                """
++            ) from err
+         y_true_rgb = tf.concat(3 * [y_true], axis=-1)
+         y_pred_rgb = tf.concat(3 * [y_pred], axis=-1)
+ 

--- a/var/spack/repos/builtin/packages/py-atlalign/package.py
+++ b/var/spack/repos/builtin/packages/py-atlalign/package.py
@@ -28,7 +28,7 @@ class PyAtlalign(PythonPackage):
     depends_on('py-scikit-learn@0.20.2:', type=('run'))
     depends_on('py-scipy', type=('run'))
     # Addons need to be in lockstep with TF
-    depends_on('py-tensorflow@2.4', type=('run'))
-    depends_on('py-tensorflow-addons@0.12', type=('run'))
+    depends_on('py-tensorflow@2.4.2', type=('run'))
+    depends_on('py-tensorflow-addons@0.12.1', type=('run'))
 
     patch('lpips.patch', when='@0.6.0')

--- a/var/spack/repos/builtin/packages/py-atlalign/package.py
+++ b/var/spack/repos/builtin/packages/py-atlalign/package.py
@@ -27,5 +27,6 @@ class PyAtlalign(PythonPackage):
     depends_on('py-scikit-image@0.16.0:', type=('run'))
     depends_on('py-scikit-learn@0.20.2:', type=('run'))
     depends_on('py-scipy', type=('run'))
-    depends_on('py-tensorflow@2.4.0:', type=('run'))
-    depends_on('py-tensorflow-addons', type=('run'))
+    # Addons need to be in lockstep with TF
+    depends_on('py-tensorflow@2.4', type=('run'))
+    depends_on('py-tensorflow-addons@0.12', type=('run'))

--- a/var/spack/repos/builtin/packages/py-atlalign/package.py
+++ b/var/spack/repos/builtin/packages/py-atlalign/package.py
@@ -30,3 +30,5 @@ class PyAtlalign(PythonPackage):
     # Addons need to be in lockstep with TF
     depends_on('py-tensorflow@2.4', type=('run'))
     depends_on('py-tensorflow-addons@0.12', type=('run'))
+
+    patch('lpips.patch', when='@0.6.0')

--- a/var/spack/repos/builtin/packages/py-tensorflow-addons/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-addons/package.py
@@ -24,7 +24,6 @@ class PyTensorflowAddons(Package):
     # The version below just serves to trigger a rebuild!
     version('0.13.0.20210728', url=url, sha256='ea76eab2abf2e1de3037acca27953b30c010087aabb27d80d860f92e1c66cef8', expand=False)
     version('0.13.0', sha256='eaa258923bbf48fcd3688177a9e1055f674854437c93ae461b1a166d08e06286', expand=False)
-
     version('0.12.1', url="https://files.pythonhosted.org/packages/08/ac/c5a37833dd71acbb6ccc40847680f2882231acb6dca4c19a2b975f3a358d/tensorflow_addons-0.12.1-cp38-cp38-manylinux2010_x86_64.whl", sha256='288919ec1debf0bc56357fc1db6dccd27389d446b214042cd4de39d7edabdad6', expand=False)
 
     maintainers = ['pramodk', 'matz-e']

--- a/var/spack/repos/builtin/packages/py-tensorflow-addons/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-addons/package.py
@@ -34,7 +34,7 @@ class PyTensorflowAddons(Package):
     depends_on('py-pip', type='build')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-tensorflow@2.3:2.5', type=('run'), when='@0.13:')
+    depends_on('py-tensorflow@2.5', type=('run'), when='@0.13:')
     depends_on('py-tensorflow@2.4.0:2.4.2', type=('run'), when='@0.12.1')
     depends_on('py-typeguard@2.7:', type=('run'))
     # no versions for Mac OS added

--- a/var/spack/repos/builtin/packages/py-tensorflow-addons/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-addons/package.py
@@ -25,6 +25,8 @@ class PyTensorflowAddons(Package):
     version('0.13.0.20210728', url=url, sha256='ea76eab2abf2e1de3037acca27953b30c010087aabb27d80d860f92e1c66cef8', expand=False)
     version('0.13.0', sha256='eaa258923bbf48fcd3688177a9e1055f674854437c93ae461b1a166d08e06286', expand=False)
 
+    version('0.12.1', url="https://files.pythonhosted.org/packages/08/ac/c5a37833dd71acbb6ccc40847680f2882231acb6dca4c19a2b975f3a358d/tensorflow_addons-0.12.1-cp38-cp38-manylinux2010_x86_64.whl", sha256='288919ec1debf0bc56357fc1db6dccd27389d446b214042cd4de39d7edabdad6', expand=False)
+
     maintainers = ['pramodk', 'matz-e']
     import_modules = ['tensorflow_addons']
 
@@ -33,7 +35,8 @@ class PyTensorflowAddons(Package):
     depends_on('py-pip', type='build')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-tensorflow@2.3:2.5', type=('run'))
+    depends_on('py-tensorflow@2.3:2.5', type=('run'), when='@0.13:')
+    depends_on('py-tensorflow@2.4.0:2.4.2', type=('run'), when='@0.12.1')
     depends_on('py-typeguard@2.7:', type=('run'))
     # no versions for Mac OS added
     conflicts('platform=darwin', msg='macOS is not supported')


### PR DESCRIPTION
This change is liable to solve the following install issue on BB5 (see https://bbpteam.epfl.ch/project/issues/browse/BBPP82-482 for full context):

```
module load unstable py-atlalign
python3 -mvenv venv
source venv/bin/activate
pip install git+http://github.com/alexlee-gk/lpips-tensorflow.git
```
In  the python console:

```
from atlalign.ml_utils import load_model, merge_global_local
local_ = "/gpfs/bbp.cscs.ch/data/project/proj101/pretrained_models/local/blue_bird"
load_model(local_)  # Aïe aïe aïe!
```

The error
```
NotFoundError: /gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/applications/2021-01-06/linux-rhel7-x86_64/gcc-9.3.0/py-tensorflow-addons-0.13.0.20210728-3kq66j/lib/python3.8/site-packages/tensorflow_addons/custom_ops/image/_resampler_ops.so: undefined symbol: _ZN10tensorflow6StatusC1ENS_5error4CodeEN4absl14lts_2020_09_2311string_viewEOSt6vectorINS_10StackFrameESaIS7_EE
```
comes with a warning from the tensorflow developers:

> You are currently using TensorFlow 2.4.2 and trying to load a custom op (custom_ops/image/_resampler_ops.so).
TensorFlow Addons has compiled its custom ops against TensorFlow 2.5.0, and there are no compatibility guarantees between the two versions. 
>This means that you might get segfaults when loading the custom op, or other kind of low-level errors.
 If you do, do not file an issue on Github. This is a known limitation.

> It might help you to fallback to pure Python ops by setting environment variable `TF_ADDONS_PY_OPS=1` or using `tfa.options.disable_custom_kernel()` in your code. To do that, see https://github.com/tensorflow/addons#gpucpu-custom-ops 

> You can also change the TensorFlow version installed on your system. You would need a TensorFlow version equal to or above 2.5.0 and strictly below 2.6.0.
 Note that nightly versions of TensorFlow, as well as non-pip TensorFlow like `conda install tensorflow` or compiled from source are not supported.

> The last solution is to find the TensorFlow Addons version that has custom ops compatible with the TensorFlow installed on your system. To do that, refer to the readme: https://github.com/tensorflow/addons

This pull-request aims at implementing the last solution. The version 0.12.1 of tensorflow-addons is compatible with tensorflow 2.4.2 which is currently installed by py-atlalign, see the custom ops compatibility matrix here: https://github.com/tensorflow/addons#c-custom-op-compatibility-matrix.


**Note**: The first solution, i.e., installing tensorflow 2.5.0 yields another problem ("ERROR: Cannot uninstall 'six'. It is a distutils installed project ...") which we cowardly refrain from addressing right now.

The second solution, which consists in disabling custom ops didn't work:

```
AttributeError: in user code:

    /gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/applications/2021-01-06/linux-rhel7-x86_64/gcc-9.3.0/py-atlalign-0.6.0-tf5yum/lib/python3.8/site-packages/atlalign/ml_utils/layers.py:353 call  *
        output = resampler(imgs, f_x_f_y)
    /gpfs/bbp.cscs.ch/ssd/apps/hpc/jenkins/deploy/applications/2021-01-06/linux-rhel7-x86_64/gcc-9.3.0/py-tensorflow-addons-0.13.0.20210728-3kq66j/lib/python3.8/site-packages/tensorflow_addons/image/resampler_ops.py:57 resampler  *
        return _resampler_so.ops.addons_resampler(data_tensor, warp_tensor)

    AttributeError: module 'de3ad3acc172d510cb421b511fafb14a' has no attribute 'addons_resampler'

```