### PR TITLE
(deployment) py-cgal-pybind: Add version 0.1.3 [NSETM-1660]

### DIFF
--- a/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
+++ b/var/spack/repos/builtin/packages/py-cgal-pybind/package.py
@@ -13,6 +13,7 @@ class PyCgalPybind(PythonPackage):
     git = "git@bbpgitlab.epfl.ch:nse/cgal-pybind.git"
 
     version("develop", submodules=True)
+    version("0.1.3", tag="cgal-pybind-v0.1.3", submodules=True)
     version("0.1.2", tag="cgal-pybind-v0.1.2", submodules=True)
     version("0.1.1", tag="cgal-pybind-v0.1.1", submodules=True)
     version("0.1.0", tag="cgal_pybind-v0.1.0", submodules=True)


### PR DESCRIPTION
This release includes the addition of a layer thickness estimator, to be used by `nse/atlas-building-tools` for the computation of placement hints. 

It comprises also some updates of the files `tox.ini` and `README.md`.

The deployment of `py-cgal-pybind@0.1.3` on the BB5 cluster will fix the pipeline failure of the following merge request of `nse/atlas-building-tools`: https://bbpgitlab.epfl.ch/nse/atlas-building-tools/-/merge_requests/22 