### PR TITLE
deployment: py-atlas-building-tools 0.1.6 and its dependency py-cgal-pyding 0.1.2 [BBPP82-630]

### DIFF
--- a/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
+++ b/var/spack/repos/builtin/packages/py-atlas-building-tools/package.py
@@ -11,6 +11,7 @@ class PyAtlasBuildingTools(PythonPackage):
     homepage = "https://bbpgitlab.epfl.ch/nse/atlas-building-tools"
     git      = "git@bbpgitlab.epfl.ch:nse/atlas-building-tools.git"
 
+    version('0.1.6', tag='atlas-building-tools-v0.1.7')
     version('0.1.6', tag='atlas-building-tools-v0.1.6')
     version('0.1.5', tag='atlas-building-tools-v0.1.5')
     version('0.1.4', tag='atlas-building-tools-v0.1.4')

--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -13,6 +13,7 @@ class PyCgalPybind(PythonPackage):
     git = "git@bbpgitlab.epfl.ch:nse/cgal-pybind.git"
 
     version("develop", submodules=True)
+    version("0.1.2", tag="cgal-pybind-v0.1.2", submodules=True)
     version("0.1.1", tag="cgal-pybind-v0.1.1", submodules=True)
     version("0.1.0", tag="cgal_pybind-v0.1.0", submodules=True)
 


### PR DESCRIPTION
This deployment makes the fix on negative density values available on BB5 (https://bbpteam.epfl.ch/project/issues/browse/NSETM-1665) as well a better documentation of `cgal-pybind`'s volume slicer which is used by `atlas-building-tools` to split layer 2/3 of the AIBS mouse isocortex into layer 2 and layer 3 (https://bbpteam.epfl.ch/project/issues/browse/NSETM-1658).