### PR TITLE
Deploys py-atlas-building-tools@0.1.4 [NSETM-1562]

### DIFF
--- a/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
+++ b/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
@@ -17,7 +17,6 @@ class PyAtlasBuildingTools(PythonPackage):
     version('0.1.1', tag='atlas_building_tools-v0.1.1')
 
     depends_on('py-setuptools', type=('build', 'run'))
-
     depends_on('py-cgal-pybind@0.1.1:', type=('build', 'run'), when='@0.1.2:')
     depends_on('py-cgal-pybind@0.1.0:', type=('build', 'run'), when='@0.1.1')
     depends_on('py-click@7.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
+++ b/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
@@ -8,9 +8,10 @@ from spack import *
 
 class PyAtlasBuildingTools(PythonPackage):
     """BBP Python tools to build brain region atlases."""
-    homepage = "https://bbpcode.epfl.ch/browse/code/nse/atlas-building-tools/tree/"
-    git      = "ssh://bbpcode.epfl.ch/nse/atlas-building-tools"
+    homepage = "https://bbpgitlab.epfl.ch/nse/atlas-building-tools"
+    git      = "git@bbpgitlab.epfl.ch:nse/atlas-building-tools.git"
 
+    version('0.1.4', tag='atlas-building-tools-v0.1.4')
     version('0.1.3', tag='atlas-building-tools-v0.1.3')
     version('0.1.2', tag='atlas-building-tools-v0.1.2')
     version('0.1.1', tag='atlas_building_tools-v0.1.1')


### PR DESCRIPTION
The project `atlas-building-tools` has been migrated from gerrit to gitlab (see https://bbpteam.epfl.ch/project/issues/browse/NSETM-1562).

This pull-request updates `py-atlas-building-tools/package.py` and deploys the latest version, namely `0.1.4` (see https://bbpgitlab.epfl.ch/nse/atlas-building-tools/-/merge_requests/6).