### PR TITLE
ccache 4.4.{1,2}, other upstream changes.

### DIFF
--- a/var/spack/repos/builtin/packages/ccache/package.py
+++ b/var/spack/repos/builtin/packages/ccache/package.py
@@ -15,9 +15,12 @@ class Ccache(CMakePackage):
 
     homepage = "https://ccache.dev/"
     url      = "https://github.com/ccache/ccache/releases/download/v4.2.1/ccache-4.2.1.tar.gz"
+    maintainers = ['haampie']
 
     executables = ['^ccache$']
 
+    version('4.4.2', sha256='357a2ac55497b39ad6885c14b00cda6cf21d1851c6290f4288e62972665de417')
+    version('4.4.1', sha256='e20632f040a7d50bc622c10b2ab4c7a4a5dc2730c18492543d49ce4cf51b4c54')
     version('4.4',   sha256='61a993d62216aff35722a8d0e8ffef9b677fc3f6accd8944ffc2a6db98fb3142')
     version('4.3',   sha256='b9789c42e52c73e99428f311a34def9ffec3462736439afd12dbacc7987c1533')
     version('4.2.1', sha256='320d2b17d2f76393e5d4bb28c8dee5ca783248e9cd23dff0654694d60f8a4b62')
@@ -40,6 +43,9 @@ class Ccache(CMakePackage):
     depends_on('hiredis@0.13.3:', when='@4.4:')
     depends_on('libxslt', when='@:3.99')
     depends_on('zlib', when='@:3.99')
+
+    conflicts('%gcc@:5', when='@4.4:')
+    conflicts('%clang@:4', when='@4.4:')
 
     # Before 4.0 this was an Autotools package
     @when('@:3.99')


### PR DESCRIPTION
Content of: https://github.com/spack/spack/pull/25783, https://github.com/spack/spack/pull/25957, https://github.com/spack/spack/pull/26327.
The bug noted in https://ccache.dev/releasenotes.html#_ccache_4_4_2 was seen to affect https://github.com/BlueBrain/nmodl.