### PR TITLE
Addresses issues related to gene-expression-volume's package.py [BBPP82-482]

### DIFF
--- a/var/spack/repos/builtin/packages/gene-expression-volume/package.py
+++ b/var/spack/repos/builtin/packages/gene-expression-volume/package.py
@@ -21,10 +21,10 @@ class GeneExpressionVolume(PythonPackage):
     depends_on('py-click@7.0:', type=('build', 'run'))
     depends_on('py-nptyping@1.0.1:', type=('build', 'run'))
     depends_on('py-numpy@1.15.0:', type=('build', 'run'))
-    depends_on('py-scikit-image@0.017.2:', type=('build', 'run'))
+    depends_on('py-scikit-image@0.17.2:', type=('build', 'run'))
     depends_on('py-types-pyyaml@5.4.0:', type=('build', 'run'))
-    depends_on('py-voxcell@2.7.4', type=('run', 'build'))
-    depends_on('py-pyaml@5.3.1:', type=('build', 'run'))
+    depends_on('py-voxcell@2.7.4:2.999', type=('run', 'build'))
+    depends_on('py-pyyaml@5.3.1:', type=('build', 'run'))
     depends_on('py-pytest', type='test')
     depends_on('py-mock', type='test')
 

--- a/var/spack/repos/builtin/packages/py-types-pyyaml/package.py
+++ b/var/spack/repos/builtin/packages/py-types-pyyaml/package.py
@@ -10,7 +10,7 @@ class PyTypesPyyaml(PythonPackage):
     """Typing stubs for PyYAML."""
 
     homepage = "https://github.com/python/typeshed"
-    url      = "https://files.pythonhosted.org/packages/3c/96/22a02c905aec42d8f7f7c48b7a00d68019edd4768e3fb94b754966d07870/types-PyYAML-5.4.6.tar.gz"
+    url      = "https://pypi.io/packages/source/t/types-pyyaml/types-PyYAML-5.4.6.tar.gz"
 
     version('5.4.6', sha256='745dcb4b1522423026bcc83abb9925fba747f1e8602d902f71a4058f9e7fb662')
 


### PR DESCRIPTION
This pull-request addresses several issues reported by @GianlucaFicarelli .

- reference to the wrong `py-pyaml` package (intended: `py-pyyaml`)
- the url in `py-types-pyyaml` shouldn't contain the hash of the associated `.tar.gz` file
- several typos in `version`s declared by `gene-expression-volume/package.py`