### PR TITLE
steps: requires omega-h < 9.30

### DIFF
--- a/var/spack/repos/builtin/packages/steps/package.py
+++ b/var/spack/repos/builtin/packages/steps/package.py
@@ -53,7 +53,7 @@ class Steps(CMakePackage):
     depends_on("python")
     depends_on('py-pre-commit', type='build', when='+codechecks')
     depends_on('py-pyyaml', type='build', when='+codechecks')
-    depends_on("omega-h+gmsh+mpi", when="~bundle+distmesh")
+    depends_on("omega-h+gmsh+mpi@:9.29.99", when="~bundle+distmesh")
     depends_on("gmsh", when="+distmesh")
     depends_on("easyloggingpp", when="~bundle")
     depends_on("random123", when="~bundle")


### PR DESCRIPTION
It seems there is a huge performance degradation with 9.30