### PR TITLE
deploy: stop building meshball

### DIFF
--- a/bluebrain/deployment/environments/applications_viz.yaml
+++ b/bluebrain/deployment/environments/applications_viz.yaml
@@ -12,5 +12,4 @@ spack:
     - brayns%gcc +brion ^ospray%intel@19.1.3.304 target=x86_64 ^intel-tbb%intel@19.1.3.304
     - brayns@1.1.0%gcc +brion+net ^brion@3.3.1 ^ospray%intel@19.1.3.304 target=x86_64 ^intel-tbb%intel@19.1.3.304
     - brion +python
-    - meshball ^brion@3.1.0
     - ultraliser ^hdf5~mpi


### PR DESCRIPTION
This should allow us to retire lunchbox, servus, and vmmlib, too.
