### PR TITLE
clang-tools: recipe+deploy+module.

### DIFF
--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -8,6 +8,7 @@ spack:
         - bison
         - blender
         - ccache
+        - clang-tools
         - cli-tools
         - cmake
         - cuda
@@ -72,6 +73,7 @@ spack:
     - bzip2
     - ccache
     - cgal
+    - clang-tools
     - cli-tools
     - cmake
     - cuda@11.0.2

--- a/bluebrain/repo-bluebrain/packages/clang-tools/package.py
+++ b/bluebrain/repo-bluebrain/packages/clang-tools/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from llnl.util.filesystem import install, mkdirp
+
+from spack.directives import depends_on, version
+from spack.package import Package
+from spack.pkg.patches.llvm import Llvm as LLVM
+
+
+class ClangTools(Package):
+    """Copy binaries like clang-format out of an LLVM installation and into a
+    clean directory for which a module can safely be generated."""
+
+    has_code = False
+    homepage = LLVM.homepage
+
+    # Add a clang-format version for every LLVM version
+    for llvm_ver in LLVM.versions:
+        version(llvm_ver)
+        depends_on(
+            "llvm@{}".format(llvm_ver), when="@{}".format(llvm_ver), type="build"
+        )
+
+    def install(self, spec, prefix):
+        mkdirp(spec.prefix.bin)
+        for utility in ("clang-format", "clang-tidy"):
+            install(
+                spec["llvm"].prefix.bin.join(utility), spec.prefix.bin.join(utility)
+            )


### PR DESCRIPTION
Copy clang-format and clang-tidy out of an LLVM installation and
truncate the dependency graph. This should allow easy code formatting
without polluting things with too much of the LLVM world.