### PR TITLE
Do not overrise `CMAKE_BUILD_TYPE` for all compilers

### DIFF
--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -52,8 +52,6 @@ class Nmodl(CMakePackage):
         # installation with pgi fails when debug symbols are added
         if '%pgi' in spec:
             options.append('-DCMAKE_BUILD_TYPE=Release')
-        else:
-            options.append('-DCMAKE_BUILD_TYPE=RelWithDebInfo')
 
         if "+legacy-unit" in spec:
             options.append('-DNMODL_ENABLE_LEGACY_UNITS=ON')


### PR DESCRIPTION
 - Only PGI compiler has issue with debug symbols
 - For other compilers, `build_type` variant should
   be respected.