### PR TITLE
docs: better git clone

### DIFF
--- a/deploy/docs/ci_bb5.md
+++ b/deploy/docs/ci_bb5.md
@@ -3,7 +3,8 @@
 When building Spack packages with Jenkins, please use the `bb5` executors.
 Then you will be able to install software with:
 
-    $ git clone https://github.com/BlueBrain/spack.git
+    $ module load unstable git
+    $ git clone -c feature.manyFiles=true https://github.com/BlueBrain/spack.git
     $ . spack/share/spack/setup-env.sh
     $ mkdir fake_home
     $ export HOME=${PWD}/fake_home

--- a/deploy/docs/setup_bb5.md
+++ b/deploy/docs/setup_bb5.md
@@ -3,7 +3,8 @@
 On BlueBrain5, clone this repository to get started using Spack.
 The following commands are a good way to get started:
 
-    $ git clone https://github.com/BlueBrain/spack.git
+    $ module load unstable git
+    $ git clone -c feature.manyFiles=true https://github.com/BlueBrain/spack.git
     $ . spack/share/spack/setup-env.sh
     $ ln -s /gpfs/bbp.cscs.ch/apps/hpc/jenkins/config/*.yaml ${SPACK_ROOT}/etc/spack
 

--- a/deploy/docs/setup_personal.md
+++ b/deploy/docs/setup_personal.md
@@ -13,7 +13,7 @@ Before starting, please install brew and the required packages.
 If you require Python please install a version dowloaded from
 Python.org, as several issues have been found with Homebrew's Python
 
-    $ git clone https://github.com/BlueBrain/spack.git
+    $ git clone -c feature.manyFiles=true https://github.com/BlueBrain/spack.git
     $ mkdir ~/.spack
     $ cp spack/sysconfig/mac_osx/*.yaml ~/.spack
     $ . spack/share/spack/setup-env.sh
@@ -28,7 +28,7 @@ Use Spack on the workstations provided by the project.
 We build Docker images based on Ubuntu 18.04, and the same settings can be
 used to set Spack up on the desktops:
 
-    $ git clone https://github.com/BlueBrain/spack.git
+    $ git clone -c feature.manyFiles=true https://github.com/BlueBrain/spack.git
     $ mkdir ~/.spack
     $ cp spack/sysconfig/ubuntu-18.04/*.yaml ~/.spack
     $ sed -e 's/#.*//g' spack/sysconfig/ubuntu-18.04/packages|xargs -r sudo apt-get install --assume-yes
@@ -37,7 +37,7 @@ used to set Spack up on the desktops:
 
 ### Ubuntu 20.04
 
-    $ git clone https://github.com/BlueBrain/spack.git
+    $ git clone -c feature.manyFiles=true https://github.com/BlueBrain/spack.git
     $ mkdir ~/.spack
     $ cp spack/sysconfig/ubuntu-20.04/*.yaml ~/.spack
     $ sed -e 's/#.*//g' spack/sysconfig/ubuntu-20.04/packages|xargs -r sudo apt-get install --assume-yes


### PR DESCRIPTION
Noticed recently that the official Spack documentation recommends this
option. The git documentation concurs. May not be available for obsolete
platforms.