### PR TITLE
cmake: stop putting a CMAKE_ROOT into the module

### DIFF
--- a/deploy/configs/modules.yaml
+++ b/deploy/configs/modules.yaml
@@ -20,6 +20,11 @@ modules:
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'
+    # Don't set any environment (like CMAKE_ROOT), it'll interfere with
+    # library finding. `::` overrides with the empty set.
+    cmake:
+      environment:
+        set:: {}
     gcc:
       environment:
         set:


### PR DESCRIPTION
Should help with building, i.e., py-torch.
