### PR TITLE
Fix py-bluepy@develop branch

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-bluepy/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-bluepy/package.py
@@ -12,7 +12,7 @@ class PyBluepy(PythonPackage):
     homepage = "https://bbpgitlab.epfl.ch/nse/bluepy"
     git      = "git@bbpgitlab.epfl.ch:nse/bluepy.git"
 
-    version('develop')
+    version('develop', branch='main')
     version('2.4.4', tag='bluepy-v2.4.4')
 
     depends_on('py-setuptools', type=('build', 'run'))


### PR DESCRIPTION
Restore `branch='main'` for `py-bluepy@develop` as it was added in https://github.com/BlueBrain/spack/pull/1433.
Without it, the installation fails with:
```
==> Error: Package PyBluepy has no version with a URL.
```