### PR TITLE
{py-,}morpho-kit: fix highfive link dependency

### DIFF
--- a/bluebrain/repo-bluebrain/packages/morpho-kit/h5.patch
+++ b/bluebrain/repo-bluebrain/packages/morpho-kit/h5.patch
@@ -1,0 +1,23 @@
+commit f19b3d110e55dcbb25d6a8962a49aa87b5b859b0
+Author: Matthias Wolf <matthias.wolf@epfl.ch>
+Date:   Thu Feb 17 11:12:40 2022 +0100
+
+    dependencies: we have an explicit dependency on HighFive, link to it.
+    
+    Otherwise, this fails to compile on Monterey.
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b13b7bd..776776b 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -64,6 +64,10 @@ foreach(lib morphokit_shared morphokit_static)
+     PUBLIC
+     MorphIO::morphio
+     )
++  target_link_libraries(${lib}
++    PRIVATE
++    HighFive
++    )
+ endforeach(lib)
+ 
+ install(

--- a/bluebrain/repo-bluebrain/packages/morpho-kit/package.py
+++ b/bluebrain/repo-bluebrain/packages/morpho-kit/package.py
@@ -20,6 +20,8 @@ class MorphoKit(CMakePackage):
     depends_on('morphio@2.3.9:')
     depends_on('boost', when='@0.2.0')
 
+    patch('h5.patch', when='@0.3.2')
+
     def cmake_args(self):
         return [
             '-DBUILD_BINDINGS:BOOL=OFF',

--- a/bluebrain/repo-bluebrain/packages/py-morpho-kit/h5.patch
+++ b/bluebrain/repo-bluebrain/packages/py-morpho-kit/h5.patch
@@ -1,0 +1,23 @@
+commit f19b3d110e55dcbb25d6a8962a49aa87b5b859b0
+Author: Matthias Wolf <matthias.wolf@epfl.ch>
+Date:   Thu Feb 17 11:12:40 2022 +0100
+
+    dependencies: we have an explicit dependency on HighFive, link to it.
+    
+    Otherwise, this fails to compile on Monterey.
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b13b7bd..776776b 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -64,6 +64,10 @@ foreach(lib morphokit_shared morphokit_static)
+     PUBLIC
+     MorphIO::morphio
+     )
++  target_link_libraries(${lib}
++    PRIVATE
++    HighFive
++    )
+ endforeach(lib)
+ 
+ install(

--- a/bluebrain/repo-bluebrain/packages/py-morpho-kit/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-morpho-kit/package.py
@@ -24,3 +24,5 @@ class PyMorphoKit(PythonPackage):
     depends_on('cmake@3.2:', type='build')
     depends_on('py-numpy', type='run')
     depends_on('boost', when='@0.2.0')
+
+    patch('h5.patch', when='@0.3.2')


### PR DESCRIPTION
Required for Monterey
