### PR TITLE
spack configure-pipelines: --ignore-packages.

### DIFF
--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -809,7 +809,7 @@ _spack_config_revert() {
 _spack_configure_pipeline() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --write-commit-file"
+        SPACK_COMPREPLY="-h --help --ignore-packages --write-commit-file"
     else
         SPACK_COMPREPLY=""
     fi


### PR DESCRIPTION
This reduces the need for complicated shell scripting when using `spack configure-pipelines`.

Also fix patching recipes such as `touchdetector` that do not have an explicit branch/commit/tag.