### PR TITLE
cuda: restore CUPTI fix #1112.

### DIFF
--- a/bluebrain/repo-patches/packages/cuda/package.py
+++ b/bluebrain/repo-patches/packages/cuda/package.py
@@ -1,0 +1,9 @@
+from spack.pkg.builtin.cuda import Cuda as BuiltinCuda
+
+
+class Cuda(BuiltinCuda):
+    __doc__ = BuiltinCuda.__doc__
+
+    def setup_run_environment(self, env):
+        super().setup_run_environment(env)
+        env.append_path("LD_LIBRARY_PATH", self.prefix.extras.CUPTI.lib64)

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -19,7 +19,7 @@ packages:
     version: [3.21.4]
   cuda:
     # Should match what is provided by NVHPC, too
-    version: [11.4.2]
+    version: [11.6.0]
   curl:
     version: [7.29.0]
     externals:


### PR DESCRIPTION
Augment CUDA recipe to include the fix from https://github.com/BlueBrain/spack/pull/1112.

This was previously in our `develop` branch: https://github.com/BlueBrain/spack/blob/76bfcbe560aa7ea9c1f1718f7aab734371461b01/var/spack/repos/builtin/packages/cuda/package.py#L164
but it got reverted in b77b485eac96c8a9f9fe2cfecc1b9eafe63f1e0c.

Note the upstream PR https://github.com/spack/spack/pull/22704 is still open.