### PR TITLE
Neurodamus unified models

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -7,6 +7,7 @@ spack:
           - asciitoh5
           - model-neocortex
           - nest
+          - neurodamus
           - neurodamus-hippocampus
           - neurodamus-neocortex
           - neurodamus-thalamus
@@ -37,6 +38,7 @@ spack:
     - neuron%nvhpc+caliper+coreneuron+gpu+tests~openmp+nmodl
     - neuron%nvhpc+caliper+coreneuron+gpu+tests+openmp+nmodl+sympy
     - nest@2.20.1
+    - neurodamus+coreneuron  # Experimental
     - neurodamus-hippocampus+coreneuron+caliper
     - neurodamus-mousify+coreneuron+caliper
     - neurodamus-neocortex~plasticity+coreneuron+caliper

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -93,7 +93,7 @@ class NeurodamusModel(SimModel):
         self._build_mods("mod", dependencies=[])  # No dependencies
         self._install_binaries()
 
-    def merge_hoc_mod(self, spec, prefix, copyfunc=make_link):
+    def merge_hoc_mod(self, spec, prefix, copyfunc=make_link, merge_hoc=True):
         """Add hocs, mods and python scripts from neurodamus-core which comes
         as a submodule of py-neurodamus.
 
@@ -122,7 +122,8 @@ class NeurodamusModel(SimModel):
         # Neurodamus model may not have python scripts
         mkdirp("python")
 
-        copy_all(core_prefix.lib.hoc, "hoc", copyfunc)
+        if merge_hoc:
+            copy_all(core_prefix.lib.hoc, "hoc", copyfunc)
         copy_all(core_prefix.lib.mod, "mod", copyfunc)
         copy_all(core_prefix.lib.python, "python", copyfunc)
 
@@ -182,13 +183,14 @@ class NeurodamusModel(SimModel):
         force_symlink(core.prefix.lib.mod, prefix.share.mod_neurodamus)
         force_symlink(prefix.lib.mod, prefix.share.mod_full)
 
-        self._install_neurodamus_builder_script(prefix)
+        self._install_neurodamus_builder_script()
+        self._patch_neurodamus_version(prefix)
 
+    def _install_neurodamus_builder_script(self):
+        shutil.move(_BUILD_NEURODAMUS_FNAME, self.prefix.bin)
 
-    def _install_neurodamus_builder_script(self, prefix):
+    def _patch_neurodamus_version(self, prefix):
         spec = self.spec
-        shutil.move(_BUILD_NEURODAMUS_FNAME, prefix.bin)
-
         filter_file(
             r"UNKNOWN_NEURODAMUS_MODEL", r"%s" % spec.name, prefix.lib.hoc.join("defvar.hoc")
         )

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -91,7 +91,7 @@ class NeurodamusModel(SimModel):
     def build_model(self, spec, prefix):
         """Build and install the bare model."""
         self._build_mods("mod", dependencies=[])  # No dependencies
-        self._install_binaries()
+        self._install_binaries(prefix)
 
     def merge_hoc_mod(self, spec, prefix, copyfunc=make_link, merge_hoc=True):
         """Add hocs, mods and python scripts from neurodamus-core which comes
@@ -175,7 +175,6 @@ class NeurodamusModel(SimModel):
         python/ If neurodamus-core comes with python, create links
         """
         self._install_binaries(prefix)
-
         self._install_src(prefix)
 
         # Create neurodamus links in share

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -94,7 +94,7 @@ class NeurodamusModel(SimModel):
         # Dont install intermediate src.
         self._install_binaries()
 
-    def merge_hoc_mod(self, spec, prefix):
+    def merge_hoc_mod(self, spec, prefix, copyfunc=make_link):
         """Add hocs, mods and python scripts from neurodamus-core which comes
         as a submodule of py-neurodamus.
 
@@ -105,7 +105,7 @@ class NeurodamusModel(SimModel):
         core_prefix = core.prefix
 
         # If we shall build mods for coreneuron,
-        # only bring from core those specified
+        # only bring from core those specified (into mod_core)
         if spec.satisfies("+coreneuron"):
             shutil.copytree("mod", "mod_core", True)
             core_nrn_mods = set()
@@ -123,9 +123,9 @@ class NeurodamusModel(SimModel):
         # Neurodamus model may not have python scripts
         mkdirp("python")
 
-        copy_all(core_prefix.lib.hoc, "hoc", make_link)
-        copy_all(core_prefix.lib.mod, "mod", make_link)
-        copy_all(core_prefix.lib.python, "python", make_link)
+        copy_all(core_prefix.lib.hoc, "hoc", copyfunc)
+        copy_all(core_prefix.lib.mod, "mod", copyfunc)
+        copy_all(core_prefix.lib.python, "python", copyfunc)
 
     def build(self, spec, prefix):
         """Build mod files from with nrnivmodl / nrnivmodl-core.

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -91,7 +91,6 @@ class NeurodamusModel(SimModel):
     def build_model(self, spec, prefix):
         """Build and install the bare model."""
         self._build_mods("mod", dependencies=[])  # No dependencies
-        # Dont install intermediate src.
         self._install_binaries()
 
     def merge_hoc_mod(self, spec, prefix, copyfunc=make_link):
@@ -127,14 +126,12 @@ class NeurodamusModel(SimModel):
         copy_all(core_prefix.lib.mod, "mod", copyfunc)
         copy_all(core_prefix.lib.python, "python", copyfunc)
 
-    def build(self, spec, prefix):
+    def build(self, spec, prefix, extra_link_flags=""):
         """Build mod files from with nrnivmodl / nrnivmodl-core.
         To support shared libs, nrnivmodl is also passed RPATH flags.
         """
         # NOTE: sim-model now attempts to build all link and
         # include flags from the dependencies
-        # link_flag += ' '
-        #         + spec['synapsetool'].package.dependency_libs(spec).joined()
 
         # Create the library with all the mod files as libnrnmech.so/.dylib
         self.mech_name = ""
@@ -144,7 +141,9 @@ class NeurodamusModel(SimModel):
         else:
             base_include_flag = ""
 
-        include_flag, link_flag = self._build_mods("mod", "", base_include_flag, "mod_core")
+        include_flag, link_flag = self._build_mods(
+            "mod", extra_link_flags, base_include_flag, "mod_core"
+        )
 
         # Create rebuild script
         if spec.satisfies("+coreneuron"):
@@ -174,18 +173,21 @@ class NeurodamusModel(SimModel):
         share/ <- neuron & coreneuron mod.c's (modc and modc_core)
         python/ If neurodamus-core comes with python, create links
         """
-        # base dest dirs already created by model install
-        # We install binaries normally, except lib has a suffix
-        self._install_binaries()
+        self._install_binaries(prefix)
 
-        # Install mods/hocs, and a builder script
         self._install_src(prefix)
-        shutil.move(_BUILD_NEURODAMUS_FNAME, prefix.bin)
 
-        # Create mods links in share
+        # Create neurodamus links in share
         core = spec["py-neurodamus"]
         force_symlink(core.prefix.lib.mod, prefix.share.mod_neurodamus)
         force_symlink(prefix.lib.mod, prefix.share.mod_full)
+
+        self._install_neurodamus_builder_script(prefix)
+
+
+    def _install_neurodamus_builder_script(self, prefix):
+        spec = self.spec
+        shutil.move(_BUILD_NEURODAMUS_FNAME, prefix.bin)
 
         filter_file(
             r"UNKNOWN_NEURODAMUS_MODEL", r"%s" % spec.name, prefix.lib.hoc.join("defvar.hoc")

--- a/bluebrain/repo-bluebrain/packages/neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus/package.py
@@ -10,13 +10,21 @@ from .neurodamus_model import NeurodamusModel
 
 
 class Neurodamus(NeurodamusModel):
-    """The Blue Brain Project simulation suite with BBP models"""
+    """ The next-generation AllInOne Neurodamus deployment.
+
+    Neurodamus includes BBP's simulation suite with all internal sim models.
+    """
 
     # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://bbpgitlab.epfl.ch/hpc/sim/neurodamus-models"
     git      = "git@bbpgitlab.epfl.ch:hpc/sim/neurodamus-models.git"
 
     version('develop', submodules=True)
+    # For now let the version give a good hint about what we are, to avoid
+    # users loading it by mistake and getting puzzled
+    version('0.0.1_allInOne', tag='0.0.1', submodules=True)
+
+    depends_on('py-neurodamus', type=('build', 'run'))
 
     models = ("common", "neocortex", "hippocampus", "thalamus", "mousify")
     phases = ["build_" + model for model in models] + ["install"]

--- a/bluebrain/repo-bluebrain/packages/neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus/package.py
@@ -2,13 +2,14 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import os
+
 from spack import *
-from spack.pkg.builtin.neurodamus_model import NeurodamusModel
+
+from .neurodamus_model import NeurodamusModel
 
 
-class Neurodamus3(NeurodamusModel):
+class Neurodamus(NeurodamusModel):
     """The Blue Brain Project simulation suite with BBP models"""
 
     # FIXME: Add a proper url for your package's homepage here.

--- a/bluebrain/repo-bluebrain/packages/neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus/package.py
@@ -65,10 +65,10 @@ class Neurodamus(NeurodamusModel):
             with working_dir(model_name):
                 self._install_src(prefix, model_name)
                 self._install_binaries(model_install_prefix)
-                if model_name == "common":
-                    self._install_neurodamus_builder_script()
             force_symlink(model_install_prefix.bin.special,
                           prefix.bin.join("special-" + model_name))
+        with working_dir('common'):
+            self._install_neurodamus_builder_script()
 
     def setup_run_environment(self, env):
         self._setup_run_environment_common(env)

--- a/bluebrain/repo-bluebrain/packages/reportinglib/package.py
+++ b/bluebrain/repo-bluebrain/packages/reportinglib/package.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
-from spack.package import *
+from spack import *
 
 
 class Reportinglib(CMakePackage):

--- a/bluebrain/repo-bluebrain/packages/sim-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/sim-model/package.py
@@ -209,6 +209,7 @@ class SimModel(Package):
             copy_all(folder, dest_dir)
 
         modc_dest_dir = prefix.share.join(destination_subdir).modc
+        mkdirp(modc_dest_dir)
         for cmod in find(arch, "*.c", recursive=False):
             shutil.move(cmod, modc_dest_dir)
 

--- a/bluebrain/repo-bluebrain/packages/sim-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/sim-model/package.py
@@ -148,14 +148,12 @@ class SimModel(Package):
         lib/ <- hoc, mod and lib*mech*.so
         share/ <- neuron & coreneuron mod.c's (modc and modc_core)
         """
-        self._install_binaries()
+        self._install_binaries(prefix)
 
         if install_src:
             self._install_src(prefix)
 
-    def _install_binaries(self, prefix=None):
-        # Install special
-        prefix = prefix or self.prefix
+    def _install_binaries(self, prefix):
         mkdirp(prefix.bin)
         mkdirp(prefix.lib)
         mkdirp(prefix.share.modc)

--- a/bluebrain/repo-bluebrain/packages/sim-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/sim-model/package.py
@@ -168,7 +168,7 @@ class SimModel(Package):
             with working_dir("build_" + mech_name):
                 if self.spec.satisfies("^coreneuron@0.0:0.14"):
                     raise Exception(
-                        "Coreneuron versions before 0.14 are" "not supported by Neurodamus model"
+                        "Coreneuron versions before 0.14 are not supported by Neurodamus model"
                     )
                 elif self.spec.satisfies("^coreneuron@0.14:0.16.99"):
                     which("nrnivmech_install.sh", path=".")(prefix)
@@ -197,17 +197,20 @@ class SimModel(Package):
             which("sed")("-i.bak", 's#-dll .*#-dll %s "$@"#' % lib_dst, prefix.bin.special)
             os.remove(prefix.bin.join("special.bak"))
 
-    def _install_src(self, prefix):
-        """Copy original and translated c mods"""
+    def _install_src(self, prefix, destination_subdir=""):
+        """Copy original and translated c mods
+        """
         arch = os.path.basename(self.spec["neuron"].package.archdir)
-        mkdirp(prefix.lib.mod, prefix.lib.hoc, prefix.lib.python)
-        copy_all("mod", prefix.lib.mod)
-        copy_all("hoc", prefix.lib.hoc)
-        if os.path.isdir("python"):  # Recent neurodamus
-            copy_all("python", prefix.lib.python)
+        for folder in ("mod", "hoc", "python"):
+            if not os.path.isdir(folder):
+                continue
+            dest_dir = prefix.lib.join(destination_subdir).join(folder)
+            mkdirp(dest_dir)
+            copy_all(folder, dest_dir)
 
+        modc_dest_dir = prefix.share.join(destination_subdir).modc
         for cmod in find(arch, "*.c", recursive=False):
-            shutil.move(cmod, prefix.share.modc)
+            shutil.move(cmod, modc_dest_dir)
 
     def _setup_build_environment_common(self, env):
         env.unset("LC_ALL")

--- a/bluebrain/repo-bluebrain/packages/sim-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/sim-model/package.py
@@ -164,7 +164,6 @@ class SimModel(Package):
         nrnivmodl_outdir = self.spec["neuron"].package.archdir
         arch = os.path.basename(nrnivmodl_outdir)
 
-
         if self.spec.satisfies("+coreneuron"):
             with working_dir("build_" + mech_name):
                 if self.spec.satisfies("^coreneuron@0.0:0.14"):
@@ -201,6 +200,7 @@ class SimModel(Package):
     def _install_src(self, prefix, destination_subdir=""):
         """Copy original and translated c mods
         """
+        mkdirp(prefix.share.modc)
         arch = os.path.basename(self.spec["neuron"].package.archdir)
         for folder in ("mod", "hoc", "python"):
             if not os.path.isdir(folder):

--- a/bluebrain/repo-bluebrain/packages/sim-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/sim-model/package.py
@@ -153,16 +153,17 @@ class SimModel(Package):
         if install_src:
             self._install_src(prefix)
 
-    def _install_binaries(self, mech_name=None):
+    def _install_binaries(self, prefix=None):
         # Install special
-        mkdirp(self.spec.prefix.bin)
-        mkdirp(self.spec.prefix.lib)
-        mkdirp(self.spec.prefix.share.modc)
+        prefix = prefix or self.prefix
+        mkdirp(prefix.bin)
+        mkdirp(prefix.lib)
+        mkdirp(prefix.share.modc)
 
-        mech_name = mech_name or self.mech_name
+        mech_name = self.mech_name
         nrnivmodl_outdir = self.spec["neuron"].package.archdir
         arch = os.path.basename(nrnivmodl_outdir)
-        prefix = self.prefix
+
 
         if self.spec.satisfies("+coreneuron"):
             with working_dir("build_" + mech_name):

--- a/var/spack/repos/builtin/packages/neurodamus3/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus3/package.py
@@ -28,7 +28,8 @@ class Neurodamus3(NeurodamusModel):
     def _build_model(self, model_name, spec, prefix):
         with working_dir(model_name):
             self.mech_name = model_name
-            NeurodamusModel.merge_hoc_mod(self, spec, prefix, create_link_if_not_found)
+            NeurodamusModel.merge_hoc_mod(self, spec, prefix, create_link_if_not_found,
+                                          merge_hoc=False)
             extra_link_args = "-Wl,-rpath," + self.model_install_prefix(model_name).lib
             NeurodamusModel.build(self, spec, prefix, extra_link_args)
 
@@ -55,8 +56,14 @@ class Neurodamus3(NeurodamusModel):
             with working_dir(model_name):
                 self._install_src(prefix, model_name)
                 self._install_binaries(model_install_prefix)
+                if model_name == "common":
+                    self._install_neurodamus_builder_script()
             force_symlink(model_install_prefix.bin.special,
                           prefix.bin.join("special-" + model_name))
+
+    def setup_run_environment(self, env):
+        self._setup_run_environment_common(env)
+        env.set('MODELS_LIBRARY_PATH', self.prefix.lib)
 
 
 def create_link_if_not_found(src, dst):

--- a/var/spack/repos/builtin/packages/neurodamus3/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus3/package.py
@@ -4,10 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import shutil
 from spack import *
 from spack.pkg.builtin.neurodamus_model import NeurodamusModel
-from llnl.util import tty
 
 
 class Neurodamus3(NeurodamusModel):
@@ -28,10 +26,12 @@ class Neurodamus3(NeurodamusModel):
     def _build_model(self, model_name, spec, prefix):
         with working_dir(model_name):
             self.mech_name = model_name
-            NeurodamusModel.merge_hoc_mod(self, spec, prefix, create_link_if_not_found,
-                                          merge_hoc=False)
-            extra_link_args = "-Wl,-rpath," + self.model_install_prefix(model_name).lib
-            NeurodamusModel.build(self, spec, prefix, extra_link_args)
+            NeurodamusModel.merge_hoc_mod(
+                self, spec, prefix, create_link_if_not_found,
+                merge_hoc=False
+            )
+            ld_args = "-Wl,-rpath," + self.model_install_prefix(model_name).lib
+            NeurodamusModel.build(self, spec, prefix, ld_args)
 
     def build_common(self, spec, prefix):
         self._build_model("common", spec, prefix)
@@ -64,6 +64,7 @@ class Neurodamus3(NeurodamusModel):
     def setup_run_environment(self, env):
         self._setup_run_environment_common(env)
         env.set('MODELS_LIBRARY_PATH', self.prefix.lib)
+        env.prepend_path("PYTHONPATH", self.prefix.lib.common.python)
 
 
 def create_link_if_not_found(src, dst):

--- a/var/spack/repos/builtin/packages/neurodamus3/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus3/package.py
@@ -1,0 +1,67 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import shutil
+from spack import *
+from spack.pkg.builtin.neurodamus_model import NeurodamusModel
+from llnl.util import tty
+
+
+class Neurodamus3(NeurodamusModel):
+    """The Blue Brain Project simulation suite with BBP models"""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://bbpgitlab.epfl.ch/hpc/sim/neurodamus-models"
+    git      = "git@bbpgitlab.epfl.ch:hpc/sim/neurodamus-models.git"
+
+    version('develop', submodules=True)
+
+    models = ("common", "neocortex")  #, "hippocampus", "thalamus", "mousify")
+    phases = ["build_" + model for model in models] + ["install"]
+
+    def _build_model(self, model_name, spec, prefix):
+        with working_dir(model_name):
+            self.mech_name = model_name
+            NeurodamusModel.merge_hoc_mod(self, spec, prefix, create_link_if_not_found)
+            NeurodamusModel.build(self, spec, prefix)
+
+    def build_common(self, spec, prefix):
+        self._build_model("common", spec, prefix)
+
+    def build_neocortex(self, spec, prefix):
+        copy_all('neocortex/mod/v6', 'neocortex/mod')
+        self._build_model("neocortex", spec, prefix)
+
+    def build_hippocampus(self, spec, prefix):
+        self._build_model("hippocampus", spec, prefix)
+
+    def build_thalamus(self, spec, prefix):
+        self._build_model("thalamus", spec, prefix)
+
+    def build_mousify(self, spec, prefix):
+        self._build_model("mousify", spec, prefix)
+
+    def install(self, spec, prefix):
+        for model_name in self.models:
+            self._install_src(prefix, destination_subdir=model_name)
+
+
+def create_link_if_not_found(src, dst):
+    """
+    Args:
+        src (str): The path of the file to create a link to
+        dst (str): The link destination path (may be a directory)
+    """
+    if os.path.isdir(dst):
+        dst_dir = dst
+        dst = join_path(dst, os.path.basename(src))
+    else:
+        dst_dir = os.path.dirname(dst)
+    if os.path.exists(dst):
+        return
+    if not os.path.isabs(src):
+        src = os.path.relpath(src, dst_dir)  # update path relation
+    os.symlink(src, dst)

--- a/var/spack/repos/builtin/packages/neurodamus3/package.py
+++ b/var/spack/repos/builtin/packages/neurodamus3/package.py
@@ -19,7 +19,7 @@ class Neurodamus3(NeurodamusModel):
 
     version('develop', submodules=True)
 
-    models = ("common", "neocortex")  #, "hippocampus", "thalamus", "mousify")
+    models = ("common", "neocortex", "hippocampus", "thalamus", "mousify")
     phases = ["build_" + model for model in models] + ["install"]
 
     def _build_model(self, model_name, spec, prefix):
@@ -46,7 +46,8 @@ class Neurodamus3(NeurodamusModel):
 
     def install(self, spec, prefix):
         for model_name in self.models:
-            self._install_src(prefix, destination_subdir=model_name)
+            with working_dir(model_name):
+                self._install_src(prefix, destination_subdir=model_name)
 
 
 def create_link_if_not_found(src, dst):


### PR DESCRIPTION
## Context
Unified Neurodamus is the concept where all BBP simulation models are deployed together and can be loaded on demand by neurodamus-py.

This setup is desirable, not only because it doesn't require users to switch modules anymore, but also for developers and the ultimate goal of reproducibility, as it makes the whole set of models and their inter-dependencies stable and easier to deploy,

## This PR
Building on the new unified `neurodamus-models` repo in GitLab, we build a new Spack recipe which, extending the solid `neurodamus-model` recipe, builds the multiple models, side by side, to a common destination.

At the same time the `common` set of mods becomes a first-class model, since it it might be used by bglib-py, replacing the old `neurodamus-core+common_mods`.

### Impl details
 - Each model build output is stored in `<install_prefix>/lib/<model_name>`
 - Soft links to each binary `special` are created in bin, e.g. `bin/special-neocortex`, `bin/special-hippocampus`...
 - A new env var `MODELS_LIBRARY_PATH` points to `<install_prefix>/lib` to allow `neurodamus-py` to pick the requested one.
 - One prepends each model hocs dir to the env var `HOC_LIBRARY_PATH`. **We effectively make use of two hoc paths**,
 - python files which are required from within Hoc files have their path prepended to `PYTHONPATH` from the `common` model