### PR TITLE
deploy: include applications in user-facing upstreams

### DIFF
--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -234,9 +234,6 @@ update_chain_config() {
     local add="${2:-}"
     local suffix="${3:-}"
 
-    conf="${HOME}/.spack/upstreams.yaml"
-    ckey="^upstreams:"
-
     chains=""
     for stage in ${stages}; do
         if [[ "${stage}" = "${what}" ]]; then
@@ -251,13 +248,13 @@ update_chain_config() {
     chains="${add}${add:+ }${chains}"
 
     if [[ -n "${chains}" ]]; then
-        grep -e ${ckey} ${conf} &> /dev/null || {
-            echo "upstreams:" >> "${conf}"
-        }
+        if [[ -z "$suffix" ]]; then
+            echo "upstreams:"
+        fi
         log "chaining up ${what}"
         for stage in ${chains}; do
             log "...adding ${stage}"
-            cat << EOF >> "${conf}"
+            cat << EOF
   ${stage}${suffix}:
     install_tree: $(last_install_dir ${stage})
     modules:
@@ -579,7 +576,7 @@ generate_archive_modules() {
 }
 
 copy_user_configuration() {
-    what="$1"
+    local what="$1"
 
     local source="$(install_dir ${what})/data"
     local target="${DEPLOYMENT_ROOT}/config/"
@@ -594,7 +591,7 @@ copy_user_configuration() {
     log "...into ${target}"
 
     mkdir -p "${target}"
-    cp ${source}/{compilers,.spack/upstreams,packages}.yaml ${target}
+    cp ${source}/{compilers,packages}.yaml ${target}
 
     rm -f ${target}/modules.{,c}sh
     echo "export MODULEPATH=\"\${MODULEPATH}\${MODULEPATH:+:}${root}\"" > ${target}/modules.sh
@@ -607,6 +604,8 @@ endif
 EOF
 
     ./modules.rb > "${target}/modules.yaml"
+
+    update_chain_config "$what" "$what" > "${target}/upstreams.yaml"
 
     cat << EOF > "${target}/config.yaml"
 config:
@@ -673,7 +672,7 @@ export SPACK_INSTALL_PREFIX
 EOF
 
     copy_configuration "${what}"
-    update_chain_config "${what}"
+    update_chain_config "${what}" > "${HOME}/.spack/upstreams.yaml"
     update_module_path "${what}"
 
     if [[ "${DEPLOYMENT_UPSTREAM:-${DEPLOYMENT_ROOT}}" != "${DEPLOYMENT_ROOT}" ]]; then
@@ -681,7 +680,7 @@ EOF
         DEPLOYMENT_ROOT="${DEPLOYMENT_UPSTREAM}"
         export DEPLOYMENT_ROOT
         log "setting up upstream chains, modules"
-        update_chain_config "${what}" "${what}" "-upstream"
+        update_chain_config "${what}" "${what}" "-upstream" >> "${HOME}/.spack/upstreams.yaml"
         update_module_path "${what}" "yes"
         DEPLOYMENT_ROOT="${OLD_DEPLOYMENT_ROOT}"
         export DEPLOYMENT_ROOT

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -248,9 +248,7 @@ update_chain_config() {
     chains="${add}${add:+ }${chains}"
 
     if [[ -n "${chains}" ]]; then
-        if [[ -z "$suffix" ]]; then
-            echo "upstreams:"
-        fi
+        echo "upstreams:"
         log "chaining up ${what}"
         for stage in ${chains}; do
             log "...adding ${stage}"
@@ -684,6 +682,8 @@ EOF
         update_module_path "${what}" "yes"
         DEPLOYMENT_ROOT="${OLD_DEPLOYMENT_ROOT}"
         export DEPLOYMENT_ROOT
+        # Delete any additional "upstream:" lines
+        sed -i -e '2,999{/foo:/d}' "${HOME}/.spack/upstreams.yaml"
     fi
 
     # This directory may fail intel builds, pre-emptively remove it.


### PR DESCRIPTION
@pramodk we discussed this before: currently we *exclude* applications from the user-facing upstreams configuration, with the original argument that we would like to avoid Spack seeing applications already installed when users want to install them with modifications.

As the customary install methods by now create unique hashes even for every installed package, the old argument is moot, and we should include applications to speed up builds and include more dependencies.