### PR TITLE
deploy: move *_ROOT var setting to central location

### DIFF
--- a/deploy/configs/modules.yaml
+++ b/deploy/configs/modules.yaml
@@ -17,6 +17,9 @@ modules:
     all:
       autoload: 'all'
       load_only_generated: true
+      environment:
+        set:
+          '${PACKAGE}_ROOT': '${PREFIX}'
     gcc:
       environment:
         set:

--- a/deploy/environments/applications.yaml
+++ b/deploy/environments/applications.yaml
@@ -3,10 +3,6 @@ spack:
   concretization: separately
   modules:
     tcl:
-      all:
-        environment:
-          set:
-            '${PACKAGE}_ROOT': '${PREFIX}'
       whitelist:
         - asciitoh5
         - brainbuilder

--- a/deploy/environments/compilers.yaml
+++ b/deploy/environments/compilers.yaml
@@ -4,6 +4,8 @@ spack:
   modules:
     tcl:
       all:
+        environment:
+          set:: {}
         filter:
           environment_blacklist: ['CPATH', 'LIBRARY_PATH']
       whitelist:

--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -3,10 +3,6 @@ spack:
   concretization: separately
   modules:
     tcl:
-      all:
-        environment:
-          set:
-            '${PACKAGE}_ROOT': '${PREFIX}'
       whitelist:
         - arm-forge
         - bison

--- a/deploy/environments/libraries.yaml
+++ b/deploy/environments/libraries.yaml
@@ -3,10 +3,6 @@ spack:
   concretization: separately
   modules:
     tcl:
-      all:
-        environment:
-          set:
-            '${PACKAGE}_ROOT': '${PREFIX}'
       whitelist:
         - boost
         - gmsh


### PR DESCRIPTION
Custom modules did not specify the `<PACKAGE>_ROOT` environment variable
in the module files any longer. Fix this by moving it from the
environment definitions to our central configuration.
