### PR TITLE
Remove old py-bluepy versions

### DIFF
--- a/var/spack/repos/builtin/packages/circuit-analysis/package.py
+++ b/var/spack/repos/builtin/packages/circuit-analysis/package.py
@@ -13,7 +13,7 @@ class CircuitAnalysis(PythonPackage):
     git      = "git@bbpgitlab.epfl.ch:nse/circuit-analysis.git"
 
     version('develop', branch='master')
-    version('0.0.4', tag='circuit-analysis-v0.0.4')
+    version('0.0.5', tag='circuit-analysis-v0.0.5')
 
     depends_on('py-setuptools', type=('build', 'run'))
 
@@ -22,8 +22,9 @@ class CircuitAnalysis(PythonPackage):
     depends_on('py-pandas@0.17:', type='run')
     depends_on('py-matplotlib@2.0:', type='run')
     depends_on('py-seaborn@0.8:', type='run')
-    depends_on('py-bluepy@0.14:0.99', type='run')
-    depends_on('py-neurom@1.0:1.5.99', type='run')
+    depends_on('py-bluepy@2:', type='run')
+    depends_on('py-neurom@1.6:', type='run')
     depends_on('py-joblib@0.14:', type='run')
     depends_on('py-libsonata@0.1.4:', type='run')
     depends_on('py-tqdm@4.3:', type='run')
+    depends_on('py-lxml@3.3.2:', type='run')

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -15,17 +15,6 @@ class PyBglibpy(PythonPackage):
     version('develop', branch='master')
 
     version('4.4.36', commit='07fe9999a137c3741fd95713149a76a202cb7d7a')
-    version('4.4.20', commit='59cd13df919e60c272f1f90d178eea687206f13f')
-    version('4.4.18', commit='cbfb1c214d44eaab0a1cef3d3bbafa097469fe85')
-    version('4.4.10', commit='53db9eee6f0b4e025f19c271b3235831f86c866e')
-    version('4.4.6', commit='18e211153025535ebecb7e0a9868033b1462bec1')
-    version('4.4', commit='4597bf81374f4041f689a4e73e4319bf5c13947b')
-    version('4.3.19', commit='bce00a1ddedb605a5ed5225989192eb5f7e133ae')
-    version('4.3.15', commit='dccd717a2570d32776de824d864fba9dfdbf56f6')
-    version('4.3.12', commit='eb4accd2dc4ebcb01e65d6429bb8221af5aa14bf')
-    version('4.3', commit='61293ef3f64a18e7a336d7a5a959020c8237b207')
-    version('4.2.23', commit='4f88c9df716ca1c7b1c779ee934b28aa991a366b')
-    version('4.1.4', commit='e54d294460e5bdf6b9990bc10a4606b412b76d90')
 
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('neuron+python', type='run')
@@ -34,10 +23,7 @@ class PyBglibpy(PythonPackage):
     depends_on('py-cachetools', type='run')
     depends_on('py-h5py@2.3:', type='run')
 
-    # bluepy
-    depends_on('py-bluepy@:2.0', type='run', when='@:4.4.20')
-    depends_on('py-bluepy@2.1:', type='run', when='@4.4.36:')
-
+    depends_on('py-bluepy@2.1:', type='run')
     depends_on('py-libsonata', type='run')
 
     # skip import test, because bglibpy needs HOC_LIBRARY_PATH

--- a/var/spack/repos/builtin/packages/py-bglibpy/package.py
+++ b/var/spack/repos/builtin/packages/py-bglibpy/package.py
@@ -23,7 +23,7 @@ class PyBglibpy(PythonPackage):
     depends_on('py-cachetools', type='run')
     depends_on('py-h5py@2.3:', type='run')
 
-    depends_on('py-bluepy@2.1:', type='run')
+    depends_on('py-bluepy@2.1:2.999', type='run')
     depends_on('py-libsonata', type='run')
 
     # skip import test, because bglibpy needs HOC_LIBRARY_PATH

--- a/var/spack/repos/builtin/packages/py-bluepy/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepy/package.py
@@ -13,62 +13,23 @@ class PyBluepy(PythonPackage):
     git      = "ssh://bbpcode.epfl.ch/nse/bluepy"
 
     version('2.4.1', tag='bluepy-v2.4.1')
-    version('2.3.0', tag='bluepy-v2.3.0')
-    version('2.2.0', tag='bluepy-v2.2.0')
-    version('2.1.0', tag='bluepy-v2.1.0')
-    version('2.0.0', tag='bluepy-v2.0.0')
-    version('0.16.0', tag='bluepy-v0.16.0')
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('py-libsonata@0.1.7:', type='run')
-    depends_on('py-pandas@1.0.0:', type='run', when='@2.0.0:')
-    depends_on('py-bluepy-configfile@0.1.11:', type='run')
+    depends_on('py-libsonata@0.1.7:0.999', type='run')
+    depends_on('py-pandas@1.0.0:1.999', type='run')
+    depends_on('py-bluepy-configfile@0.1.15:0.999', type='run')
     depends_on('py-numpy@1.8:', type='run')
-
-    # the version of bluepy <2 needed multiple dependencies compatible
-    # with h5py < 3.0.0 and bluepy > 2 needs h5py > 3.0.0. Hence the
-    # following switches :
-    # h5py
-    depends_on('py-h5py@3.0.0:', type='run', when='@2.0.0:')
-    depends_on('py-h5py@2.3:2.99', type='run', when='@:1.0.0')
-
-    # neurom
-    depends_on('py-neurom@1.6.0:1.99.99', type='run', when='@2.0.0:2.2.0')
-    depends_on('py-neurom@1.4.18:1.5.99', type='run', when='@:1.0.0')
-
-    # py-lru
-    depends_on('py-pylru@1.2:', type='run', when='@:2.2.9')
-
-    # morph-tool
-    depends_on('py-morph-tool@2.5.1:2.999', type='run', when='@2.3.0:')
-
-    # morphio
-    depends_on('py-morphio@3.0.1:3.999', type='run', when='@2.3.0:')
-
-    # voxcell
-    depends_on('py-voxcell@3.0.0:', type='run', when='@2.0.0:')
-    depends_on('py-voxcell@2.7.4:2.99', type='run', when='@0.14.16:0.16.0')
-
-    # bluepysnap
-    depends_on('py-bluepysnap@0.12.0:0.999', type='run', when='@2.3.0:')
-    depends_on('py-bluepysnap@0.10.0:0.999', type='run', when='@2.2.0:')
-    depends_on('py-bluepysnap@0.8.0:0.999', type='run', when='@2.0.0:')
-    depends_on('py-bluepysnap@0.4.1:0.7.1', type='run', when='@:1.0.0')
-
-    # lazy / cached properties (change of backend for caching)
-    depends_on('py-cached-property@1.0:', type='run', when='@2.0.0:')
-    depends_on('py-lazy@1.0:', type='run', when='@:1.0.0')
-
-    # brion changed package name in 3.3.0 and brion bump in bluepy==2.1.0
-    depends_on('brion+python@3.1.0:3.2.0', type='run', when='@:2.0.9')
-    depends_on('brion+python@3.3.0:', type='run', when='@2.1.0:')
+    depends_on('py-h5py@3.0.1:3.999', type='run')
+    depends_on('py-morph-tool@2.4.3:2.999', type='run')
+    depends_on('py-morphio@3.0.1:3.999', type='run')
+    depends_on('py-voxcell@3.0.0:3.999', type='run')
+    depends_on('py-bluepysnap@0.12.0:0.999', type='run')
+    depends_on('py-cached-property@1.0:', type='run')
+    depends_on('brion+python@3.3.0:3.999', type='run')
 
     @property
     def import_modules(self):
-        if self.version < Version('2.0.0'):
-            # don't run import tests on older versions
-            return []
         # bluepy.index requires libFLATIndex, unavailable on spack
         modules = super(PyBluepy, self).import_modules
         return [m for m in modules if m != 'bluepy.index']

--- a/var/spack/repos/builtin/packages/py-bluepy/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepy/package.py
@@ -9,8 +9,8 @@ from spack import *
 class PyBluepy(PythonPackage):
     """Pythonic Blue Brain data access API"""
 
-    homepage = "https://bbpcode.epfl.ch/code/#/admin/projects/nse/bluepy"
-    git      = "ssh://bbpcode.epfl.ch/nse/bluepy"
+    homepage = "https://bbpgitlab.epfl.ch/nse/bluepy"
+    git      = "git@bbpgitlab.epfl.ch:nse/bluepy.git"
 
     version('2.4.1', tag='bluepy-v2.4.1')
 


### PR DESCRIPTION
Other related changes:
- bump circuit-analysis to 0.5.0 that is depending on py-bluepy >= 2 (need confirmation)
- remove old py-bglibpy versions depending on old versions of py-bluepy (need confirmation from Werner).

Notes about the old versions:
- the old versions are not currently built in unstable
- they can only be installed from old archives
- there are no other spack packages depending on them
so removing them from packages.py should be harmless.