### PR TITLE
Add mariadb connector

### DIFF
--- a/bluebrain/repo-patches/packages/mariadb-c-client/package.py
+++ b/bluebrain/repo-patches/packages/mariadb-c-client/package.py
@@ -1,0 +1,10 @@
+from spack import *
+from spack.pkg.builtin.mariadb_c_client import MariadbCClient as BuiltinMariadbCClient
+
+
+class MariadbCClient(BuiltinMariadbCClient):
+    __doc__ = BuiltinMariadbCClient.__doc__
+
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.prepend_path("LD_LIBRARY_PATH", join_path(self.prefix, "lib/mariadb"))

--- a/bluebrain/repo-patches/packages/mariadb-c-client/package.py
+++ b/bluebrain/repo-patches/packages/mariadb-c-client/package.py
@@ -5,6 +5,5 @@ from spack.pkg.builtin.mariadb_c_client import MariadbCClient as BuiltinMariadbC
 class MariadbCClient(BuiltinMariadbCClient):
     __doc__ = BuiltinMariadbCClient.__doc__
 
-
     def setup_dependent_run_environment(self, env, dependent_spec):
         env.prepend_path("LD_LIBRARY_PATH", join_path(self.prefix, "lib/mariadb"))

--- a/bluebrain/repo-patches/packages/py-mariadb/package.py
+++ b/bluebrain/repo-patches/packages/py-mariadb/package.py
@@ -2,8 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
-
 from spack import *
 
 
@@ -15,4 +13,4 @@ class PyMariadb(PythonPackage):
 
     version('1.0.10', sha256='79028ba6051173dad1ad0be7518389cab70239f92b4ff8b8813dae55c3f2c53d')
 
-    depends_on('mariadb-c-client', type=['build','run'])
+    depends_on('mariadb-c-client', type=['build', 'run'])

--- a/bluebrain/repo-patches/packages/py-mariadb/package.py
+++ b/bluebrain/repo-patches/packages/py-mariadb/package.py
@@ -13,5 +13,5 @@ class PyMariadb(PythonPackage):
 
     version('1.0.10', sha256='79028ba6051173dad1ad0be7518389cab70239f92b4ff8b8813dae55c3f2c53d')
 
-    depends_on('setuptools', type='build')
+    depends_on('py-setuptools', type='build')
     depends_on('mariadb-c-client', type=('build', 'run'))

--- a/bluebrain/repo-patches/packages/py-mariadb/package.py
+++ b/bluebrain/repo-patches/packages/py-mariadb/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
+from spack import *
+
+
+class PyMariadb(PythonPackage):
+    """A module for connecting to mariaDB databases"""
+
+    homepage = "https://github.com/mariadb-corporation/mariadb-connector-python"
+    pypi = "mariadb/mariadb-1.0.10.zip"
+
+    version('1.0.10', sha256='79028ba6051173dad1ad0be7518389cab70239f92b4ff8b8813dae55c3f2c53d')
+
+    depends_on('mariadb-c-client', type=['build','run'])

--- a/bluebrain/repo-patches/packages/py-mariadb/package.py
+++ b/bluebrain/repo-patches/packages/py-mariadb/package.py
@@ -13,4 +13,5 @@ class PyMariadb(PythonPackage):
 
     version('1.0.10', sha256='79028ba6051173dad1ad0be7518389cab70239f92b4ff8b8813dae55c3f2c53d')
 
-    depends_on('mariadb-c-client', type=['build', 'run'])
+    depends_on('setuptools', type='build')
+    depends_on('mariadb-c-client', type=('build', 'run'))

--- a/bluebrain/repo-patches/packages/python-dev/package.py
+++ b/bluebrain/repo-patches/packages/python-dev/package.py
@@ -27,6 +27,7 @@ class PythonDev(BundlePackage):
     depends_on('py-jinja2-cli', type=('build', 'run'))
     depends_on('py-lazy-property', type=('build', 'run'))
     depends_on('py-lxml', type=('build', 'run'))
+    depends_on('py-mariadb', type=('build', 'run'))
     depends_on('py-mock', type=('build', 'run'))
     depends_on('py-mypy', type=('build', 'run'))
     depends_on('py-pandas', type=('build', 'run'))


### PR DESCRIPTION
Allowing python scripts to do `import mariadb` and connect to MariaDB databases.