### PR TITLE
Bumps py-libsonata with v0.10.0 and removes temp. tags

### DIFF
--- a/var/spack/repos/builtin/packages/libsonata/package.py
+++ b/var/spack/repos/builtin/packages/libsonata/package.py
@@ -18,11 +18,7 @@ class Libsonata(CMakePackage):
 
     version('develop', branch='master', submodules=False, get_full_repo=True)
     version('0.1.10', submodules=False, get_full_repo=True)
-    # Important: v0.1.9 contains an external dependency that cannot be easily
-    # resolved by Spack. Hence, the temp. versions v0.1.9.YYYYMMDD add fixes,
-    # which will be included in future official releases (v0.1.10 and above).
-    version('0.1.9.20210901', commit='653d104', submodules=False, get_full_repo=True)
-    version('0.1.9.20210721', commit='59b298e', submodules=False, get_full_repo=True)
+    # Important: v0.1.9 is not Spack-compatible (use v0.1.10 instead)
     # version('0.1.9', tag='v0.1.9', submodules=False, get_full_repo=True)
     version('0.1.8', tag='v0.1.8', submodules=False, get_full_repo=True)
     version('0.1.6', tag='v0.1.6', submodules=False, get_full_repo=True)

--- a/var/spack/repos/builtin/packages/py-libsonata/package.py
+++ b/var/spack/repos/builtin/packages/py-libsonata/package.py
@@ -13,11 +13,8 @@ class PyLibsonata(PythonPackage):
     git = "https://github.com/BlueBrain/libsonata.git"
 
     version('develop', branch='master', submodules=True, get_full_repo=True)
-    # Important: v0.1.9 contains an external dependency that cannot be easily
-    # resolved by Spack. Hence, the temp. versions v0.1.9.YYYYMMDD add fixes,
-    # which will be included in future official releases (v0.1.10 and above).
-    version('0.1.9.20210901', commit='653d104', submodules=True, get_full_repo=True)
-    version('0.1.9.20210721', commit='59b298e', submodules=True, get_full_repo=True)
+    version('0.1.10', submodules=True, get_full_repo=True)
+    # Important: v0.1.9 is not Spack-compatible (use v0.1.10 instead)
     # version('0.1.9', tag='v0.1.9', submodules=True, get_full_repo=True)
     version('0.1.8', tag='v0.1.8', submodules=True, get_full_repo=True)
     version('0.1.6', tag='v0.1.6', submodules=True, get_full_repo=True)


### PR DESCRIPTION
This PR adds the missing `v0.10.0` version to the `py-libsonata` recipe and deletes the unnecessary `v0.1.9.YYYYMMDD` temp. tags that were created during the development of the new release.