### PR TITLE
Deploy NVHPC 22.1

### DIFF
--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -64,6 +64,7 @@ spack:
     - nvhpc@21.2 install_type=network
     - nvhpc@21.9
     - nvhpc@21.11
+    - nvhpc@22.1
     - arm-forge
     - bison
     - blender

--- a/bluebrain/repo-bluebrain/packages/coreneuron/package.py
+++ b/bluebrain/repo-bluebrain/packages/coreneuron/package.py
@@ -133,10 +133,11 @@ class Coreneuron(CMakePackage):
             flags = '-xHost -qopt-report=5'
             if '+knl' in spec:
                 flags = '-xMIC-AVX512 -qopt-report=5'
-        # NVHPC 21.11 detects ABM support and defines __ABM__, which breaks
-        # Random123 compilation
-        if spec.satisfies('%nvhpc@21.11'):
-            flags += ' -mno-abm'
+        # NVHPC 21.11 and newer detect ABM support and define __ABM__, which
+        # breaks Random123 compilation. CoreNEURON inserts a workaround for
+        # this in https://github.com/BlueBrain/CoreNeuron/pull/754.
+        if self.spec.satisfies('@:1.0.0.20220111%nvhpc@21.11:'):
+            flags += ' -DR123_USE_INTRIN_H=0'
         # when pdt is used for instrumentation, the gcc's unint128 extension
         # is activated from random123 which results in compilation error
         if '+profile' in spec:

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -171,10 +171,11 @@ class Neuron(CMakePackage):
             args.append('-DNRN_DYNAMIC_UNITS_USE_LEGACY=ON')
         if "+coreneuron" in self.spec:
             args.append('-DCORENEURON_DIR=' + self.spec["coreneuron"].prefix)
-        # NVHPC 21.11 detects ABM support and defines __ABM__, which breaks
-        # Random123 compilation
-        if self.spec.satisfies('%nvhpc@21.11'):
-            compilation_flags.append('-mno-abm')
+        # NVHPC 21.11 and newer detect ABM support and define __ABM__, which
+        # breaks Random123 compilation. NEURON inserts a workaround for this in
+        # https://github.com/neuronsimulator/nrn/pull/1587.
+        if self.spec.satisfies('@:8.0.0%nvhpc@21.11:'):
+            compilation_flags.append('-DR123_USE_INTRIN_H=0')
         compilation_flags = ' '.join(compilation_flags)
         args.append("-DCMAKE_C_FLAGS=" + compilation_flags)
         args.append("-DCMAKE_CXX_FLAGS=" + compilation_flags)

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -22,6 +22,10 @@ from spack.util.prefix import Prefix
 #  - package key must be in the form '{os}-{arch}' where 'os' is in the
 #    format returned by platform.system() and 'arch' by platform.machine()
 _versions = {
+    '22.1': {
+        'Linux-aarch64': ('05cfa8c520a34eab01272a261b157d421a9ff7129fca7d859b944ce6a16d2255', 'https://developer.download.nvidia.com/hpc-sdk/22.1/nvhpc_2022_221_Linux_aarch64_cuda_multi.tar.gz'),
+        'Linux-ppc64le': ('9fa9b64fba2c9b287b5800693417d8065c695d18cab0526bad41d9aecc8be2b3', 'https://developer.download.nvidia.com/hpc-sdk/22.1/nvhpc_2022_221_Linux_ppc64le_cuda_multi.tar.gz'),
+        'Linux-x86_64': ('7e4366509ed9031ff271e73327dd3121909902a81ac436307801a5373efaff5e', 'https://developer.download.nvidia.com/hpc-sdk/22.1/nvhpc_2022_221_Linux_x86_64_cuda_multi.tar.gz')},
     '21.11': {
         'Linux-aarch64': ('3b11bcd9cca862fabfce1e7bcaa2050ea12130c7e897f4e7859ba4c155d20720', 'https://developer.download.nvidia.com/hpc-sdk/21.11/nvhpc_2021_2111_Linux_aarch64_cuda_multi.tar.gz'),
         'Linux-ppc64le': ('ac51ed92de4eb5e1bdb064ada5bbace5b89ac732ad6c6473778edfb8d29a6527', 'https://developer.download.nvidia.com/hpc-sdk/21.11/nvhpc_2021_2111_Linux_ppc64le_cuda_multi.tar.gz'),


### PR DESCRIPTION
ABM-related workaround for 21.11 is needed for 22.1 too, but is no longer needed for `develop` versions.
