### PR TITLE
Added newer versions of bluepy and bluepysnap

### DIFF
--- a/var/spack/repos/builtin/packages/py-bluepy/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepy/package.py
@@ -13,6 +13,7 @@ class PyBluepy(PythonPackage):
     git      = "git@bbpgitlab.epfl.ch:nse/bluepy.git"
 
     version('develop')
+    version('2.4.3', tag='bluepy-v2.4.3')
     version('2.4.2', tag='bluepy-v2.4.2')
 
     depends_on('py-setuptools', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-bluepysnap/package.py
+++ b/var/spack/repos/builtin/packages/py-bluepysnap/package.py
@@ -14,6 +14,7 @@ class PyBluepysnap(PythonPackage):
     url      = "https://pypi.io/packages/source/b/bluepysnap/bluepysnap-0.12.0.tar.gz"
 
     version('develop')
+    version('0.13.0', sha256='7a59cf06db9c22b16b717ae1164f4108282c146b78fbf538197d838920121d16')
     version('0.12.0', sha256='a2cc24031905310941296ca975814ee0c0f27229a2c133d6a13ca92cc8dc6c9b')
 
     depends_on('python@3.6:', type=('build', 'run'))


### PR DESCRIPTION
Added 
- `bluepy v2.4.3`
- `bluepysnap v0.13.0`

I kept the previous versions for now.