### PR TITLE
Bump py-bluepy to 2.4.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-bluepy/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepy/package.py
@@ -12,21 +12,21 @@ class PyBluepy(PythonPackage):
     homepage = "https://bbpgitlab.epfl.ch/nse/bluepy"
     git      = "git@bbpgitlab.epfl.ch:nse/bluepy.git"
 
-    version('2.4.1', tag='bluepy-v2.4.1')
+    version('2.4.2', tag='bluepy-v2.4.2')
 
     depends_on('py-setuptools', type=('build', 'run'))
 
-    depends_on('py-libsonata@0.1.7:0.999', type='run')
-    depends_on('py-pandas@1.0.0:1.999', type='run')
-    depends_on('py-bluepy-configfile@0.1.15:0.999', type='run')
-    depends_on('py-numpy@1.8:', type='run')
-    depends_on('py-h5py@3.0.1:3.999', type='run')
-    depends_on('py-morph-tool@2.4.3:2.999', type='run')
-    depends_on('py-morphio@3.0.1:3.999', type='run')
-    depends_on('py-voxcell@3.0.0:3.999', type='run')
-    depends_on('py-bluepysnap@0.12.0:0.999', type='run')
-    depends_on('py-cached-property@1.0:', type='run')
-    depends_on('brion+python@3.3.0:3.999', type='run')
+    depends_on('py-libsonata@0.1.7:0.999', type=('build', 'run'))
+    depends_on('py-pandas@1.0.0:1.999', type=('build', 'run'))
+    depends_on('py-bluepy-configfile@0.1.15:0.999', type=('build', 'run'))
+    depends_on('py-numpy@1.8:', type=('build', 'run'))
+    depends_on('py-h5py@3.0.1:3.999', type=('build', 'run'))
+    depends_on('py-morph-tool@2.4.3:2.999', type=('build', 'run'))
+    depends_on('py-morphio@3.0.1:3.999', type=('build', 'run'))
+    depends_on('py-voxcell@3.0.0:3.999', type=('build', 'run'))
+    depends_on('py-bluepysnap@0.12.0:0.999', type=('build', 'run'))
+    depends_on('py-cached-property@1.0:', type=('build', 'run'))
+    depends_on('brion+python@3.3.0:3.999', type=('build', 'run'))
 
     @property
     def import_modules(self):


### PR DESCRIPTION
- Bump py-bluepy to 2.4.2
- Replace `type='run'` with `type=('build', 'run')` as indicated in https://spack.readthedocs.io/en/latest/build_systems/pythonpackage.html#python-dependencies