### PR TITLE
Add Intel/NVHPC builds of [core]neuron.

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -31,6 +31,10 @@ spack:
         +plasticity: '{name}-plasticity/{version}'
   specs:
     - asciitoh5@1.0
+    - coreneuron%intel+tests
+    - coreneuron%intel+tests+nmodl+sympy
+    - coreneuron%nvhpc+tests+gpu+openmp
+    - coreneuron%nvhpc+tests+gpu+openmp+nmodl+sympy
     - model-neocortex%intel
     - nest@2.20.1
     - neurodamus-core~common%intel
@@ -43,6 +47,9 @@ spack:
     - neurodamus-neocortex+coreneuron+plasticity%intel^coreneuron+caliper
     - neurodamus-thalamus+coreneuron%intel^coreneuron+caliper
     - neurodamus-thalamus+coreneuron%intel^coreneuron+caliper+knl
+    - neuron%intel+coreneuron+tests
+    - neuron%nvhpc+coreneuron+tests ^coreneuron+gpu
+    - nmodl
     - parquet-converters
     - py-basalt@0.2.9
     - py-neurodamus+all_deps

--- a/bluebrain/repo-bluebrain/packages/coreneuron/package.py
+++ b/bluebrain/repo-bluebrain/packages/coreneuron/package.py
@@ -21,6 +21,7 @@ class Coreneuron(CMakePackage):
 
     version('develop', branch='master')
     # 1.0.1 > 1.0.0.20210519 > 1.0 as far as Spack is concerned
+    version('1.0.0.20220111', commit='64e56b7')
     version('1.0.0.20211020', commit='e265f9d')
     version('1.0.0.20211012', commit='846b3a6')
     version('1.0.0.20210708', commit='d54a3aa')

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -13,9 +13,11 @@ class Nmodl(CMakePackage):
     url      = "https://github.com/BlueBrain/nmodl.git"
     git      = "https://github.com/BlueBrain/nmodl.git"
 
+    # 0.3.1 > 0.3.0.20220110 > 0.3.0 > 0.3b > 0.3 to Spack
     version('develop', branch='master', submodules=True)
-    # 0.3.0 > 0.3b > 0.3 as far as Spack is concerned
-    version('0.3.0', tag='0.3', preferred=True)
+    # For deployment; nmodl@0.3.0%nvhpc@21.11 does not build with eigen/intrinsics errors
+    version('0.3.0.20220110', commit='9e0a6f260ac2e6fad068a39ea3bdf7aa7a6f4ee0')
+    version('0.3.0', tag='0.3')
     version('0.3b', commit="c30ea06", submodules=True)
     version('0.3a', commit="86fc52d", submodules=True)
     version('0.2', tag='0.2', submodules=True)
@@ -27,8 +29,9 @@ class Nmodl(CMakePackage):
     generator = 'Ninja'
     depends_on('ninja', type='build')
 
-    depends_on('bison@3.0:3.4.99', when='@:0.3', type='build')
-    depends_on('bison@3.0.5:', when='@0.3.1:', type='build')
+    # 0.3b includes #270 and #318 so should work with bison 3.6+
+    depends_on('bison@3.0:3.4.99', when='@:0.3a', type='build')
+    depends_on('bison@3.0.5:', when='@0.3b:', type='build')
     depends_on('cmake@3.3.0:', type='build')
     depends_on('flex@2.6:', type='build')
     depends_on('python@3.6.0:')

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -15,7 +15,7 @@ class Nmodl(CMakePackage):
 
     # 0.3.1 > 0.3.0.20220110 > 0.3.0 > 0.3b > 0.3 to Spack
     version('develop', branch='master', submodules=True)
-    # For deployment; nmodl@0.3.0%nvhpc@21.11 does not build with eigen/intrinsics errors
+    # For deployment; nmodl@0.3.0%nvhpc@21.11 doesn't build with eigen/intrinsics errors
     version('0.3.0.20220110', commit='9e0a6f260ac2e6fad068a39ea3bdf7aa7a6f4ee0')
     version('0.3.0', tag='0.3')
     version('0.3b', commit="c30ea06", submodules=True)

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,6 +31,8 @@ class Neuron(CMakePackage):
     # Patch which reverts d9605cb for not hanging on ExperimentalMechComplex
     patch("apply_79a4d2af_load_balance_fix.patch", when="@7.8.0b")
     patch("fix_brew_py_18e97a2d.patch", when="@7.8.0c")
+    # Patch for recent CMake versions that don't identify NVHPC as PGI
+    patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
     version("8.0.0", tag="8.0.0", preferred=True)

--- a/bluebrain/repo-patches/packages/neuron/patch-v800-cmake-nvhpc.patch
+++ b/bluebrain/repo-patches/packages/neuron/patch-v800-cmake-nvhpc.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/CompilerHelper.cmake b/cmake/CompilerHelper.cmake
+index e80e93d..19e69d7 100644
+--- a/cmake/CompilerHelper.cmake
++++ b/cmake/CompilerHelper.cmake
+@@ -9,7 +9,7 @@ else()
+   set(UNDEFINED_SYMBOLS_IGNORE_FLAG "--unresolved-symbols=ignore-all")
+ endif()
+ 
+-if(CMAKE_C_COMPILER_ID MATCHES "PGI")
++if(CMAKE_C_COMPILER_ID MATCHES "PGI" OR CMAKE_C_COMPILER_ID MATCHES "NVHPC")
+   set(USING_PGI_COMPILER_TRUE "")
+   set(USING_PGI_COMPILER_FALSE "#")
+ else()

--- a/bluebrain/repo-patches/packages/py-cython/package.py
+++ b/bluebrain/repo-patches/packages/py-cython/package.py
@@ -1,0 +1,12 @@
+from spack import *
+from spack.pkg.builtin.py_cython import PyCython as BuiltinPyCython
+
+
+class PyCython(BuiltinPyCython):
+    def setup_build_environment(self, env):
+        # Otherwise we get errors related to python being %gcc:
+        # nvc-Error-Unknown switch: -Wno-unused-result
+        # nvc-Error-Unknown switch: -fwrapv
+        if self.spec.satisfies('%nvhpc'):
+            for var in ['CPPFLAGS', 'CFLAGS', 'CXXFLAGS']:
+                env.append_flags(var, '-noswitcherror')

--- a/bluebrain/repo-patches/packages/py-cython/package.py
+++ b/bluebrain/repo-patches/packages/py-cython/package.py
@@ -3,6 +3,8 @@ from spack.pkg.builtin.py_cython import PyCython as BuiltinPyCython
 
 
 class PyCython(BuiltinPyCython):
+    __doc__ = BuiltinPyCython.__doc__
+
     def setup_build_environment(self, env):
         # Otherwise we get errors related to python being %gcc:
         # nvc-Error-Unknown switch: -Wno-unused-result

--- a/bluebrain/repo-patches/packages/py-cython/package.py
+++ b/bluebrain/repo-patches/packages/py-cython/package.py
@@ -1,4 +1,3 @@
-from spack import *
 from spack.pkg.builtin.py_cython import PyCython as BuiltinPyCython
 
 

--- a/bluebrain/repo-patches/packages/py-numpy/package.py
+++ b/bluebrain/repo-patches/packages/py-numpy/package.py
@@ -3,6 +3,8 @@ from spack.pkg.builtin.py_numpy import PyNumpy as BuiltinPyNumpy
 
 
 class PyNumpy(BuiltinPyNumpy):
+    __doc__ = BuiltinPyNumpy.__doc__
+
     def setup_build_environment(self, env):
         # Otherwise we get errors related to python being %gcc:
         # nvc-Error-Unknown switch: -Wno-unused-result

--- a/bluebrain/repo-patches/packages/py-numpy/package.py
+++ b/bluebrain/repo-patches/packages/py-numpy/package.py
@@ -1,0 +1,12 @@
+from spack import *
+from spack.pkg.builtin.py_numpy import PyNumpy as BuiltinPyNumpy
+
+
+class PyNumpy(BuiltinPyNumpy):
+    def setup_build_environment(self, env):
+        # Otherwise we get errors related to python being %gcc:
+        # nvc-Error-Unknown switch: -Wno-unused-result
+        # nvc-Error-Unknown switch: -fwrapv
+        if self.spec.satisfies('%nvhpc'):
+            for var in ['CPPFLAGS', 'CFLAGS', 'CXXFLAGS']:
+                env.append_flags(var, '-noswitcherror')

--- a/bluebrain/repo-patches/packages/py-numpy/package.py
+++ b/bluebrain/repo-patches/packages/py-numpy/package.py
@@ -1,3 +1,4 @@
+from spack.directives import conflicts
 from spack.pkg.builtin.py_numpy import PyNumpy as BuiltinPyNumpy
 
 

--- a/bluebrain/repo-patches/packages/py-numpy/package.py
+++ b/bluebrain/repo-patches/packages/py-numpy/package.py
@@ -3,6 +3,10 @@ from spack.pkg.builtin.py_numpy import PyNumpy as BuiltinPyNumpy
 
 class PyNumpy(BuiltinPyNumpy):
     __doc__ = BuiltinPyNumpy.__doc__
+    # With the CPPFLAGS/CFLAGS/CXXFLAGS fix below then there does not appear
+    # to be any compiler error message with NVHPC, but at least with 21.11
+    # then an llc process gets stuck and eventually killed when compiling
+    # loops.c
     conflicts('%nvhpc')
 
     def setup_build_environment(self, env):

--- a/bluebrain/repo-patches/packages/py-numpy/package.py
+++ b/bluebrain/repo-patches/packages/py-numpy/package.py
@@ -3,6 +3,7 @@ from spack.pkg.builtin.py_numpy import PyNumpy as BuiltinPyNumpy
 
 class PyNumpy(BuiltinPyNumpy):
     __doc__ = BuiltinPyNumpy.__doc__
+    conflicts('%nvhpc')
 
     def setup_build_environment(self, env):
         # Otherwise we get errors related to python being %gcc:

--- a/bluebrain/repo-patches/packages/py-numpy/package.py
+++ b/bluebrain/repo-patches/packages/py-numpy/package.py
@@ -1,4 +1,3 @@
-from spack import *
 from spack.pkg.builtin.py_numpy import PyNumpy as BuiltinPyNumpy
 
 

--- a/bluebrain/repo-patches/packages/py-pyyaml/package.py
+++ b/bluebrain/repo-patches/packages/py-pyyaml/package.py
@@ -1,0 +1,12 @@
+from spack import *
+from spack.pkg.builtin.py_pyyaml import PyPyyaml as BuiltinPyPyyaml
+
+
+class PyPyyaml(BuiltinPyPyyaml):
+    def setup_build_environment(self, env):
+        # Otherwise we get errors related to python being %gcc:
+        # nvc-Error-Unknown switch: -Wno-unused-result
+        # nvc-Error-Unknown switch: -fwrapv
+        if self.spec.satisfies('%nvhpc'):
+            for var in ['CPPFLAGS', 'CFLAGS', 'CXXFLAGS']:
+                env.append_flags(var, '-noswitcherror')

--- a/bluebrain/repo-patches/packages/py-pyyaml/package.py
+++ b/bluebrain/repo-patches/packages/py-pyyaml/package.py
@@ -1,4 +1,3 @@
-from spack import *
 from spack.pkg.builtin.py_pyyaml import PyPyyaml as BuiltinPyPyyaml
 
 

--- a/bluebrain/repo-patches/packages/py-pyyaml/package.py
+++ b/bluebrain/repo-patches/packages/py-pyyaml/package.py
@@ -3,6 +3,8 @@ from spack.pkg.builtin.py_pyyaml import PyPyyaml as BuiltinPyPyyaml
 
 
 class PyPyyaml(BuiltinPyPyyaml):
+    __doc__ = BuiltinPyPyyaml.__doc__
+
     def setup_build_environment(self, env):
         # Otherwise we get errors related to python being %gcc:
         # nvc-Error-Unknown switch: -Wno-unused-result


### PR DESCRIPTION
CoreNEURON GitLab CI currently rebuilds a lot of dependencies when run against the 2022 deployment.

This adds some CoreNEURON, NEURON and NMODL builds to the deployment that are similar to the builds in the CI, which should mean most dependencies are already available.