### PR TITLE
deployment: unset *_ROOT to not interfere with CMake and potentially other packages

### DIFF
--- a/deploy/configs/modules.yaml
+++ b/deploy/configs/modules.yaml
@@ -17,15 +17,6 @@ modules:
     all:
       autoload: 'all'
       load_only_generated: true
-      environment:
-        set:
-          '${PACKAGE}_ROOT': '${PREFIX}'
-    # CMAKE_ROOT is globally set by the above but interferes with CMake's
-    # working, thus unset it again
-    cmake:
-      environment:
-        unset:
-          - CMAKE_ROOT
     gcc:
       environment:
         set:

--- a/deploy/configs/modules.yaml
+++ b/deploy/configs/modules.yaml
@@ -20,11 +20,12 @@ modules:
       environment:
         set:
           '${PACKAGE}_ROOT': '${PREFIX}'
-    # Don't set any environment (like CMAKE_ROOT), it'll interfere with
-    # library finding. `::` overrides with the empty set.
+    # CMAKE_ROOT is globally set by the above but interferes with CMake's
+    # working, thus unset it again
     cmake:
       environment:
-        set:: {}
+        unset:
+          - CMAKE_ROOT
     gcc:
       environment:
         set:

--- a/deploy/environments/compilers.yaml
+++ b/deploy/environments/compilers.yaml
@@ -4,8 +4,6 @@ spack:
   modules:
     tcl:
       all:
-        environment:
-          set:: {}
         filter:
           environment_blacklist: ['CPATH', 'LIBRARY_PATH']
       whitelist:


### PR DESCRIPTION
It seems that we have `*_ROOT` defined for all packages. But Spack also uses
```
    build_link_prefixes = filter_system_paths(
        x.prefix for x in build_link_deps)

    # Add dependencies to CMAKE_PREFIX_PATH
    env.set_path('CMAKE_PREFIX_PATH', build_link_prefixes)
```
to set the CMake search path to all deps that are not in standard locations. See also:
```
❯ spack build-env neuron|awk -F= '/CMAKE_PREFIX_PATH=/{gsub(":", "\n", $2);print $2}'
/home/matwolf/Work/spack/opt/spack/gcc-9.3.0-skylake/gettext-0.21-u7a73h
/home/matwolf/Work/spack/opt/spack/gcc-9.3.0-skylake/libiconv-1.16-af5tdk
/home/matwolf/Work/spack/opt/spack/gcc-9.3.0-skylake/py-cython-0.29.21-m3z22a
/home/matwolf/Work/spack/opt/spack/gcc-9.3.0-skylake/py-numpy-1.19.4-bbiijb
```

Thus I think we should leave `*_ROOT` alone unless explicitly required by a package. This will unbreak the CMake installation we have, as `CMAKE_ROOT` is referred to within CMake, pointing to a *different* prefix.