### PR TITLE
Add py-atlannot version 0.1.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-atlannot/package.py
+++ b/var/spack/repos/builtin/packages/py-atlannot/package.py
@@ -10,7 +10,7 @@ from spack.directives import depends_on, version
 class PyAtlannot(PythonPackage):
     """Alignment of brain atlas annotations."""
 
-    homepage = "atlas-annotation.rtfd.io"
+    homepage = "https://atlas-annotation.rtfd.io"
     maintainers = ["EmilieDel", "Stannislav"]
 
     version(

--- a/var/spack/repos/builtin/packages/py-atlannot/package.py
+++ b/var/spack/repos/builtin/packages/py-atlannot/package.py
@@ -30,16 +30,16 @@ class PyAtlannot(PythonPackage):
     depends_on("py-setuptools-scm", type="build")
 
     # Installation requirements
-    depends_on("py-antspyx@0.2.4", type=("run"))
-    depends_on("py-atldld@0.2.2", type=("run"))
-    depends_on("py-matplotlib", type=("run"))
-    depends_on("py-numpy", type=("run"))
-    depends_on("py-pynrrd", type=("run"))
+    depends_on("py-antspyx@0.2.4", type=("build", "run"))
+    depends_on("py-atldld@0.2.2", type=("build", "run"))
+    depends_on("py-matplotlib", type=("build", "run"))
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-pynrrd", type=("build", "run"))
 
     # From the "interactive" extra
-    depends_on("py-ipython", type=("run"))
-    depends_on("py-ipywidgets", type=("run"))
-    depends_on("py-nibabel", type=("run"))
-    depends_on("py-scipy", type=("run"))
-    depends_on("py-toml", type=("run"))
-    depends_on("py-tqdm", type=("run"))
+    depends_on("py-ipython", type=("build", "run"))
+    depends_on("py-ipywidgets", type=("build", "run"))
+    depends_on("py-nibabel", type=("build", "run"))
+    depends_on("py-scipy", type=("build", "run"))
+    depends_on("py-toml", type=("build", "run"))
+    depends_on("py-tqdm", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-atlannot/package.py
+++ b/var/spack/repos/builtin/packages/py-atlannot/package.py
@@ -10,29 +10,36 @@ from spack.directives import depends_on, version
 class PyAtlannot(PythonPackage):
     """Alignment of brain atlas annotations."""
 
-    homepage = 'https://bbpgitlab.epfl.ch/project/proj101/atlas_annotation'
-    git = 'git@bbpgitlab.epfl.ch:project/proj101/atlas_annotation.git'
+    homepage = "atlas-annotation.rtfd.io"
+    maintainers = ["EmilieDel", "Stannislav"]
 
-    maintainers = ['EmilieDel', 'Stannislav']
+    version(
+        "0.1.2",
+        url="https://files.pythonhosted.org/packages/08/b9/6edff732ad711e600b91d32052604987b744f054c049739df73c07ef0232/atlannot-0.1.2.tar.gz",
+        sha256="145dac874752d5e5d093b977aa04798916daf31d1e942cc64d059175deea27df",
+    )
+    version(
+        "0.1.1",
+        tag="v0.1.1",
+        git="git@bbpgitlab.epfl.ch:project/proj101/atlas_annotation.git",
+    )
 
-    version('0.1.1', commit='5271681de15f23e1df6f8556405b03218541d241')
-
-    depends_on('python@3.7:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
-    depends_on('py-setuptools-scm', type='build')
+    # Setup requirements
+    depends_on("python@3.7:", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools-scm", type="build")
 
     # Installation requirements
-    depends_on('py-antspyx@0.2.4', type=('run'))
-    depends_on('py-atldld@0.2.2', type=('run'))
-    # depends_on('py-dvc', type=('run'))
-    depends_on('py-matplotlib', type=('run'))
-    depends_on('py-numpy', type=('run'))
+    depends_on("py-antspyx@0.2.4", type=("run"))
+    depends_on("py-atldld@0.2.2", type=("run"))
+    depends_on("py-matplotlib", type=("run"))
+    depends_on("py-numpy", type=("run"))
+    depends_on("py-pynrrd", type=("run"))
 
     # From the "interactive" extra
-    depends_on('py-ipython', type=('run'))
-    depends_on('py-ipywidgets', type=('run'))
-    depends_on('py-nibabel', type=('run'))
-    depends_on('py-pynrrd', type=('run'))
-    depends_on('py-scipy', type=('run'))
-    depends_on('py-toml', type=('run'))
-    depends_on('py-tqdm', type=('run'))
+    depends_on("py-ipython", type=("run"))
+    depends_on("py-ipywidgets", type=("run"))
+    depends_on("py-nibabel", type=("run"))
+    depends_on("py-scipy", type=("run"))
+    depends_on("py-toml", type=("run"))
+    depends_on("py-tqdm", type=("run"))


### PR DESCRIPTION
* The new version (`0.1.2`) is hosted on GitHub / PyPI (open-sourced recently)
* The old version (`0.1.1`) is still pointing to GitLab because there won't be a release for it on PyPI.