### PR TITLE
fix: set install RPATH to where the libraries actually are

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -678,12 +678,20 @@ def get_rpath_deps(pkg):
 
 def get_rpaths(pkg):
     """Get a list of all the rpaths for a package."""
-    rpaths = [pkg.prefix.lib, pkg.prefix.lib64]
+    def _rpaths(p):
+        if hasattr(p, 'libs'):
+            for pth in set(os.path.dirname(lib) for lib  in p.libs):
+                yield pth
+        else:
+            if os.path.isdir(p.prefix.lib):
+                yield p.prefix.lib
+            if os.path.isdir(p.prefix.lib64):
+                yield p.prefix.lib64
+
     deps = get_rpath_deps(pkg)
-    rpaths.extend(d.prefix.lib for d in deps
-                  if os.path.isdir(d.prefix.lib))
-    rpaths.extend(d.prefix.lib64 for d in deps
-                  if os.path.isdir(d.prefix.lib64))
+    rpaths = list(_rpaths(pkg))
+    for dep in deps:
+        rpaths.extend(_rpaths(dep.package))
     # Second module is our compiler mod name. We use that to get rpaths from
     # module show output.
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -680,7 +680,7 @@ def get_rpaths(pkg):
     """Get a list of all the rpaths for a package."""
     def _rpaths(p):
         if hasattr(p, 'libs'):
-            for pth in set(os.path.dirname(lib) for lib  in p.libs):
+            for pth in set(os.path.dirname(lib) for lib in p.libs):
                 yield pth
         else:
             if os.path.isdir(p.prefix.lib):
@@ -688,9 +688,8 @@ def get_rpaths(pkg):
             if os.path.isdir(p.prefix.lib64):
                 yield p.prefix.lib64
 
-    deps = get_rpath_deps(pkg)
-    rpaths = list(_rpaths(pkg))
-    for dep in deps:
+    rpaths = [pkg.prefix.lib, pkg.prefix.lib64]
+    for dep in get_rpath_deps(pkg):
         rpaths.extend(_rpaths(dep.package))
     # Second module is our compiler mod name. We use that to get rpaths from
     # module show output.


### PR DESCRIPTION
Arises when linking against, e.g., `intel-oneapi-tbb`, which has the
libraries hidden away in `$prefix/tbb/$version/lib/intel64/gcc4.8`, and
not the assumed `$prefix/lib{64,}`.

If a package offers specialized library introspection, use that to
detect where libraries are actually stored.
