### PR TITLE
Add NVHPC/21.11 and CUDA/11.5.1

### DIFF
--- a/deploy/bin/configure-compilers
+++ b/deploy/bin/configure-compilers
@@ -21,7 +21,7 @@ fi
 # active (-E).  Prefer the hash passed through by earlier stages, if
 # not available fall back to the crude version.
 GCC_DIR=$(spack -E location --install-dir ${INTEL_GCC_HASH:-gcc@${INTEL_GCC_VERSION}})
-NVHPC_GCC_DIR=$(spack -E location --install-dir gcc@${DEFAULT_GCC_VERSION})
+NVHPC_GCC_DIR=$(spack -E location --install-dir gcc@${DEFAULT_GCC_VERSION}+binutils)
 # Use the Spack configuration to grab the matching module for GCC;
 # requires GCC to be compiler found beforehand.
 GCC_MODULES="$(spack -E config get compilers|sed -n "
@@ -98,6 +98,8 @@ while read -r line; do
         # standard library from the deployed version of GCC.
         NVHPC_DIR=$(dirname $(which makelocalrc))
         NVHPC_TMPDIR=$(mktemp -d -p .)
+        # Try and avoid autoloaded dependencies of other compilers (looking
+        # at you, LLVM) polluting the localrc of the NVIDIA compilers
         (
             module purge
             ${cmd}

--- a/deploy/bin/configure-compilers
+++ b/deploy/bin/configure-compilers
@@ -21,11 +21,12 @@ fi
 # active (-E).  Prefer the hash passed through by earlier stages, if
 # not available fall back to the crude version.
 GCC_DIR=$(spack -E location --install-dir ${INTEL_GCC_HASH:-gcc@${INTEL_GCC_VERSION}})
-NVHPC_GCC_DIR=$(spack -E location --install-dir gcc@${DEFAULT_GCC_VERSION}+binutils)
+NVHPC_GCC_DIR=$(spack -E location --install-dir ${DEFAULT_GCC_HASH:-gcc@${DEFAULT_GCC_VERSION}})
+log "...got NVHPC_GCC_DIR=${NVHPC_GCC_DIR}"
 # Use the Spack configuration to grab the matching module for GCC;
 # requires GCC to be compiler found beforehand.
 GCC_MODULES="$(spack -E config get compilers|sed -n "
-    /^\s*spec: gcc@${NVHPC_GCC_DIR}/,/^\s*modules:/ {
+    /^\s*spec: gcc@${DEFAULT_GCC_VERSION}/,/^\s*modules:/ {
         /^\s*modules:/ {
             s/^\s*modules: \[\(.*\)\]\$/\1/;
             p;

--- a/deploy/bin/configure-compilers
+++ b/deploy/bin/configure-compilers
@@ -21,17 +21,18 @@ fi
 # active (-E).  Prefer the hash passed through by earlier stages, if
 # not available fall back to the crude version.
 GCC_DIR=$(spack -E location --install-dir ${INTEL_GCC_HASH:-gcc@${INTEL_GCC_VERSION}})
+NVHPC_GCC_DIR=$(spack -E location --install-dir gcc@${DEFAULT_GCC_VERSION})
 # Use the Spack configuration to grab the matching module for GCC;
 # requires GCC to be compiler found beforehand.
 GCC_MODULES="$(spack -E config get compilers|sed -n "
-    /^\s*spec: gcc@${INTEL_GCC_VERSION}/,/^\s*modules:/ {
+    /^\s*spec: gcc@${NVHPC_GCC_DIR}/,/^\s*modules:/ {
         /^\s*modules:/ {
             s/^\s*modules: \[\(.*\)\]\$/\1/;
             p;
         }
     }")"
-log "...using gcc ${INTEL_GCC_VERSION} from ${GCC_DIR}"
-log "...using gcc ${INTEL_GCC_VERSION} with module(s) ${GCC_MODULES}"
+log "...using gcc ${INTEL_GCC_VERSION} from ${GCC_DIR} for Intel"
+log "...using gcc ${DEFAULT_GCC_VERSION} from ${NVHPC_GCC_DIR} for NVHPC with module(s) ${GCC_MODULES}"
 
 while read -r line; do
     sha="${line%% *}"  # Remove everything after and including the first space
@@ -97,7 +98,11 @@ while read -r line; do
         # standard library from the deployed version of GCC.
         NVHPC_DIR=$(dirname $(which makelocalrc))
         NVHPC_TMPDIR=$(mktemp -d -p .)
-        makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${GCC_DIR}/bin/gcc -gpp ${GCC_DIR}/bin/g++ -g77 ${GCC_DIR}/bin/gfortran -x
+        (
+            module purge
+            ${cmd}
+            makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${NVHPC_GCC_DIR}/bin/gcc -gpp ${NVHPC_GCC_DIR}/bin/g++ -g77 ${NVHPC_GCC_DIR}/bin/gfortran -x
+        )
         # olupton 2021-10-15: is this still needed? Not sure.
         echo "set PREOPTIONS=-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1;" >> "${NVHPC_TMPDIR}/localrc"
         log "NVIDIA localrc template"

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -339,7 +339,13 @@ configure_compilers() {
             # standard library from the deployed version of GCC.
             NVHPC_DIR=$(dirname $(which makelocalrc))
             NVHPC_TMPDIR=$(mktemp -d -p .)
-            makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${GCC_DIR}/bin/gcc -gpp ${GCC_DIR}/bin/g++ -g77 ${GCC_DIR}/bin/gfortran -x
+            # Try and avoid autoloaded dependencies of other compilers (looking
+            # at you, LLVM) polluting the localrc of the NVIDIA compilers
+            (
+              module purge
+              ${cmd}
+              makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${GCC_DIR}/bin/gcc -gpp ${GCC_DIR}/bin/g++ -g77 ${GCC_DIR}/bin/gfortran -x
+            )
             # olupton 2021-10-15: is this still needed? Not sure.
             echo "set PREOPTIONS=-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1;" >> "${NVHPC_TMPDIR}/localrc"
             log "NVIDIA localrc template"

--- a/deploy/deploy.lib
+++ b/deploy/deploy.lib
@@ -339,13 +339,7 @@ configure_compilers() {
             # standard library from the deployed version of GCC.
             NVHPC_DIR=$(dirname $(which makelocalrc))
             NVHPC_TMPDIR=$(mktemp -d -p .)
-            # Try and avoid autoloaded dependencies of other compilers (looking
-            # at you, LLVM) polluting the localrc of the NVIDIA compilers
-            (
-              module purge
-              ${cmd}
-              makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${GCC_DIR}/bin/gcc -gpp ${GCC_DIR}/bin/g++ -g77 ${GCC_DIR}/bin/gfortran -x
-            )
+            makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${GCC_DIR}/bin/gcc -gpp ${GCC_DIR}/bin/g++ -g77 ${GCC_DIR}/bin/gfortran -x
             # olupton 2021-10-15: is this still needed? Not sure.
             echo "set PREOPTIONS=-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1;" >> "${NVHPC_TMPDIR}/localrc"
             log "NVIDIA localrc template"

--- a/deploy/environments/externals.yaml
+++ b/deploy/environments/externals.yaml
@@ -63,6 +63,7 @@ spack:
     - llvm@11.1.0
     - nvhpc@21.2 install_type=network
     - nvhpc@21.9
+    - nvhpc@21.11
     - arm-forge
     - bison
     - blender
@@ -74,6 +75,7 @@ spack:
     - cmake
     - cuda@11.0.2
     - cuda@11.4.2
+    - cuda@11.5.1
     - cudnn@8.0.3.33-11.0
     - darshan-runtime
     - darshan-util

--- a/deploy/gitlab-ci.yml
+++ b/deploy/gitlab-ci.yml
@@ -216,7 +216,9 @@ setup_spack:
     - if [[ "${CI_JOB_STAGE}" == "compilers" ]]; then
     # This will be needed by future compiler finds: extract the one base
     # gcc used in the compiler stage.
+    -     export DEFAULT_GCC_HASH="/$(spack find --format '{hash:7}' gcc@$DEFAULT_GCC_VERSION)"
     -     export INTEL_GCC_HASH="/$(spack find --format '{hash:7}' gcc@$INTEL_GCC_VERSION)"
+    -     echo "DEFAULT_GCC_HASH=$DEFAULT_GCC_HASH" >> deployment.env
     -     echo "INTEL_GCC_HASH=$INTEL_GCC_HASH" >> deployment.env
     # Make compilers here available to following stages
     -     configure-compilers < specs.txt

--- a/deploy/set-compiler-flags.py
+++ b/deploy/set-compiler-flags.py
@@ -1,0 +1,33 @@
+import argparse
+import spack
+from spack.config import config
+
+parser = argparse.ArgumentParser(
+    description="Add C/C++ compiler flags to Spack configuration."
+)
+parser.add_argument(
+    "--scope", default="user", help="Configuration scope to read/write."
+)
+parser.add_argument("--compiler-spec", type=str, help="Compiler spec to modify.")
+parser.add_argument(
+    "--fields",
+    type=str,
+    nargs="+",
+    help="Which type of flags to write.",
+    default=["cflags", "cxxflags"],
+    choices=["cflags", "cxxflags", "cppflags", "fflags", "ldflags", "ldlibs"],
+)
+parser.add_argument(
+    "flags", type=str, nargs="+", help="Compiler flags to set in the configuration."
+)
+args = parser.parse_args()
+flags_str = " ".join(args.flags)
+compiler_configs = config.get("compilers", scope=args.scope)
+for compiler_config in compiler_configs:
+    compiler_spec = spack.spec.Spec(compiler_config["compiler"]["spec"])
+    if compiler_spec.satisfies(args.compiler_spec):
+        compiler_flags = compiler_config["compiler"].get("flags", {})
+        for field in args.fields:
+            compiler_flags[field] = flags_str
+        compiler_config["compiler"]["flags"] = compiler_flags
+config.update_config("compilers", compiler_configs, scope=args.scope)

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -25,6 +25,10 @@ from spack import *
 #    format returned by platform.system() and 'arch' by platform.machine()
 
 _versions = {
+    '11.5.1': {
+        'Linux-aarch64': ('73e1d0e97c7fa686efe7e00fb1e5f179372c4eec8e14d4f44ab58d5f6cf57f63', 'https://developer.download.nvidia.com/compute/cuda/11.5.1/local_installers/cuda_11.5.1_495.29.05_linux_sbsa.run'),
+        'Linux-x86_64': ('60bea2fc0fac95574015f865355afbf599422ec2c85554f5f052b292711a4bca', 'https://developer.download.nvidia.com/compute/cuda/11.5.1/local_installers/cuda_11.5.1_495.29.05_linux.run'),
+        'Linux-ppc64le': ('9e0e494d945634fe8ad3e12d7b91806aa4220ed27487bb211030d651b27c67a9', 'https://developer.download.nvidia.com/compute/cuda/11.5.1/local_installers/cuda_11.5.1_495.29.05_linux_ppc64le.run')},
     '11.5.0': {
         'Linux-aarch64': ('6ea9d520cc956cc751a5ac54f4acc39109627f4e614dd0b1a82cc86f2aa7d8c4', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_sbsa.run'),
         'Linux-x86_64': ('ae0a1693d9497cf3d81e6948943e3794636900db71c98d58eefdacaf7f1a1e4c', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run'),

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -22,6 +22,10 @@ from spack.util.prefix import Prefix
 #  - package key must be in the form '{os}-{arch}' where 'os' is in the
 #    format returned by platform.system() and 'arch' by platform.machine()
 _versions = {
+    '21.11': {
+        'Linux-aarch64': ('3b11bcd9cca862fabfce1e7bcaa2050ea12130c7e897f4e7859ba4c155d20720', 'https://developer.download.nvidia.com/hpc-sdk/21.11/nvhpc_2021_2111_Linux_aarch64_cuda_multi.tar.gz'),
+        'Linux-ppc64le': ('ac51ed92de4eb5e1bdb064ada5bbace5b89ac732ad6c6473778edfb8d29a6527', 'https://developer.download.nvidia.com/hpc-sdk/21.11/nvhpc_2021_2111_Linux_ppc64le_cuda_multi.tar.gz'),
+        'Linux-x86_64': ('d8d8ccd0e558d22bcddd955f2233219c96f7de56aa8e09e7be833e384d32d6aa', 'https://developer.download.nvidia.com/hpc-sdk/21.11/nvhpc_2021_2111_Linux_x86_64_cuda_multi.tar.gz')},
     '21.9': {
         'Linux-aarch64': ('52c2c66e30043add4afccedf0ba77daa0000bf42e0db844baa630bb635b91a7d', 'https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_aarch64_cuda_multi.tar.gz'),
         'Linux-ppc64le': ('cff0b55fb782be1982bfeec1d9763b674ddbf84ff2c16b364495299266320289', 'https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_ppc64le_cuda_multi.tar.gz'),


### PR DESCRIPTION
Cherry pick of #1392 targeting `merge-upstream` branch.

* Add + deploy NVIDIA HPC SDK 21.11.
* Add + deploy CUDA 11.5.1 to match it.
* Do not define CMAKE_C_FLAGS in `coreneuron+nmodl`.
* Run `makelocalrc` for `nvhpc` in a cleaner environment.
* Add `-mno-abm` to [Core]NEURON recipes for `nvhpc@21.11`.

[skip jenkins]