### PR TITLE
Bump connectome-tools 0.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/connectome-tools/package.py
+++ b/var/spack/repos/builtin/packages/connectome-tools/package.py
@@ -13,18 +13,20 @@ class ConnectomeTools(PythonPackage):
     git = "git@bbpgitlab.epfl.ch:nse/connectome-tools.git"
 
     version('develop', branch='main')
-    version('0.5.1', tag='connectome-tools-v0.5.1')
+    version('0.6.0', tag='connectome-tools-v0.6.0')
 
     depends_on('py-setuptools', type=('build', 'run'))
 
     depends_on('py-click@7.0:8.999', type='run')
     depends_on('py-equation@1.2:', type='run')
-    depends_on('py-joblib@0.16.0:', type='run')
+    depends_on('py-joblib@1.0.1:', type='run')
+    depends_on('py-jsonschema@3.2.0:3.999', type='run')
     depends_on('py-lxml@3.3:', type='run')
     depends_on('py-numpy@1.9:', type='run')
     depends_on('py-pandas@1.0.0:', type='run')
     depends_on('py-psutil@5.7.2:', type='run')
     depends_on('py-pyyaml@5.3.1:', type='run')
+    depends_on('py-submitit@1.3.3:', type='run')
 
     depends_on('py-bluepy@2.3.0:2.999', type='run')
     depends_on('py-morphio@3.0.1:3.999', type='run')

--- a/var/spack/repos/builtin/packages/py-submitit/package.py
+++ b/var/spack/repos/builtin/packages/py-submitit/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PySubmitit(PythonPackage):
+    """Submit Python functions for computation within a Slurm cluster."""
+
+    homepage = "https://github.com/facebookincubator/submitit"
+    url      = "https://pypi.io/packages/source/s/submitit/submitit-1.3.3.tar.gz"
+
+    version("1.3.3", sha256="efaa77b2df9ea9ee02545478cbfc377853ddf8016bff59df6988bebcf51ffa7e")
+
+    depends_on("py-setuptools", type=("build", "run"))
+
+    depends_on("py-cloudpickle@1.2.1:", type="run")
+    depends_on("py-typing-extensions@3.7.4.2:", type="run")

--- a/var/spack/repos/builtin/packages/py-typing-extensions/package.py
+++ b/var/spack/repos/builtin/packages/py-typing-extensions/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -15,6 +15,8 @@ class PyTypingExtensions(PythonPackage):
     homepage = "https://github.com/python/typing/tree/master/typing_extensions"
     url      = "https://pypi.io/packages/source/t/typing_extensions/typing_extensions-3.7.4.tar.gz"
 
+    version('3.10.0.0', sha256='50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342')
+    version('3.7.4.3', sha256='99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c')
     version('3.7.4', sha256='2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95')
     version('3.7.2', sha256='fb2cd053238d33a8ec939190f30cfd736c00653a85a2919415cecf7dc3d9da71')
     version('3.6.6', sha256='51e7b7f3dcabf9ad22eed61490f3b8d23d9922af400fe6656cb08e66656b701f')


### PR DESCRIPTION
This version of `connectome-tools` could depend on `py-bluepy@2.4.1:` to make use of the latest improvements, but it's not released yet.
However, it should work also with `py-bluepy@2.3.0`.