### PR TITLE
Use HPE-MPI v2.25 (1.9 release) for deployment

### DIFF
--- a/deploy/environments/applications_hpc.yaml
+++ b/deploy/environments/applications_hpc.yaml
@@ -5,7 +5,6 @@ spack:
     tcl:
       whitelist:
         - asciitoh5
-        - functionalizer
         - model-neocortex
         - nest
         - neurodamus-core
@@ -31,7 +30,6 @@ spack:
         +common: '{name}/{version}-commonmods'
   specs:
     - asciitoh5@1.0
-    #- functionalizer@3.12.2
     - model-neocortex%intel
     - nest@2.18.0
     - nest@2.20.0

--- a/deploy/environments/applications_hpc.yaml
+++ b/deploy/environments/applications_hpc.yaml
@@ -31,7 +31,7 @@ spack:
         +common: '{name}/{version}-commonmods'
   specs:
     - asciitoh5@1.0
-    - functionalizer@3.12.2
+    #- functionalizer@3.12.2
     - model-neocortex%intel
     - nest@2.18.0
     - nest@2.20.0

--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -91,7 +91,7 @@ spack:
     - help2man
     - hpctoolkit@2020.03.01
     - hpcviewer
-    - hpe-mpi@2.22.hmpt
+    - hpe-mpi@2.25.hmpt
     - intel-mkl
     - intel-mpi
     - ispc@1.12.0

--- a/var/spack/repos/builtin/packages/hpe-mpi/package.py
+++ b/var/spack/repos/builtin/packages/hpe-mpi/package.py
@@ -30,7 +30,10 @@ class HpeMpi(Package):
             url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.21.hmpt.tar.xz')
     version('2.22.hmpt',
             sha256='e067e4ba382d306d540e1ad5bcd63035a4aa93e7d7c15d617e82de4160e5ad8a',
-            url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.22.hmpt.tar.xz',
+            url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.22.hmpt.tar.xz')
+    version('2.25.hmpt',
+            sha256='70ceccca4dccd1865e778b01a631c7e85ea0913d7dbea6608d59ad4be3738187',
+            url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.25.hmpt.tar.xz',
             preferred=True)
 
     provides('mpi')

--- a/var/spack/repos/builtin/packages/hpe-mpi/package.py
+++ b/var/spack/repos/builtin/packages/hpe-mpi/package.py
@@ -33,8 +33,7 @@ class HpeMpi(Package):
             url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.22.hmpt.tar.xz')
     version('2.25.hmpt',
             sha256='70ceccca4dccd1865e778b01a631c7e85ea0913d7dbea6608d59ad4be3738187',
-            url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.25.hmpt.tar.xz',
-            preferred=True)
+            url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.25.hmpt.tar.xz')
 
     provides('mpi')
 

--- a/var/spack/repos/builtin/packages/hpe-mpi/package.py
+++ b/var/spack/repos/builtin/packages/hpe-mpi/package.py
@@ -32,7 +32,7 @@ class HpeMpi(Package):
             sha256='e067e4ba382d306d540e1ad5bcd63035a4aa93e7d7c15d617e82de4160e5ad8a',
             url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.22.hmpt.tar.xz')
     version('2.25.hmpt',
-            sha256='70ceccca4dccd1865e778b01a631c7e85ea0913d7dbea6608d59ad4be3738187',
+            sha256='126a46bb2cbd4b63bd7b3aed74cee5e8d08e166e9748071fd0b308be29335e1a',
             url='file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.25.hmpt.tar.xz')
 
     provides('mpi')


### PR DESCRIPTION
 * we have seen performance regression and deadlocks
   at scale with versions <= 2.23
 * ongoing tests with latest release i.e. v2.25 seems
   promising and we haven't observed deadlock so far.
 * hence, we might need to move to v2.25.

Creating this PR so that we can already have software stack
built with latest MPI and we can test it on reservation.