### PR TITLE
Enable extra Blue Brain NEURON tests

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -142,6 +142,8 @@ class Neuron(CMakePackage):
                                                              "+rx3d",
                                                              "+coreneuron",
                                                              "+tests"]]
+        if '+tests' in self.spec:
+            args.append('-DNRN_ENABLE_TESTS_BBP:BOOL=ON')
         if "+mpi" in self.spec:
             args.append("-DNRN_ENABLE_MPI=ON")
             if "~coreneuron" in self.spec:


### PR DESCRIPTION
`+tests` implies `-DNRN_ENABLE_TESTS_BBP:BOOL=ON`.

Minimalist approach, minor downsides:
- no way to disable these tests, CMake will fail if you have `+tests` and you cannot authenticate to BBP's GitLab
- no version constraint, CMake will warn about an unknown variable (`NRN_ENABLE_TESTS_BBP`) in old versions

This option is added in https://github.com/neuronsimulator/nrn/pull/1439, that PR and this one are tested by the CI of https://github.com/BlueBrain/CoreNeuron/pull/640.