### PR TITLE
Add/deploy NVHPC 22.2 and CUDA 11.6.0.

### DIFF
--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -77,8 +77,8 @@ spack:
     - cli-tools
     - cmake
     - cuda@11.0.2
-    - cuda@11.4.2
     - cuda@11.5.1
+    - cuda@11.6.0
     - cudnn@8.0.3.33-11.0
     - darshan-runtime
     - darshan-util

--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -63,9 +63,9 @@ spack:
     - llvm@12.0.1
     - llvm@11.1.0
     - nvhpc@21.2 install_type=network
-    - nvhpc@21.9
     - nvhpc@21.11
     - nvhpc@22.1
+    - nvhpc@22.2
     - arm-forge
     - bison
     - blender

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -104,10 +104,9 @@ class CudaPackage(PackageBase):
     # This implies that the last one in the list has to be updated at
     # each release of a new cuda minor version.
     conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
-    conflicts('%gcc@11:', when='+cuda ^cuda@:11.4.0')
-    conflicts('%gcc@12:', when='+cuda ^cuda@:11.5.0')
-    conflicts('%clang@12:', when='+cuda ^cuda@:11.4.0')
-    conflicts('%clang@13:', when='+cuda ^cuda@:11.5.0')
+    conflicts('%gcc@12:', when='+cuda ^cuda@:11.6')
+    conflicts('%clang@13:', when='+cuda ^cuda@:11.5')
+    conflicts('%clang@14:', when='+cuda ^cuda@:11.6')
 
     # https://gist.github.com/ax3l/9489132#gistcomment-3860114
     conflicts('%gcc@10', when='+cuda ^cuda@:11.4.0')

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -25,6 +25,10 @@ from spack import *
 #    format returned by platform.system() and 'arch' by platform.machine()
 
 _versions = {
+    '11.6.0': {
+        'Linux-aarch64': ('5898579f5e59b708520883cb161089f5e4f3426158d1e9f973c49d224085d1d2', 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_510.39.01_linux_sbsa.run'),
+        'Linux-x86_64': ('1783da6d63970786040980b57fa3cb6420142159fc7d0e66f8f05c4905d98c83', 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_510.39.01_linux.run'),
+        'Linux-ppc64le': ('c86b866a42baf59ddc6f1f4a79e6d77213c90749e77e574f0e0d796a749ab7d0', 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_510.39.01_linux_ppc64le.run')},
     '11.5.1': {
         'Linux-aarch64': ('73e1d0e97c7fa686efe7e00fb1e5f179372c4eec8e14d4f44ab58d5f6cf57f63', 'https://developer.download.nvidia.com/compute/cuda/11.5.1/local_installers/cuda_11.5.1_495.29.05_linux_sbsa.run'),
         'Linux-x86_64': ('60bea2fc0fac95574015f865355afbf599422ec2c85554f5f052b292711a4bca', 'https://developer.download.nvidia.com/compute/cuda/11.5.1/local_installers/cuda_11.5.1_495.29.05_linux.run'),

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -22,6 +22,10 @@ from spack.util.prefix import Prefix
 #  - package key must be in the form '{os}-{arch}' where 'os' is in the
 #    format returned by platform.system() and 'arch' by platform.machine()
 _versions = {
+    '22.2': {
+        'Linux-aarch64': ('a8241d1139a768d9a0066d1853748160e4098253024e17e997983884d0d33a19', 'https://developer.download.nvidia.com/hpc-sdk/22.2/nvhpc_2022_222_Linux_aarch64_cuda_multi.tar.gz'),
+        'Linux-ppc64le': ('f84f72423452968d5bbe02e297f188682c4759864a736a72b32acb3433db3a26', 'https://developer.download.nvidia.com/hpc-sdk/22.2/nvhpc_2022_222_Linux_ppc64le_cuda_multi.tar.gz'),
+        'Linux-x86_64': ('8dfb4007d6912b2722946358ac69409592c1f03426d81971ffbcb6fc5fea2cb8', 'https://developer.download.nvidia.com/hpc-sdk/22.2/nvhpc_2022_222_Linux_x86_64_cuda_multi.tar.gz')},
     '22.1': {
         'Linux-aarch64': ('05cfa8c520a34eab01272a261b157d421a9ff7129fca7d859b944ce6a16d2255', 'https://developer.download.nvidia.com/hpc-sdk/22.1/nvhpc_2022_221_Linux_aarch64_cuda_multi.tar.gz'),
         'Linux-ppc64le': ('9fa9b64fba2c9b287b5800693417d8065c695d18cab0526bad41d9aecc8be2b3', 'https://developer.download.nvidia.com/hpc-sdk/22.1/nvhpc_2022_221_Linux_ppc64le_cuda_multi.tar.gz'),


### PR DESCRIPTION
- Add NVHPC 22.2 to recipe.
- Add CUDA 11.6.0 to recipe (hopefully https://github.com/spack/spack/issues/19365 will be addressed soon so we don't need these parallel installations of CUDA versions that are bundled with NVHPC).
- Add NVHPC 22.2 to the BB5 deployment and drop NVHPC 21.9
- Add CUDA 11.6.0 to the BB5 deployment and drop CUDA 11.4.2, which was added along with NVHPC 21.9.