### PR TITLE
Allow neuron model_tests=tqperf-heavy.

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -83,7 +83,7 @@ class Neuron(CMakePackage):
     variant("rx3d",       default=True,  description="Enable cython translated 3-d rxd. Depends on pysetup")
     variant("shared",     default=True,  description="Build shared libraries")
     variant("tests",      default=False, description="Enable unit tests")
-    variant("model_tests", default="None", description="Enable detailed model tests included in neuron", multi=True, values=("None", "olfactory", "channel-benchmark"))
+    variant("model_tests", default="None", description="Enable detailed model tests included in neuron", multi=True, values=("None", "olfactory", "channel-benchmark", "tqperf-heavy"))
     variant("legacy-unit", default=True,   description="Enable legacy units")
 
     variant("codechecks", default=False,


### PR DESCRIPTION
https://github.com/neuronsimulator/nrn/pull/1573 makes the tqperf test lightweight-by-default.

This lets us re-enable the heavy version when we are running CI on BB5.

Not targeting `merge-upstream` because GitLab CI plans are still using the 2021 deployment.