### PR TITLE
Update nvhpc recipe, deploy 21.9.

### DIFF
--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -335,24 +335,22 @@ configure_compilers() {
                 fi
             done
         elif [[ ${line} = *"pgi"* || ${line} = *"nvhpc"* ]]; then
-            #update pgi modules for network installation
-            PGI_DIR=$(dirname $(which makelocalrc))
-            PGI_TMPDIR=$(mktemp -d -p .)
-            makelocalrc ${PGI_DIR} -d "${PGI_TMPDIR}" -gcc ${GCC_DIR}/bin/gcc -gpp ${GCC_DIR}/bin/g++ -g77 ${GCC_DIR}/bin/gfortran -x -net
-            #configure pgi network license
-            template=$(ls -rt "${PGI_TMPDIR}"/localrc* | tail -n 1)
-            echo "set PREOPTIONS=-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1;" >> "${template}"
+            # Configure NVHPC compilers to use an up to date version of the C++
+            # standard library from the deployed version of GCC.
+            NVHPC_DIR=$(dirname $(which makelocalrc))
+            NVHPC_TMPDIR=$(mktemp -d -p .)
+            makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${GCC_DIR}/bin/gcc -gpp ${GCC_DIR}/bin/g++ -g77 ${GCC_DIR}/bin/gfortran -x
+            # OL211015 is this still needed? Not sure.
+            echo "set PREOPTIONS=-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1;" >> "${NVHPC_TMPDIR}/localrc"
             log "NVIDIA localrc template"
-            cat "${template}"
-            compute_nodes=$(sinfo -h -N -o %n | sort -u)
-            if [[ "${PGI_DIR}" != "${SPACK_INSTALL_PREFIX}"* ]]; then
+            cat "${NVHPC_TMPDIR}/localrc"
+            if [[ "${NVHPC_DIR}" != "${SPACK_INSTALL_PREFIX}"* ]]; then
+                # Don't modify an NVHPC version we didn't just install.
                 log "...installation does not match install prefix, skipping modification of files"
             else
-                for node in bbpv1 bbpv2 bbptadm tds03 tds04 ${compute_nodes}; do
-                    cp $template $PGI_DIR/localrc.$node || true
-                done
+                cp -v "${NVHPC_TMPDIR}/localrc" "${NVHPC_DIR}/localrc"
             fi
-            rm -rf "${PGI_TMPDIR}"
+            rm -rf "${NVHPC_TMPDIR}"
         fi
         cmd=${cmd/load/unload}
         echo "${cmd}"

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -340,12 +340,11 @@ configure_compilers() {
             NVHPC_DIR=$(dirname $(which makelocalrc))
             NVHPC_TMPDIR=$(mktemp -d -p .)
             makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${GCC_DIR}/bin/gcc -gpp ${GCC_DIR}/bin/g++ -g77 ${GCC_DIR}/bin/gfortran -x
-            # OL211015 is this still needed? Not sure.
+            # olupton 2021-10-15: is this still needed? Not sure.
             echo "set PREOPTIONS=-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1;" >> "${NVHPC_TMPDIR}/localrc"
             log "NVIDIA localrc template"
             cat "${NVHPC_TMPDIR}/localrc"
             if [[ "${NVHPC_DIR}" != "${SPACK_INSTALL_PREFIX}"* ]]; then
-                # Don't modify an NVHPC version we didn't just install.
                 log "...installation does not match install prefix, skipping modification of files"
             else
                 cp -v "${NVHPC_TMPDIR}/localrc" "${NVHPC_DIR}/localrc"

--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -59,8 +59,8 @@ spack:
       variants: +mpi~cuda~cupti+caliper~gperftools~python
   specs:
     - llvm@12.0.0 +cuda cuda_arch=70 +omp_tsan +python ^cuda@11.0.2
-    - nvhpc@20.9 install_type=network
     - nvhpc@21.2 install_type=network
+    - nvhpc@21.9 install_type=single
     - arm-forge@20.2.0-Redhat-7.0-x86_64
     - bison
     - blender

--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -60,7 +60,7 @@ spack:
   specs:
     - llvm@12.0.0 +cuda cuda_arch=70 +omp_tsan +python ^cuda@11.0.2
     - nvhpc@21.2 install_type=network
-    - nvhpc@21.9 install_type=single
+    - nvhpc@21.9
     - arm-forge@20.2.0-Redhat-7.0-x86_64
     - bison
     - blender

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -5,10 +5,11 @@
 #
 # Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 
-from spack import *
-from spack.util.prefix import Prefix
 import os
 import platform
+
+from spack import *
+from spack.util.prefix import Prefix
 
 # FIXME Remove hack for polymorphic versions
 # This package uses a ugly hack to be able to dispatch, given the same
@@ -21,6 +22,22 @@ import platform
 #  - package key must be in the form '{os}-{arch}' where 'os' is in the
 #    format returned by platform.system() and 'arch' by platform.machine()
 _versions = {
+    '21.9': {
+        'Linux-aarch64': ('52c2c66e30043add4afccedf0ba77daa0000bf42e0db844baa630bb635b91a7d', 'https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_aarch64_cuda_multi.tar.gz'),
+        'Linux-ppc64le': ('cff0b55fb782be1982bfeec1d9763b674ddbf84ff2c16b364495299266320289', 'https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_ppc64le_cuda_multi.tar.gz'),
+        'Linux-x86_64': ('7de6a6880fd7e59afe0dee51f1fae4d3bff1ca0fb8ee234b24e1f2fdff23ffc9', 'https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_x86_64_cuda_multi.tar.gz')},
+    '21.7': {
+        'Linux-aarch64': ('73eb3513845b59645f118b1e313472f54519dc252d5f5c32a05df2a2a8a19878', 'https://developer.download.nvidia.com/hpc-sdk/21.7/nvhpc_2021_217_Linux_aarch64_cuda_multi.tar.gz'),
+        'Linux-ppc64le': ('37ea23b5a9c696fb3fdb82855643afc4e02aea618102ec801206441f10fc9fba', 'https://developer.download.nvidia.com/hpc-sdk/21.7/nvhpc_2021_217_Linux_ppc64le_cuda_multi.tar.gz'),
+        'Linux-x86_64': ('49d6e23492d131474698cf12971722d42e13a54a4eddec382e66e1053b4ac902', 'https://developer.download.nvidia.com/hpc-sdk/21.7/nvhpc_2021_217_Linux_x86_64_cuda_multi.tar.gz')},
+    '21.5': {
+        'Linux-aarch64': ('1a1748cd7cf538199d92ab3b1208935fa4a62708ba21125aeadb328ddc7380d4', 'https://developer.download.nvidia.com/hpc-sdk/21.5/nvhpc_2021_215_Linux_aarch64_cuda_multi.tar.gz'),
+        'Linux-ppc64le': ('4674931a5ce28724308cb9cebd546eefa3f0646d3d08adbea28ba5ad27f0c163', 'https://developer.download.nvidia.com/hpc-sdk/21.5/nvhpc_2021_215_Linux_ppc64le_cuda_multi.tar.gz'),
+        'Linux-x86_64': ('21989e52c58a6914743631c8200de1fec7e10b3449c6c1833f3032ee74b85f8e', 'https://developer.download.nvidia.com/hpc-sdk/21.5/nvhpc_2021_215_Linux_x86_64_cuda_multi.tar.gz')},
+    '21.3': {
+        'Linux-aarch64': ('88e0dbf8fcdd06a2ba06aacf65ae1625b8683688f6593ed3bf8ce129ce1b17b7', 'https://developer.download.nvidia.com/hpc-sdk/21.3/nvhpc_2021_213_Linux_aarch64_cuda_multi.tar.gz'),
+        'Linux-ppc64le': ('08cd0cd6c80d633f107b44f88685ada7f014fbf6eac19ef5ae4a7952cabe4037', 'https://developer.download.nvidia.com/hpc-sdk/21.3/nvhpc_2021_213_Linux_ppc64le_cuda_multi.tar.gz'),
+        'Linux-x86_64': ('391d5604a70f61bdd4ca6a3e4692f6f2391948990c8a35c395b6867341890031', 'https://developer.download.nvidia.com/hpc-sdk/21.3/nvhpc_2021_213_Linux_x86_64_cuda_multi.tar.gz')},
     '21.2': {
         'Linux-aarch64': ('fe19c0232f7c9534f8699b7432483c9cc649f1e92e7f0961d1aa7c54d83297ff', 'https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc_2021_212_Linux_aarch64_cuda_multi.tar.gz'),
         'Linux-ppc64le': ('6b69b6e4ebec6a91b9f1627384c50adad79ebdd25dfb20a5f64cf01c3a07f11a', 'https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc_2021_212_Linux_ppc64le_cuda_multi.tar.gz'),
@@ -57,9 +74,10 @@ class Nvhpc(Package):
     and debugging tools simplify porting and optimization of HPC
     applications."""
 
-    homepage = "http://developer.nvidia.com/hpc-sdk"
+    homepage = "https://developer.nvidia.com/hpc-sdk"
 
     maintainers = ['samcmill']
+    tags = ['e4s']
 
     for ver, packages in _versions.items():
         key = "{0}-{1}".format(platform.system(), platform.machine())
@@ -110,7 +128,6 @@ class Nvhpc(Package):
         env.set('FC',  join_path(prefix.bin, 'nvfortran'))
 
         env.prepend_path('PATH',            prefix.bin)
-        env.prepend_path('CPATH',           prefix.include)
         env.prepend_path('LIBRARY_PATH',    prefix.lib)
         env.prepend_path('LD_LIBRARY_PATH', prefix.lib)
         env.prepend_path('MANPATH',         prefix.man)
@@ -120,7 +137,21 @@ class Nvhpc(Package):
                                           'Linux_%s' % self.spec.target.family,
                                           self.version, 'comm_libs', 'mpi'))
             env.prepend_path('PATH', mpi_prefix.bin)
-            env.prepend_path('CPATH', mpi_prefix.include)
+            env.prepend_path('LD_LIBRARY_PATH', mpi_prefix.lib)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        prefix = Prefix(join_path(self.prefix,
+                                  'Linux_%s' % self.spec.target.family,
+                                  self.version, 'compilers'))
+
+        env.prepend_path('LIBRARY_PATH',    prefix.lib)
+        env.prepend_path('LD_LIBRARY_PATH', prefix.lib)
+
+        if '+mpi' in self.spec:
+            mpi_prefix = Prefix(join_path(self.prefix,
+                                          'Linux_%s' % self.spec.target.family,
+                                          self.version, 'comm_libs', 'mpi'))
+
             env.prepend_path('LD_LIBRARY_PATH', mpi_prefix.lib)
 
     def setup_dependent_package(self, module, dependent_spec):


### PR DESCRIPTION
Simplify deployment script by generating a single `localrc` instead of
copying identical `localrc.hostname` files for all known nodes.