### PR TITLE
Thalamus neocortex dep, fix resource

### DIFF
--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -37,5 +37,12 @@ class NeurodamusThalamus(NeurodamusModel):
         git="git@bbpgitlab.epfl.ch:hpc/sim/models/neocortex.git",
         tag="1.6",
         when="@1.6:",
-        destination="deps"
     )
+
+    def setup_common_mods(self, spec, prefix):
+        """Setup common mod files if provided through variant.
+        """
+        super().setup_common_mods(spec, prefix)
+        if spec.satisfies("@1.6:"):
+            force_symlink("../neocortex", "deps/neocortex")
+

--- a/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus-thalamus/package.py
@@ -45,4 +45,3 @@ class NeurodamusThalamus(NeurodamusModel):
         super().setup_common_mods(spec, prefix)
         if spec.satisfies("@1.6:"):
             force_symlink("../neocortex", "deps/neocortex")
-


### PR DESCRIPTION
Resources don't overwrite existing soft links in linux (they do in mac)
So we checkout to root and overwrite the link in case.