### PR TITLE
Add channel-benchmark variant to neuron.

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/channel-benchmark-CMakeLists.txt
+++ b/var/spack/repos/builtin/packages/neuron/channel-benchmark-CMakeLists.txt
@@ -1,0 +1,28 @@
+include(NeuronTestHelper)
+set(prefix "benchmark/channels") # everything is under this prefix in the repository
+nrn_add_test_group(
+  NAME external_channel_benchmark
+  SUBMODULE tests/channel-benchmark
+  OUTPUT asciispikes::out.dat
+  MODFILE_PATTERNS benchmark/channels/lib/modlib/*.mod
+  SCRIPT_PATTERNS "${prefix}/lib/hoclib/*.hoc" "${prefix}/*.txt" "${prefix}/*.asc")
+
+nrn_add_test(
+  GROUP external_channel_benchmark
+  NAME neuron
+  COMMAND "HOC_LIBRARY_PATH=${prefix}/lib/hoclib" special -c "strdef arg_datapath" -c
+          "arg_datapath = \"${prefix}\"" "${prefix}/lib/hoclib/init.hoc")
+
+# CoreNEURON's reports require MPI and segfault if it is not initialised. This is a crude
+# workaround.
+if(CORENRN_ENABLE_REPORTING)
+  set(special_mpi_arg -mpi)
+endif()
+nrn_add_test(
+  GROUP external_channel_benchmark
+  NAME coreneuron
+  REQUIRES coreneuron
+  COMMAND "HOC_LIBRARY_PATH=${prefix}/lib/hoclib" special ${special_mpi_arg} -c arg_coreneuron=1 -c
+          "strdef arg_datapath" -c "arg_datapath = \"${prefix}\"" "${prefix}/lib/hoclib/init.hoc")
+
+nrn_add_test_group_comparison(GROUP external_channel_benchmark)


### PR DESCRIPTION
If set to a non-default value this variant patches some extra tests into NEURON. These depend on currently-BBP-internal data and cannot, therefore, be added to the NEURON repository directly.

When the data are made public this can be cleaned up, but note that it may remain helpful to have this variant for the sake of testing changes to the test data repository. (The challenge is that these repositories are designed to add tests to the CTest suite in NEURON, which implies that NEURON needs to be built against them to test any changes to the test repository itself.)

This was previously https://github.com/BlueBrain/spack/pull/1147, but apparently I can't re-open that having force-pushed to the branch. It should be viewed as an interim measure until https://github.com/neuronsimulator/nrn/issues/1346 is resolved. To take advantage of it, we will need to set the `channel-benchmark` variant in the CoreNEURON GitLab CI config.