### PR TITLE
PythonPackage conflicts with %{intel,nvhpc,oneapi}.

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -31,18 +31,25 @@ spack:
         +plasticity: '{name}-plasticity/{version}'
   specs:
     - asciitoh5@1.0
-    - model-neocortex%intel
+    - coreneuron%intel+tests
+    - coreneuron%intel+tests+nmodl+sympy
+    - coreneuron%nvhpc+tests+gpu+openmp
+    - coreneuron%nvhpc+tests+gpu+openmp+nmodl+sympy
+    - model-neocortex%intel ^neuron%intel
     - nest@2.20.1
-    - neurodamus-core~common%intel
+    - neurodamus-core~common%intel ^neuron%intel
     - neurodamus-core+common
-    - neurodamus-hippocampus+coreneuron%intel^coreneuron+caliper
-    - neurodamus-hippocampus+coreneuron%intel^coreneuron+caliper+knl
-    - neurodamus-mousify+coreneuron%intel^coreneuron+caliper
-    - neurodamus-neocortex+coreneuron%intel^coreneuron+caliper
-    - neurodamus-neocortex+coreneuron%intel^coreneuron+caliper+knl
-    - neurodamus-neocortex+coreneuron+plasticity%intel^coreneuron+caliper
-    - neurodamus-thalamus+coreneuron%intel^coreneuron+caliper
-    - neurodamus-thalamus+coreneuron%intel^coreneuron+caliper+knl
+    - neurodamus-hippocampus+coreneuron%intel ^coreneuron%intel+caliper ^neuron%intel
+    - neurodamus-hippocampus+coreneuron%intel ^coreneuron%intel+caliper+knl ^neuron%intel
+    - neurodamus-mousify+coreneuron%intel^coreneuron%intel+caliper ^neuron%intel
+    - neurodamus-neocortex+coreneuron%intel^coreneuron%intel+caliper ^neuron%intel
+    - neurodamus-neocortex+coreneuron%intel^coreneuron%intel+caliper+knl ^neuron%intel
+    - neurodamus-neocortex+coreneuron+plasticity%intel^coreneuron%intel+caliper ^neuron%intel
+    - neurodamus-thalamus+coreneuron%intel^coreneuron%intel+caliper ^neuron%intel
+    - neurodamus-thalamus+coreneuron%intel^coreneuron%intel+caliper+knl ^neuron%intel
+    - neuron%intel+coreneuron+tests ^coreneuron%intel
+    - neuron%nvhpc+coreneuron+tests ^coreneuron+gpu%nvhpc
+    - nmodl
     - parquet-converters
     - py-basalt@0.2.9
     - py-neurodamus+all_deps

--- a/bluebrain/repo-bluebrain/packages/coreneuron/package.py
+++ b/bluebrain/repo-bluebrain/packages/coreneuron/package.py
@@ -21,6 +21,7 @@ class Coreneuron(CMakePackage):
 
     version('develop', branch='master')
     # 1.0.1 > 1.0.0.20210519 > 1.0 as far as Spack is concerned
+    version('1.0.0.20220111', commit='64e56b7')
     version('1.0.0.20211020', commit='e265f9d')
     version('1.0.0.20211012', commit='846b3a6')
     version('1.0.0.20210708', commit='d54a3aa')

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -13,9 +13,11 @@ class Nmodl(CMakePackage):
     url      = "https://github.com/BlueBrain/nmodl.git"
     git      = "https://github.com/BlueBrain/nmodl.git"
 
+    # 0.3.1 > 0.3.0.20220110 > 0.3.0 > 0.3b > 0.3 to Spack
     version('develop', branch='master', submodules=True)
-    # 0.3.0 > 0.3b > 0.3 as far as Spack is concerned
-    version('0.3.0', tag='0.3', preferred=True)
+    # For deployment; nmodl@0.3.0%nvhpc@21.11 does not build with eigen/intrinsics errors
+    version('0.3.0.20220110', commit='9e0a6f260ac2e6fad068a39ea3bdf7aa7a6f4ee0')
+    version('0.3.0', tag='0.3')
     version('0.3b', commit="c30ea06", submodules=True)
     version('0.3a', commit="86fc52d", submodules=True)
     version('0.2', tag='0.2', submodules=True)
@@ -27,8 +29,9 @@ class Nmodl(CMakePackage):
     generator = 'Ninja'
     depends_on('ninja', type='build')
 
-    depends_on('bison@3.0:3.4.99', when='@:0.3', type='build')
-    depends_on('bison@3.0.5:', when='@0.3.1:', type='build')
+    # 0.3b includes #270 and #318 so should work with bison 3.6+
+    depends_on('bison@3.0:3.4.99', when='@:0.3a', type='build')
+    depends_on('bison@3.0.5:', when='@0.3b:', type='build')
     depends_on('cmake@3.3.0:', type='build')
     depends_on('flex@2.6:', type='build')
     depends_on('python@3.6.0:')

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,6 +31,8 @@ class Neuron(CMakePackage):
     # Patch which reverts d9605cb for not hanging on ExperimentalMechComplex
     patch("apply_79a4d2af_load_balance_fix.patch", when="@7.8.0b")
     patch("fix_brew_py_18e97a2d.patch", when="@7.8.0c")
+    # Patch for recent CMake versions that don't identify NVHPC as PGI
+    patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
     version("8.0.0", tag="8.0.0", preferred=True)

--- a/bluebrain/repo-patches/packages/neuron/patch-v800-cmake-nvhpc.patch
+++ b/bluebrain/repo-patches/packages/neuron/patch-v800-cmake-nvhpc.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/CompilerHelper.cmake b/cmake/CompilerHelper.cmake
+index e80e93d..19e69d7 100644
+--- a/cmake/CompilerHelper.cmake
++++ b/cmake/CompilerHelper.cmake
+@@ -9,7 +9,7 @@ else()
+   set(UNDEFINED_SYMBOLS_IGNORE_FLAG "--unresolved-symbols=ignore-all")
+ endif()
+ 
+-if(CMAKE_C_COMPILER_ID MATCHES "PGI")
++if(CMAKE_C_COMPILER_ID MATCHES "PGI" OR CMAKE_C_COMPILER_ID MATCHES "NVHPC")
+   set(USING_PGI_COMPILER_TRUE "")
+   set(USING_PGI_COMPILER_FALSE "#")
+ else()

--- a/bluebrain/repo-patches/packages/python/package.py
+++ b/bluebrain/repo-patches/packages/python/package.py
@@ -3,6 +3,10 @@ from spack.pkg.builtin.python import Python as BuiltinPython
 
 
 class Python(BuiltinPython):
+    # See PythonPackage
+    conflicts('%intel')
+    conflicts('%nvhpc')
+    conflicts('%oneapi')
     def setup_dependent_build_environment(self, env, dependent_spec):
         super().setup_dependent_build_environment(env, dependent_spec)
         if self.spec.satisfies('%intel'):

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -17,7 +17,7 @@ from llnl.util.filesystem import (
 )
 from llnl.util.lang import match_predicate
 
-from spack.directives import extends
+from spack.directives import conflicts, extends
 from spack.package import PackageBase, run_after
 
 
@@ -85,6 +85,15 @@ class PythonPackage(PackageBase):
     install_time_test_callbacks = ['test']
 
     extends('python')
+
+    # Python assumes that build flags used to build it (GCC, on BB5) can also
+    # be used with the compiler that is used to build Python extensions, which
+    # may be different.
+    conflicts('%nvhpc')
+
+    # Gamble that this isn't a bad idea in the long run.
+    conflicts('%intel')
+    conflicts('%oneapi')
 
     py_namespace = None
 


### PR DESCRIPTION
Loosely this means that if you build `package%intel` that depends on `py-something` then `py-something` will be built with `gcc` (the default compiler), not `intel`.

**However**, this can also cause non-Python dependencies to be built with `gcc` as well due to Spack's cost model for compiler mismatches. This means that, for example, `neuron%intel+coreneuron` does not guarantee `coreneuron` will be built with `intel` and it becomes necessary to specify `neuron%intel+coreneuron ^coreneuron%intel`.

This also adds various builds that are aligned with the builds in CoreNEURON's CI to reduce the amount of dependency rebuilding that happens there.