### PR TITLE
Update morphio to support >1.2 h5v1 morph spec version

### DIFF
--- a/bluebrain/repo-bluebrain/packages/morphio/package.py
+++ b/bluebrain/repo-bluebrain/packages/morphio/package.py
@@ -11,10 +11,11 @@ class Morphio(CMakePackage):
 
     homepage = "https://github.com/BlueBrain/MorphIO"
     git      = "https://github.com/BlueBrain/MorphIO.git"
-    url      = "https://pypi.io/packages/source/m/morphio/MorphIO-3.1.1.tar.gz"
+    url      = "https://pypi.io/packages/source/m/morphio/MorphIO-3.3.2.tar.gz"
 
     version('develop', submodules=True)
 
+    version('3.3.2', sha256="fc961defbfbfb3f11360954fb3ec51373eaff25b154fa31d6b31decca6937780")
     version('3.1.1', sha256="ad9f0e363f09f03c6eda54f5f3b006d204236677d2f2c9675421e0441033a503")
     version('2.7.1', sha256="3f3e2229da85e874527775fce080f712b6dc287edc44b90b6de35d17b34badff")
 

--- a/bluebrain/repo-bluebrain/packages/py-morphio/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-morphio/package.py
@@ -11,11 +11,12 @@ class PyMorphio(PythonPackage):
 
     homepage = "https://github.com/BlueBrain/MorphIO"
     git      = "https://github.com/BlueBrain/MorphIO.git"
-    url      = "https://pypi.io/packages/source/m/morphio/MorphIO-3.1.1.tar.gz"
+    url      = "https://pypi.io/packages/source/m/morphio/MorphIO-3.3.2.tar.gz"
 
     version('develop', branch='master', submodules=True, get_full_repo=True)
     version('unifurcation', branch='unifurcation', submodules=True, get_full_repo=True)
 
+    version('3.3.2', sha256="fc961defbfbfb3f11360954fb3ec51373eaff25b154fa31d6b31decca6937780")
     version('3.1.1', sha256="ad9f0e363f09f03c6eda54f5f3b006d204236677d2f2c9675421e0441033a503")
     version('2.7.1', sha256="3f3e2229da85e874527775fce080f712b6dc287edc44b90b6de35d17b34badff")
 


### PR DESCRIPTION
The latest modules of touchdetector use morphio==3.1.1, which supports Morphology format spec version up to 1.2 .

In morphio==3.3.1 Dendritic spine was introduced, which resulted in increasing the spec version to 1.3 . Therefore, for morphio>=3.3.1 the hdf5 writer specifies a 1.3 format version:

https://github.com/BlueBrain/MorphIO/blob/585b71fb98eacfb6aa832e563928f9609586eb66/src/mut/writers.cpp#L400

When touchdetector attempts to read morphologies written with morphio>=3.3.1 a RawDataError is thrown, because of the reader's version check:

https://github.com/BlueBrain/MorphIO/blob/58d6895a2543d4aa18957c550ca40ffeb0036e55/src/readers/morphologyHDF5.cpp#L137

Updating spack with the latest morphio version will result in touchdetector using the updated version check that includes 1.3 in the morphio reader.