### PR TITLE
Bumped version of Dask and related libraries

### DIFF
--- a/var/spack/repos/builtin/packages/py-dask-mpi/package.py
+++ b/var/spack/repos/builtin/packages/py-dask-mpi/package.py
@@ -14,6 +14,7 @@ class PyDaskMpi(PythonPackage):
 
     import_modules = ['dask_mpi']
 
+    version('2021.11.0', sha256='602d2e2d7816a4abc1eb17998e1acc93a43b6f82bf94a6accca169a42de21898')
     version('2.21.0', sha256='76e153fc8c58047d898970b33ede0ab1990bd4e69cc130c6627a96f11b12a1a7')
     version('2.0.0', sha256='774cd2d69e5f7154e1fa133c22498062edd31507ffa2ea19f4ab4d8975c27bc3')
 

--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -14,6 +14,7 @@ class PyDask(PythonPackage):
 
     maintainers = ['skosukhin']
 
+    version('2021.11.2', sha256='e12bfe272928d62fa99623d98d0e0b0c045b33a47509ef31a22175aa5fd10917')
     version('2021.6.2', sha256='8588fcd1a42224b7cfcd2ebc8ad616734abb6b1a4517efd52d89c7dd66eb91f8')
     version('2021.4.1', sha256='195e4eeb154222ea7a1c368119b5f321ee4ec9d78531471fe0145a527f744aa8')
     version('2020.12.0', sha256='43e745afd4b464e6c0113131e430a16dce6ac42460b06e24d799093d098f7ab0')

--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -17,6 +17,7 @@ class PyMpi4py(PythonPackage):
     git      = "https://github.com/mpi4py/mpi4py.git"
 
     version('develop', branch='master')
+    version('3.1.2', sha256='40dd546bece8f63e1131c3ceaa7c18f8e8e93191a762cd446a8cfcf7f9cce770')
     version('3.0.3', sha256='012d716c8b9ed1e513fcc4b18e5af16a8791f51e6d1716baccf988ad355c5a1f')
     version('3.0.1', sha256='6549a5b81931303baf6600fa2e3bc04d8bd1d5c82f3c21379d0d64a9abcca851')
     version('3.0.0', sha256='b457b02d85bdd9a4775a097fac5234a20397b43e073f14d9e29b6cd78c68efd7')


### PR DESCRIPTION
Simple commit to update the version of `py-dask-mpi` and related libraries and modules.