### PR TITLE
cuda: update recipe, deploy 11.4.2

### DIFF
--- a/deploy/configs/packages.yaml
+++ b/deploy/configs/packages.yaml
@@ -13,8 +13,6 @@ packages:
     variants: +pic
   cmake:
     version: [3.15.7]
-  cuda:
-    version: [11.1.0]
   curl:
     version: [7.29.0]
     externals:

--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -70,8 +70,8 @@ spack:
     - cgal
     - cli-tools
     - cmake@3.15.7
-    - cuda@10.1.243
     - cuda@11.0.2
+    - cuda@11.4.2
     - cudnn@8.0.3.33-11.0-linux-x64
     - darshan-runtime
     - darshan-util

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -1,19 +1,18 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.package import PackageBase
-from spack.directives import depends_on, variant, conflicts
-
 import spack.variant
+from spack.directives import conflicts, depends_on, variant
+from spack.package import PackageBase
 
 
 class CudaPackage(PackageBase):
     """Auxiliary class which contains CUDA variant, dependencies and conflicts
     and is meant to unify and facilitate its usage.
 
-    Maintainers: ax3l, Rombur
+    Maintainers: ax3l, Rombur, davidbeckingsale
     """
 
     # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
@@ -79,47 +78,63 @@ class CudaPackage(PackageBase):
     depends_on('cuda@11.0:',    when='cuda_arch=80')
     depends_on('cuda@11.1:',    when='cuda_arch=86')
 
-    # There are at least three cases to be aware of for compiler conflicts
-    # 1. Linux x86_64
-    # 2. Linux ppc64le
-    # 3. Mac OS X
-    # CUDA-compiler conflicts are version-to-version specific and are
-    # difficult to express with the current Spack conflict syntax
+    # From the NVIDIA install guide we know of conflicts for particular
+    # platforms (linux, darwin), architectures (x86, powerpc) and compilers
+    # (gcc, clang). We don't restrict %gcc and %clang conflicts to
+    # platform=linux, since they should also apply to platform=cray, and may
+    # apply to platform=darwin. We currently do not provide conflicts for
+    # platform=darwin with %apple-clang.
 
     # Linux x86_64 compiler conflicts from here:
     # https://gist.github.com/ax3l/9489132
-    arch_platform = ' target=x86_64: platform=linux'
-    conflicts('%gcc@5:', when='+cuda ^cuda@:7.5' + arch_platform)
-    conflicts('%gcc@6:', when='+cuda ^cuda@:8' + arch_platform)
-    conflicts('%gcc@7:', when='+cuda ^cuda@:9.1' + arch_platform)
-    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130' + arch_platform)
-    conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89' + arch_platform)
-    conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
-    conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27' + arch_platform)
-    conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5' + arch_platform)
-    conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8' + arch_platform)
-    conflicts('%pgi@:15,18:', when='+cuda ^cuda@9.0:9.1' + arch_platform)
-    conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10' + arch_platform)
-    conflicts('%pgi@:17,20:',
-              when='+cuda ^cuda@10.1.105:10.2.89' + arch_platform)
-    conflicts('%pgi@:17,21:',
-              when='+cuda ^cuda@11.0.2:11.1.0' + arch_platform)
-    conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5' + arch_platform)
-    conflicts('%clang@:3.7,4:',
-              when='+cuda ^cuda@8.0:9.0' + arch_platform)
-    conflicts('%clang@:3.7,4.1:',
-              when='+cuda ^cuda@9.1' + arch_platform)
-    conflicts('%clang@:3.7,5.1:', when='+cuda ^cuda@9.2' + arch_platform)
-    conflicts('%clang@:3.7,6.1:', when='+cuda ^cuda@10.0.130' + arch_platform)
-    conflicts('%clang@:3.7,7.1:', when='+cuda ^cuda@10.1.105' + arch_platform)
+
+    # GCC
+    # According to
+    # https://github.com/spack/spack/pull/25054#issuecomment-886531664
+    # these conflicts are valid independently from the architecture
+
+    # minimum supported versions
+    conflicts('%gcc@:4', when='+cuda ^cuda@11.0:')
+    conflicts('%gcc@:5', when='+cuda ^cuda@11.4:')
+
+    # maximum supported version
+    # NOTE:
+    # in order to not constrain future cuda version to old gcc versions,
+    # it has been decided to use an upper bound for the latest version.
+    # This implies that the last one in the list has to be updated at
+    # each release of a new cuda minor version.
+    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
+    conflicts('%gcc@11:', when='+cuda ^cuda@:11.4.0')
+    conflicts('%gcc@12:', when='+cuda ^cuda@:11.5.0')
+    conflicts('%clang@12:', when='+cuda ^cuda@:11.4.0')
+    conflicts('%clang@13:', when='+cuda ^cuda@:11.5.0')
+
+    # https://gist.github.com/ax3l/9489132#gistcomment-3860114
+    conflicts('%gcc@10', when='+cuda ^cuda@:11.4.0')
+    conflicts('%gcc@5:', when='+cuda ^cuda@:7.5 target=x86_64:')
+    conflicts('%gcc@6:', when='+cuda ^cuda@:8 target=x86_64:')
+    conflicts('%gcc@7:', when='+cuda ^cuda@:9.1 target=x86_64:')
+    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=x86_64:')
+    conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89 target=x86_64:')
+    conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27 target=x86_64:')
+    conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5 target=x86_64:')
+    conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8 target=x86_64:')
+    conflicts('%pgi@:15,18:', when='+cuda ^cuda@9.0:9.1 target=x86_64:')
+    conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10 target=x86_64:')
+    conflicts('%pgi@:17,20:', when='+cuda ^cuda@10.1.105:10.2.89 target=x86_64:')
+    conflicts('%pgi@:17,21:', when='+cuda ^cuda@11.0.2:11.1.0 target=x86_64:')
+    conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5 target=x86_64:')
+    conflicts('%clang@:3.7,4:', when='+cuda ^cuda@8.0:9.0 target=x86_64:')
+    conflicts('%clang@:3.7,4.1:', when='+cuda ^cuda@9.1 target=x86_64:')
+    conflicts('%clang@:3.7,5.1:', when='+cuda ^cuda@9.2 target=x86_64:')
+    conflicts('%clang@:3.7,6.1:', when='+cuda ^cuda@10.0.130 target=x86_64:')
+    conflicts('%clang@:3.7,7.1:', when='+cuda ^cuda@10.1.105 target=x86_64:')
     conflicts('%clang@:3.7,8.1:',
-              when='+cuda ^cuda@10.1.105:10.1.243' + arch_platform)
-    conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89' + arch_platform)
-    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
+              when='+cuda ^cuda@10.1.105:10.1.243 target=x86_64:')
+    conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89 target=x86_64:')
+    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=x86_64:')
+    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.3 target=x86_64:')
+    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=x86_64:')
 
     # x86_64 vs. ppc64le differ according to NVidia docs
     # Linux ppc64le compiler conflicts from Table from the docs below:
@@ -129,27 +144,23 @@ class CudaPackage(PackageBase):
     # https://docs.nvidia.com/cuda/archive/9.0/cuda-installation-guide-linux/index.html
     # https://docs.nvidia.com/cuda/archive/8.0/cuda-installation-guide-linux/index.html
 
-    arch_platform = ' target=ppc64le: platform=linux'
     # information prior to CUDA 9 difficult to find
-    conflicts('%gcc@6:', when='+cuda ^cuda@:9' + arch_platform)
-    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130' + arch_platform)
-    conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243' + arch_platform)
+    conflicts('%gcc@6:', when='+cuda ^cuda@:9 target=ppc64le:')
+    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=ppc64le:')
+    conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243 target=ppc64le:')
     # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
-    conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
-    conflicts('%pgi', when='+cuda ^cuda@:8' + arch_platform)
-    conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185' + arch_platform)
-    conflicts('%pgi@:17', when='+cuda ^cuda@:10' + arch_platform)
-    conflicts('%clang@4:', when='+cuda ^cuda@:9.0.176' + arch_platform)
-    conflicts('%clang@5:', when='+cuda ^cuda@:9.1' + arch_platform)
-    conflicts('%clang@6:', when='+cuda ^cuda@:9.2' + arch_platform)
-    conflicts('%clang@7:', when='+cuda ^cuda@10.0.130' + arch_platform)
-    conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105' + arch_platform)
-    conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89' + arch_platform)
-    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
+    conflicts('%pgi', when='+cuda ^cuda@:8 target=ppc64le:')
+    conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185 target=ppc64le:')
+    conflicts('%pgi@:17', when='+cuda ^cuda@:10 target=ppc64le:')
+    conflicts('%clang@4:', when='+cuda ^cuda@:9.0.176 target=ppc64le:')
+    conflicts('%clang@5:', when='+cuda ^cuda@:9.1 target=ppc64le:')
+    conflicts('%clang@6:', when='+cuda ^cuda@:9.2 target=ppc64le:')
+    conflicts('%clang@7:', when='+cuda ^cuda@10.0.130 target=ppc64le:')
+    conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105 target=ppc64le:')
+    conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89 target=ppc64le:')
+    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=ppc64le:')
+    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2 target=ppc64le:')
+    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=ppc64le:')
 
     # Intel is mostly relevant for x86_64 Linux, even though it also
     # exists for Mac OS X. No information prior to CUDA 3.2 or Intel 11.1
@@ -171,16 +182,9 @@ class CudaPackage(PackageBase):
     conflicts('%xl@:12,14:15,17:', when='+cuda ^cuda@9.2')
     conflicts('%xl@:12,17:', when='+cuda ^cuda@:11.1.0')
 
-    # Mac OS X
-    # platform = ' platform=darwin'
-    # Apple XCode clang vs. LLVM clang are difficult to specify
-    # with spack syntax. Xcode clang name is `clang@x.y.z-apple`
-    # which precludes ranges being specified. We have proposed
-    # rename XCode clang to `clang@apple-x.y.z` or even
-    # `clang-apple@x.y.z as a possible fix.
-    # Compiler conflicts will be eventual taken from here:
-    # https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#abstract
-    conflicts('platform=darwin', when='+cuda ^cuda@11.0.2:')
+    # Darwin.
+    # TODO: add missing conflicts for %apple-clang cuda@:10
+    conflicts('platform=darwin', when='+cuda ^cuda@11.0.2: ')
 
     # Make sure cuda_arch can not be used without +cuda
     for value in cuda_arch_values:

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -187,7 +187,8 @@ class Cuda(Package):
         # https://gist.github.com/ax3l/9489132
         # for details.
 
-        # CUDA 10.1 on ppc64le fails to copy some files, the workaround is adapted from
+        # CUDA 10.1 on ppc64le fails to copy some files, the workaround is
+        # adapted from
         # https://forums.developer.nvidia.com/t/cuda-10-1-243-10-1-update-2-ppc64le-run-file-installation-issue/82433
         # See also #21170
         if spec.satisfies('@10.1.243') and platform.machine() == 'ppc64le':
@@ -200,10 +201,11 @@ class Cuda(Package):
 
         if self.spec.satisfies('@:8.0.61'):
             # Perl 5.26 removed current directory from module search path.
-            # We are addressing this by exporting `PERL5LIB` earlier, but for some
-            # reason, it is not enough. One more file needs to be extracted before
-            # running the actual installer. This solution is one of the commonly
-            # found on the Internet, when people try to install CUDA <= 8 manually.
+            # We are addressing this by exporting `PERL5LIB` earlier, but for
+            # some reason, it is not enough. One more file needs to be
+            # extracted before running the actual installer. This solution is
+            # one of the commonly found on the Internet, when people try to
+            # install CUDA <= 8 manually.
             # For example: https://askubuntu.com/a/1087842
             arguments = [runfile, '--tar', 'mxvf', './InstallUtils.pm']
             install_shell(*arguments)

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -133,13 +133,7 @@ class Cuda(Package):
     # Mojave support -- only macOS High Sierra 10.13 is supported.
     conflicts('arch=darwin-mojave-x86_64')
 
-    variant('dev', default=False, description='Enable development dependencies, i.e to use cuda-gdb')
-
     depends_on('libxml2', when='@10.1.243:')
-    # cuda-gdb needed libncurses.so.5 before 11.4.0
-    # see https://docs.nvidia.com/cuda/archive/11.3.1/cuda-gdb/index.html#common-issues-oss
-    # see https://docs.nvidia.com/cuda/archive/11.4.0/cuda-gdb/index.html#release-notes
-    depends_on('ncurses abi=5', type='run', when='@:11.3.99+dev')
 
     provides('opencl@:1.2', when='@7:')
     provides('opencl@:1.1', when='@:6')

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -3,13 +3,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-from glob import glob
-from llnl.util.filesystem import LibraryList
 import os
-import re
 import platform
+import re
+from glob import glob
+
 import llnl.util.tty as tty
+from llnl.util.filesystem import LibraryList
+
+from spack import *
 
 # FIXME Remove hack for polymorphic versions
 # This package uses a ugly hack to be able to dispatch, given the same
@@ -23,6 +25,34 @@ import llnl.util.tty as tty
 #    format returned by platform.system() and 'arch' by platform.machine()
 
 _versions = {
+    '11.5.0': {
+        'Linux-aarch64': ('6ea9d520cc956cc751a5ac54f4acc39109627f4e614dd0b1a82cc86f2aa7d8c4', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_sbsa.run'),
+        'Linux-x86_64': ('ae0a1693d9497cf3d81e6948943e3794636900db71c98d58eefdacaf7f1a1e4c', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run'),
+        'Linux-ppc64le': ('95baefdc5adf165189407b119861ffb2e9800fd94d7fc81d10fb81ed36dc12db', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_ppc64le.run')},
+    '11.4.2': {
+        'Linux-aarch64': ('f2c4a52e06329606c8dfb7c5ea3f4cb4c0b28f9d3fdffeeb734fcc98daf580d8', 'https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux_sbsa.run'),
+        'Linux-x86_64': ('bbd87ca0e913f837454a796367473513cddef555082e4d86ed9a38659cc81f0a', 'https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run'),
+        'Linux-ppc64le': ('a917c2e53dc13fdda7def71fd40920bf3809d5a2caa3e9acfe377fb9fb22f12d', 'https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux_ppc64le.run')},
+    '11.4.1': {
+        'Linux-aarch64': ('8efa725a41dfd3c0c0f453c2dd535d149154102bf2b791718859417b4f84f922', 'https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux_sbsa.run'),
+        'Linux-x86_64': ('dd6c339a719989d2518f5d54eeac1ed707d0673f8664ba0c4d4b2af7c3ba0005', 'https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux.run'),
+        'Linux-ppc64le': ('dd92ca04f76ad938da3480e2901c0e52dbff6028ada63c09071ed9e3055dc361', 'https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux_ppc64le.run')},
+    '11.4.0': {
+        'Linux-aarch64': ('f0c8e80d98a601ddca031b6764459984366008c7d3847e7c7f99b36bd4438e3c', 'https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_470.42.01_linux_sbsa.run'),
+        'Linux-x86_64': ('d219db30f7415a115a4ea22bdbb5984b0a18f7f891cad6074c5da45d223aaa4b', 'https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_470.42.01_linux.run'),
+        'Linux-ppc64le': ('6eb2fd0d9d5bc39fb243b5e1789ff827f325d098cd1fbb828a0499552b9544cc', 'https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_470.42.01_linux_ppc64le.run')},
+    '11.3.1': {
+        'Linux-aarch64': ('39990d3da88b21289ac20850bc183f0b66275f32e1f562b551c05843bf506e4c', 'https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux_sbsa.run'),
+        'Linux-x86_64': ('ad93ea98efced35855c58d3a0fc326377c60917cb3e8c017d3e6d88819bf2934', 'https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run'),
+        'Linux-ppc64le': ('220f2c10a21500d62b03c6848c1659ebb3a8e10dc0915ab87b86b397058407c5', 'https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux_ppc64le.run')},
+    '11.3.0': {
+        'Linux-aarch64': ('f7b284cf055fcf18be9a9aa216e3c7968d3e011446eb0c7200a3353c223ce718', 'https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux_sbsa.run'),
+        'Linux-x86_64': ('262da7f77db177b153a6b70b5812210f3f72f00eb608ab9cf2a4582328c4bf5c', 'https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux.run'),
+        'Linux-ppc64le': ('c0010107933b575a87e27b1293e5dc32b74201486f4ae2f4c8695ea727d22857', 'https://developer.download.nvidia.com/compute/cuda/11.3.0/local_installers/cuda_11.3.0_465.19.01_linux_ppc64le.run')},
+    '11.2.2': {
+        'Linux-aarch64': ('2f915ad631331eebdafaabd971723a60290ae8bb090d771075b9e6a0b28cbae6', 'https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux_sbsa.run'),
+        'Linux-x86_64': ('0a2e477224af7f6003b49edfd2bfee07667a8148fe3627cfd2765f6ad72fa19d', 'https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run'),
+        'Linux-ppc64le': ('2304ec235fe5d1f8bf75f00dc2c2d11473759dc23428dbbd5fb5040bc8c757e3', 'https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux_ppc64le.run')},
     '11.2.1': {
         'Linux-aarch64': ('4b322fa6477d1a2cd2f2f526fa520c0f90bef2c264ef8435cb016bebb5456c5e', 'https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux_sbsa.run'),
         'Linux-x86_64': ('1da98cb897cc5f58a7445a4a66ca4f6926867706cb3af58a669cdcd8dc3d17c8', 'https://developer.download.nvidia.com/compute/cuda/11.2.1/local_installers/cuda_11.2.1_460.32.03_linux.run'),
@@ -39,6 +69,10 @@ _versions = {
         'Linux-aarch64': ('878cbd36c5897468ef28f02da50b2f546af0434a8a89d1c724a4d2013d6aa993', 'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux_sbsa.run'),
         'Linux-x86_64': ('858cbab091fde94556a249b9580fadff55a46eafbcb4d4a741d2dcd358ab94a5', 'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux.run'),
         'Linux-ppc64le': ('a561e6f7f659bc4100e4713523b0b8aad6b36aa77fac847f6423e7780c750064', 'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux_ppc64le.run')},
+    '11.0.3': {
+        'Linux-aarch64': ('1e24f61f79c1043aa3d1d126ff6158daa03a62a51b5195a2ed5fbe75c3b718f3', 'https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux_sbsa.run'),
+        'Linux-x86_64': ('b079c4e408adf88c3f1ffb8418a97dc4227c37935676b4bf4ca0beec6c328cc0', 'https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run'),
+        'Linux-ppc64le': ('4775b21df004b1433bafff9b48a324075c008509f4c0fe28cd060d042d2e0794', 'https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux_ppc64le.run')},
     '11.0.2': {
         'Linux-aarch64': ('23851e30f7c47a1baad92891abde0adbc783de5962c7480b9725198ceacda4a0', 'https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux_sbsa.run'),
         'Linux-x86_64': ('48247ada0e3f106051029ae8f70fbd0c238040f58b0880e55026374a959a69c1', 'https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run'),
@@ -62,9 +96,9 @@ _versions = {
     '8.0.44': {
         'Linux-x86_64': ('64dc4ab867261a0d690735c46d7cc9fc60d989da0d69dc04d1714e409cacbdf0', 'https://developer.nvidia.com/compute/cuda/8.0/prod/local_installers/cuda_8.0.44_linux-run')},
     '7.5.18': {
-        'Linux-x86_64': ('08411d536741075131a1858a68615b8b73c51988e616e83b835e4632eea75eec', 'http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_linux.run')},
+        'Linux-x86_64': ('08411d536741075131a1858a68615b8b73c51988e616e83b835e4632eea75eec', 'https://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_linux.run')},
     '6.5.14': {
-        'Linux-x86_64': ('f3e527f34f317314fe8fcd8c85f10560729069298c0f73105ba89225db69da48', 'http://developer.download.nvidia.com/compute/cuda/6_5/rel/installers/cuda_6.5.14_linux_64.run')},
+        'Linux-x86_64': ('f3e527f34f317314fe8fcd8c85f10560729069298c0f73105ba89225db69da48', 'https://developer.download.nvidia.com/compute/cuda/6_5/rel/installers/cuda_6.5.14_linux_64.run')},
 }
 
 
@@ -99,7 +133,13 @@ class Cuda(Package):
     # Mojave support -- only macOS High Sierra 10.13 is supported.
     conflicts('arch=darwin-mojave-x86_64')
 
+    variant('dev', default=False, description='Enable development dependencies, i.e to use cuda-gdb')
+
     depends_on('libxml2', when='@10.1.243:')
+    # cuda-gdb needed libncurses.so.5 before 11.4.0
+    # see https://docs.nvidia.com/cuda/archive/11.3.1/cuda-gdb/index.html#common-issues-oss
+    # see https://docs.nvidia.com/cuda/archive/11.4.0/cuda-gdb/index.html#release-notes
+    depends_on('ncurses abi=5', type='run', when='@:11.3.99+dev')
 
     provides('opencl@:1.2', when='@7:')
     provides('opencl@:1.1', when='@:6')
@@ -112,6 +152,11 @@ class Cuda(Package):
         return match.group(1) if match else None
 
     def setup_build_environment(self, env):
+        if self.spec.satisfies('@:8.0.61'):
+            # Perl 5.26 removed current directory from module search path,
+            # CUDA 9 has a fix for this, but CUDA 8 and lower don't.
+            env.append_path('PERL5LIB', self.stage.source_path)
+
         if self.spec.satisfies('@10.1.243:'):
             libxml2_home = self.spec['libxml2'].prefix
             env.set('LIBXML2HOME', libxml2_home)
@@ -142,8 +187,7 @@ class Cuda(Package):
         # https://gist.github.com/ax3l/9489132
         # for details.
 
-        # CUDA 10.1 on ppc64le fails to copy some files, the workaround is
-        # adapted from
+        # CUDA 10.1 on ppc64le fails to copy some files, the workaround is adapted from
         # https://forums.developer.nvidia.com/t/cuda-10-1-243-10-1-update-2-ppc64le-run-file-installation-issue/82433
         # See also #21170
         if spec.satisfies('@10.1.243') and platform.machine() == 'ppc64le':
@@ -152,6 +196,18 @@ class Cuda(Package):
             os.makedirs(os.path.join(prefix, "src"))
             os.symlink(includedir, os.path.join(prefix, "include"))
 
+        install_shell = which('sh')
+
+        if self.spec.satisfies('@:8.0.61'):
+            # Perl 5.26 removed current directory from module search path.
+            # We are addressing this by exporting `PERL5LIB` earlier, but for some
+            # reason, it is not enough. One more file needs to be extracted before
+            # running the actual installer. This solution is one of the commonly
+            # found on the Internet, when people try to install CUDA <= 8 manually.
+            # For example: https://askubuntu.com/a/1087842
+            arguments = [runfile, '--tar', 'mxvf', './InstallUtils.pm']
+            install_shell(*arguments)
+
         # CUDA 10.1+ has different cmdline options for the installer
         arguments = [
             runfile,            # the install script
@@ -159,13 +215,15 @@ class Cuda(Package):
             '--override',       # override compiler version checks
             '--toolkit',        # install CUDA Toolkit
         ]
+
         if spec.satisfies('@10.1:'):
             arguments.append('--installpath=%s' % prefix)   # Where to install
         else:
             arguments.append('--verbose')                   # Verbose log file
             arguments.append('--toolkitpath=%s' % prefix)   # Where to install
-        install_shell = which('sh')
+
         install_shell(*arguments)
+
         try:
             os.remove('/tmp/cuda-installer.log')
         except OSError:


### PR DESCRIPTION
In https://github.com/spack/spack/pull/26892 I added the 3 newest versions of CUDA to upstream.

This PR backports the new versions, but maintains some small differences w.r.t. the upstream version:
- Keep the BBP-specific patch to add the CUPTI library path to `LD_LIBRARY_PATH`
- Drop the upstream `dev` variant and `ncurses` dependency -- even if we don't enable the variant, to make the upstream recipe work we have to backport changes to the `ncurses` recipe that would trigger a lot of rebuilding in our deployment.
- The formatting rules are different between our `develop` and `upstream/develop` 😞

In addition to the above changes to the recipes, modify the BB5 deployment to:
- include CUDA 11.4.2.
- drop CUDA 10.1.243 and a reference to CUDA 11.1.0.

We can use CUDA 11.4 with NVHPC 21.9, which was deployed in https://github.com/BlueBrain/spack/pull/1334 (actually the NVHPC installation bundles CUDA, but in our current setup we only partially use the bundled version).

Note that CUDA 11.4.1+ support GCC 11 and Clang 12 as host compilers, which may be useful for the next redeployment.