### PR TITLE
small fixes for building steps locally in ubuntu 20.04

### DIFF
--- a/bluebrain/documentation/setup_personal.md
+++ b/bluebrain/documentation/setup_personal.md
@@ -52,21 +52,23 @@ Use Spack on the workstations provided by the project.
 We build Docker images based on Ubuntu 18.04, and the same settings can be
 used to set Spack up on the desktops:
 
-    $ git clone -c feature.manyFiles=true https://github.com/BlueBrain/spack.git
+    $ git clone -c feature.manyFiles=true git@github.com:BlueBrain/spack.git
     $ mkdir ~/.spack
     $ cp spack/bluebrain/sysconfig/ubuntu-18.04/*.yaml ~/.spack
     $ sed -e 's/#.*//g' spack/bluebrain/sysconfig/ubuntu-18.04/packages|xargs -r sudo apt-get install --assume-yes
     $ . spack/share/spack/setup-env.sh
     $ spack compiler find
+    $ spack external find
 
 ### Ubuntu 20.04
 
-    $ git clone -c feature.manyFiles=true https://github.com/BlueBrain/spack.git
+    $ git clone -c feature.manyFiles=true git@github.com:BlueBrain/spack.git
     $ mkdir ~/.spack
     $ cp spack/bluebrain/sysconfig/ubuntu-20.04/*.yaml ~/.spack
     $ sed -e 's/#.*//g' spack/bluebrain/sysconfig/ubuntu-20.04/packages|xargs -r sudo apt-get install --assume-yes
     $ . spack/share/spack/setup-env.sh
     $ spack compiler find
+    $ spack external find
 
 Since Ubuntu 20.04 dropped Python 2 support, we need to set Python 3 as the
 default `python`:

--- a/bluebrain/sysconfig/ubuntu-18.04/packages.yaml
+++ b/bluebrain/sysconfig/ubuntu-18.04/packages.yaml
@@ -59,13 +59,8 @@ packages:
     externals:
     - spec: git@2.17.1
       prefix: /usr
-  hdf5:
-    version: [1.1]
-    externals:
-    - spec: hdf5@1.10~mpi+hl
-      prefix: /usr/lib/x86_64-linux-gnu/hdf5/serial
-    - spec: hdf5@1.10+mpi+hl
-      prefix: /usr/lib/x86_64-linux-gnu/hdf5/openmpi
+  gmsh:
+    variants: ~mmg~fltk
   libpciaccess:
     externals:
     - spec: libpciaccess@0.14

--- a/bluebrain/sysconfig/ubuntu-20.04/packages.yaml
+++ b/bluebrain/sysconfig/ubuntu-20.04/packages.yaml
@@ -59,13 +59,8 @@ packages:
     externals:
     - spec: git@2.25.1
       prefix: /usr
-  hdf5:
-    version: [1.1]
-    externals:
-    - spec: hdf5@1.10~mpi+hl
-      prefix: /usr/lib/x86_64-linux-gnu/hdf5/serial
-    - spec: hdf5@1.10+mpi+hl
-      prefix: /usr/lib/x86_64-linux-gnu/hdf5/openmpi
+  gmsh:
+    variants: ~mmg~fltk
   libpciaccess:
     externals:
     - spec: libpciaccess@0.16


### PR DESCRIPTION
We try to make `spack install steps@develop+distmesh+petsc` installation work on ubuntu 20.04. 

### Problems and solutions:
- med (a dependency) has hdf5 as dependency. If hdf5 has serial and openmpi as external (the current setup) it includes the headers of the serial one and compiles the other. Here we let spack compile hdf5.
- gmsh has +fltk as default. This in turn compiles llvm. Not required. We copy the bb5 configuration.