### PR TITLE
docs: use better instructions to whitelist stuff

### DIFF
--- a/bluebrain/deployment/bin/configure-spack-module
+++ b/bluebrain/deployment/bin/configure-spack-module
@@ -36,7 +36,7 @@ if [ module-info mode load ] {
     puts stderr "==========================================\n"
     puts stderr "Software will be installed into ~/spack_install${suffix} by default."
     puts stderr "Modules for installed software are disabled, to enable a specific one, use:\n"
-    puts stderr "\tspack config add modules:tcl:whitelist:package_to_install\n"
+    puts stderr "\tspack config add \"modules:tcl:whitelist:[package_to_install]\"\n"
     puts stderr "To modify the software installation directory, use\n"
     puts stderr "\texport SPACK_USER_CACHE_PATH=\$\{NEW_INSTALL_DIR\}\n"
     puts stderr "Or modify the Spack configuration with:\n"

--- a/bluebrain/documentation/FAQ.md
+++ b/bluebrain/documentation/FAQ.md
@@ -75,7 +75,7 @@
 
   Use
 
-      $ spack config add modules:tcl:whitelist:my_package
+      $ spack config add "modules:tcl:whitelist:[my_package]"
       $ spack module tcl refresh my_package
 
   To produce an up-to-date module for `my_package` (adjust as needed).

--- a/bluebrain/documentation/setup_bb5.md
+++ b/bluebrain/documentation/setup_bb5.md
@@ -40,7 +40,7 @@ To customise this, use the following commands:
 To generate a module for the package `my_package`,
 modify the whitelist with the following command:
 
-    $ spack config add modules:tcl:whitelist:my_package
+    $ spack config add "modules:tcl:whitelist:[my_package]"
 
 And use
 


### PR DESCRIPTION
Thanks to @olupton for pointing this out: the original instructions
don't work with an empty `modules.yaml`. Use better syntax to append to
non- or pre-existing whitelists.
