### PR TITLE
Deploy NVHPC 22.3 and CUDA 11.6.1

### DIFF
--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -78,8 +78,12 @@ spack:
     - cli-tools
     - cmake
     - cuda@11.0.2
+    # NVHPC 22.1 ships CUDA 11.5 (11.5.20211118 in version.json)
     - cuda@11.5.1
+    # NVHPC 22.2 ships CUDA 11.6.0 (version.json)
     - cuda@11.6.0
+    # NVHPC 22.3 ships CUDA 11.6.1 (version.json)
+    - cuda@11.6.1
     - cudnn@8.0.3.33-11.0
     - darshan-runtime
     - darshan-util

--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -64,7 +64,6 @@ spack:
     - llvm@12.0.1
     - llvm@11.1.0
     - nvhpc@21.11
-    - nvhpc@22.1
     - nvhpc@22.2
     - nvhpc@22.3
     - arm-forge
@@ -78,7 +77,7 @@ spack:
     - cli-tools
     - cmake
     - cuda@11.0.2
-    # NVHPC 22.1 ships CUDA 11.5 (11.5.20211118 in version.json)
+    # NVHPC 21.11 ships CUDA 11.5 (11.5.20211118 in version.json)
     - cuda@11.5.1
     # NVHPC 22.2 ships CUDA 11.6.0 (version.json)
     - cuda@11.6.0

--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -63,10 +63,10 @@ spack:
     - llvm@13.0.0
     - llvm@12.0.1
     - llvm@11.1.0
-    - nvhpc@21.2 install_type=network
     - nvhpc@21.11
     - nvhpc@22.1
     - nvhpc@22.2
+    - nvhpc@22.3
     - arm-forge
     - bison
     - blender

--- a/bluebrain/repo-patches/packages/py-torch/package.py
+++ b/bluebrain/repo-patches/packages/py-torch/package.py
@@ -8,5 +8,5 @@ class PyTorch(BuiltinPyTorch):
     # GCC 11 removed thread_id equality, fix other compilation errors
     patch('gcc_thread_id.patch', when='@1.10.0%gcc@11')
     patch('https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/66089.patch',
-          sha256='a03a7a55c61e965a75a979328592fb62819cf08bb5f33ff235a4035494dcb620',
+          sha256='1965445f124b15fbbfc1b9a8e70a798296123a1db0d5186d09a74bb060aa8794',
           when='@1.10.0%gcc@11')

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -19,7 +19,7 @@ packages:
     version: [3.21.4]
   cuda:
     # Should match what is provided by NVHPC, too
-    version: [11.6.0]
+    version: [11.6.1]
   curl:
     version: [7.29.0]
     externals:

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1441,6 +1441,32 @@ The ``when`` clause follows the same syntax and accepts the same
 values as the ``when`` argument of
 :py:func:`spack.directives.depends_on`
 
+^^^^^^^^^^^^^^^
+Sticky Variants
+^^^^^^^^^^^^^^^
+
+The variant directive can be marked as ``sticky`` by setting to ``True`` the
+corresponding argument:
+
+.. code-block:: python
+
+   variant('bar', default=False, sticky=True)
+
+A ``sticky`` variant differs from a regular one in that it is always set
+to either:
+
+#. An explicit value appearing in a spec literal or
+#. Its default value
+
+The concretizer thus is not free to pick an alternate value to work
+around conflicts, but will error out instead.
+Setting this property on a variant is useful in cases where the
+variant allows some dangerous or controversial options (e.g. using unsupported versions
+of a compiler for a library) and the packager wants to ensure that
+allowing these options is done on purpose by the user, rather than
+automatically by the solver.
+
+
 ^^^^^^^^^^^^^^^^^^^
 Overriding Variants
 ^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -5,6 +5,7 @@
 
 import spack.variant
 from spack.directives import conflicts, depends_on, variant
+from spack.multimethod import when
 from spack.package import PackageBase
 
 
@@ -87,103 +88,103 @@ class CudaPackage(PackageBase):
 
     # Linux x86_64 compiler conflicts from here:
     # https://gist.github.com/ax3l/9489132
+    with when('^cuda~allow-unsupported-compilers'):
+        # GCC
+        # According to
+        # https://github.com/spack/spack/pull/25054#issuecomment-886531664
+        # these conflicts are valid independently from the architecture
 
-    # GCC
-    # According to
-    # https://github.com/spack/spack/pull/25054#issuecomment-886531664
-    # these conflicts are valid independently from the architecture
+        # minimum supported versions
+        conflicts('%gcc@:4', when='+cuda ^cuda@11.0:')
+        conflicts('%gcc@:5', when='+cuda ^cuda@11.4:')
 
-    # minimum supported versions
-    conflicts('%gcc@:4', when='+cuda ^cuda@11.0:')
-    conflicts('%gcc@:5', when='+cuda ^cuda@11.4:')
+        # maximum supported version
+        # NOTE:
+        # in order to not constrain future cuda version to old gcc versions,
+        # it has been decided to use an upper bound for the latest version.
+        # This implies that the last one in the list has to be updated at
+        # each release of a new cuda minor version.
+        conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
+        conflicts('%gcc@12:', when='+cuda ^cuda@:11.6')
+        conflicts('%clang@13:', when='+cuda ^cuda@:11.5')
+        conflicts('%clang@14:', when='+cuda ^cuda@:11.6')
 
-    # maximum supported version
-    # NOTE:
-    # in order to not constrain future cuda version to old gcc versions,
-    # it has been decided to use an upper bound for the latest version.
-    # This implies that the last one in the list has to be updated at
-    # each release of a new cuda minor version.
-    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
-    conflicts('%gcc@12:', when='+cuda ^cuda@:11.6')
-    conflicts('%clang@13:', when='+cuda ^cuda@:11.5')
-    conflicts('%clang@14:', when='+cuda ^cuda@:11.6')
+        # https://gist.github.com/ax3l/9489132#gistcomment-3860114
+        conflicts('%gcc@10', when='+cuda ^cuda@:11.4.0')
+        conflicts('%gcc@5:', when='+cuda ^cuda@:7.5 target=x86_64:')
+        conflicts('%gcc@6:', when='+cuda ^cuda@:8 target=x86_64:')
+        conflicts('%gcc@7:', when='+cuda ^cuda@:9.1 target=x86_64:')
+        conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=x86_64:')
+        conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89 target=x86_64:')
+        conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27 target=x86_64:')
+        conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5 target=x86_64:')
+        conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8 target=x86_64:')
+        conflicts('%pgi@:15,18:', when='+cuda ^cuda@9.0:9.1 target=x86_64:')
+        conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10 target=x86_64:')
+        conflicts('%pgi@:17,20:', when='+cuda ^cuda@10.1.105:10.2.89 target=x86_64:')
+        conflicts('%pgi@:17,21:', when='+cuda ^cuda@11.0.2:11.1.0 target=x86_64:')
+        conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5 target=x86_64:')
+        conflicts('%clang@:3.7,4:', when='+cuda ^cuda@8.0:9.0 target=x86_64:')
+        conflicts('%clang@:3.7,4.1:', when='+cuda ^cuda@9.1 target=x86_64:')
+        conflicts('%clang@:3.7,5.1:', when='+cuda ^cuda@9.2 target=x86_64:')
+        conflicts('%clang@:3.7,6.1:', when='+cuda ^cuda@10.0.130 target=x86_64:')
+        conflicts('%clang@:3.7,7.1:', when='+cuda ^cuda@10.1.105 target=x86_64:')
+        conflicts('%clang@:3.7,8.1:',
+                  when='+cuda ^cuda@10.1.105:10.1.243 target=x86_64:')
+        conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89 target=x86_64:')
+        conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=x86_64:')
+        conflicts('%clang@10:', when='+cuda ^cuda@:11.0.3 target=x86_64:')
+        conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=x86_64:')
 
-    # https://gist.github.com/ax3l/9489132#gistcomment-3860114
-    conflicts('%gcc@10', when='+cuda ^cuda@:11.4.0')
-    conflicts('%gcc@5:', when='+cuda ^cuda@:7.5 target=x86_64:')
-    conflicts('%gcc@6:', when='+cuda ^cuda@:8 target=x86_64:')
-    conflicts('%gcc@7:', when='+cuda ^cuda@:9.1 target=x86_64:')
-    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=x86_64:')
-    conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89 target=x86_64:')
-    conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27 target=x86_64:')
-    conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5 target=x86_64:')
-    conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8 target=x86_64:')
-    conflicts('%pgi@:15,18:', when='+cuda ^cuda@9.0:9.1 target=x86_64:')
-    conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10 target=x86_64:')
-    conflicts('%pgi@:17,20:', when='+cuda ^cuda@10.1.105:10.2.89 target=x86_64:')
-    conflicts('%pgi@:17,21:', when='+cuda ^cuda@11.0.2:11.1.0 target=x86_64:')
-    conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5 target=x86_64:')
-    conflicts('%clang@:3.7,4:', when='+cuda ^cuda@8.0:9.0 target=x86_64:')
-    conflicts('%clang@:3.7,4.1:', when='+cuda ^cuda@9.1 target=x86_64:')
-    conflicts('%clang@:3.7,5.1:', when='+cuda ^cuda@9.2 target=x86_64:')
-    conflicts('%clang@:3.7,6.1:', when='+cuda ^cuda@10.0.130 target=x86_64:')
-    conflicts('%clang@:3.7,7.1:', when='+cuda ^cuda@10.1.105 target=x86_64:')
-    conflicts('%clang@:3.7,8.1:',
-              when='+cuda ^cuda@10.1.105:10.1.243 target=x86_64:')
-    conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89 target=x86_64:')
-    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=x86_64:')
-    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.3 target=x86_64:')
-    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=x86_64:')
+        # x86_64 vs. ppc64le differ according to NVidia docs
+        # Linux ppc64le compiler conflicts from Table from the docs below:
+        # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
+        # https://docs.nvidia.com/cuda/archive/9.2/cuda-installation-guide-linux/index.html
+        # https://docs.nvidia.com/cuda/archive/9.1/cuda-installation-guide-linux/index.html
+        # https://docs.nvidia.com/cuda/archive/9.0/cuda-installation-guide-linux/index.html
+        # https://docs.nvidia.com/cuda/archive/8.0/cuda-installation-guide-linux/index.html
 
-    # x86_64 vs. ppc64le differ according to NVidia docs
-    # Linux ppc64le compiler conflicts from Table from the docs below:
-    # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
-    # https://docs.nvidia.com/cuda/archive/9.2/cuda-installation-guide-linux/index.html
-    # https://docs.nvidia.com/cuda/archive/9.1/cuda-installation-guide-linux/index.html
-    # https://docs.nvidia.com/cuda/archive/9.0/cuda-installation-guide-linux/index.html
-    # https://docs.nvidia.com/cuda/archive/8.0/cuda-installation-guide-linux/index.html
+        # information prior to CUDA 9 difficult to find
+        conflicts('%gcc@6:', when='+cuda ^cuda@:9 target=ppc64le:')
+        conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=ppc64le:')
+        conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243 target=ppc64le:')
+        # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
+        conflicts('%pgi', when='+cuda ^cuda@:8 target=ppc64le:')
+        conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185 target=ppc64le:')
+        conflicts('%pgi@:17', when='+cuda ^cuda@:10 target=ppc64le:')
+        conflicts('%clang@4:', when='+cuda ^cuda@:9.0.176 target=ppc64le:')
+        conflicts('%clang@5:', when='+cuda ^cuda@:9.1 target=ppc64le:')
+        conflicts('%clang@6:', when='+cuda ^cuda@:9.2 target=ppc64le:')
+        conflicts('%clang@7:', when='+cuda ^cuda@10.0.130 target=ppc64le:')
+        conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105 target=ppc64le:')
+        conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89 target=ppc64le:')
+        conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=ppc64le:')
+        conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2 target=ppc64le:')
+        conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=ppc64le:')
 
-    # information prior to CUDA 9 difficult to find
-    conflicts('%gcc@6:', when='+cuda ^cuda@:9 target=ppc64le:')
-    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=ppc64le:')
-    conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243 target=ppc64le:')
-    # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
-    conflicts('%pgi', when='+cuda ^cuda@:8 target=ppc64le:')
-    conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185 target=ppc64le:')
-    conflicts('%pgi@:17', when='+cuda ^cuda@:10 target=ppc64le:')
-    conflicts('%clang@4:', when='+cuda ^cuda@:9.0.176 target=ppc64le:')
-    conflicts('%clang@5:', when='+cuda ^cuda@:9.1 target=ppc64le:')
-    conflicts('%clang@6:', when='+cuda ^cuda@:9.2 target=ppc64le:')
-    conflicts('%clang@7:', when='+cuda ^cuda@10.0.130 target=ppc64le:')
-    conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105 target=ppc64le:')
-    conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89 target=ppc64le:')
-    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=ppc64le:')
-    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2 target=ppc64le:')
-    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=ppc64le:')
+        # Intel is mostly relevant for x86_64 Linux, even though it also
+        # exists for Mac OS X. No information prior to CUDA 3.2 or Intel 11.1
+        conflicts('%intel@:11.0', when='+cuda ^cuda@:3.1')
+        conflicts('%intel@:12.0', when='+cuda ^cuda@5.5:')
+        conflicts('%intel@:13.0', when='+cuda ^cuda@6.0:')
+        conflicts('%intel@:13.2', when='+cuda ^cuda@6.5:')
+        conflicts('%intel@:14.9', when='+cuda ^cuda@7:')
+        # Intel 15.x is compatible with CUDA 7 thru current CUDA
+        conflicts('%intel@16.0:', when='+cuda ^cuda@:8.0.43')
+        conflicts('%intel@17.0:', when='+cuda ^cuda@:8.0.60')
+        conflicts('%intel@18.0:', when='+cuda ^cuda@:9.9')
+        conflicts('%intel@19.0:', when='+cuda ^cuda@:10.0')
+        conflicts('%intel@19.1:', when='+cuda ^cuda@:10.1')
+        conflicts('%intel@19.2:', when='+cuda ^cuda@:11.1.0')
 
-    # Intel is mostly relevant for x86_64 Linux, even though it also
-    # exists for Mac OS X. No information prior to CUDA 3.2 or Intel 11.1
-    conflicts('%intel@:11.0', when='+cuda ^cuda@:3.1')
-    conflicts('%intel@:12.0', when='+cuda ^cuda@5.5:')
-    conflicts('%intel@:13.0', when='+cuda ^cuda@6.0:')
-    conflicts('%intel@:13.2', when='+cuda ^cuda@6.5:')
-    conflicts('%intel@:14.9', when='+cuda ^cuda@7:')
-    # Intel 15.x is compatible with CUDA 7 thru current CUDA
-    conflicts('%intel@16.0:', when='+cuda ^cuda@:8.0.43')
-    conflicts('%intel@17.0:', when='+cuda ^cuda@:8.0.60')
-    conflicts('%intel@18.0:', when='+cuda ^cuda@:9.9')
-    conflicts('%intel@19.0:', when='+cuda ^cuda@:10.0')
-    conflicts('%intel@19.1:', when='+cuda ^cuda@:10.1')
-    conflicts('%intel@19.2:', when='+cuda ^cuda@:11.1.0')
+        # XL is mostly relevant for ppc64le Linux
+        conflicts('%xl@:12,14:', when='+cuda ^cuda@:9.1')
+        conflicts('%xl@:12,14:15,17:', when='+cuda ^cuda@9.2')
+        conflicts('%xl@:12,17:', when='+cuda ^cuda@:11.1.0')
 
-    # XL is mostly relevant for ppc64le Linux
-    conflicts('%xl@:12,14:', when='+cuda ^cuda@:9.1')
-    conflicts('%xl@:12,14:15,17:', when='+cuda ^cuda@9.2')
-    conflicts('%xl@:12,17:', when='+cuda ^cuda@:11.1.0')
-
-    # Darwin.
-    # TODO: add missing conflicts for %apple-clang cuda@:10
-    conflicts('platform=darwin', when='+cuda ^cuda@11.0.2: ')
+        # Darwin.
+        # TODO: add missing conflicts for %apple-clang cuda@:10
+        conflicts('platform=darwin', when='+cuda ^cuda@11.0.2: ')
 
     # Make sure cuda_arch can not be used without +cuda
     for value in cuda_arch_values:

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -36,7 +36,8 @@ class CudaPackage(PackageBase):
 
     variant('cuda_arch',
             description='CUDA architecture',
-            values=spack.variant.any_combination_of(*cuda_arch_values))
+            values=spack.variant.any_combination_of(*cuda_arch_values),
+            when='+cuda')
 
     # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-examples
     # https://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code
@@ -105,7 +106,9 @@ class CudaPackage(PackageBase):
         # This implies that the last one in the list has to be updated at
         # each release of a new cuda minor version.
         conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
+        conflicts('%gcc@11:', when='+cuda ^cuda@:11.4.0')
         conflicts('%gcc@12:', when='+cuda ^cuda@:11.6')
+        conflicts('%clang@12:', when='+cuda ^cuda@:11.4.0')
         conflicts('%clang@13:', when='+cuda ^cuda@:11.5')
         conflicts('%clang@14:', when='+cuda ^cuda@:11.6')
 
@@ -185,7 +188,3 @@ class CudaPackage(PackageBase):
         # Darwin.
         # TODO: add missing conflicts for %apple-clang cuda@:10
         conflicts('platform=darwin', when='+cuda ^cuda@11.0.2: ')
-
-    # Make sure cuda_arch can not be used without +cuda
-    for value in cuda_arch_values:
-        conflicts('~cuda', when='cuda_arch=' + value)

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -563,7 +563,9 @@ def variant(
         values=None,
         multi=None,
         validator=None,
-        when=None):
+        when=None,
+        sticky=False
+):
     """Define a variant for the package. Packager can specify a default
     value as well as a text description.
 
@@ -584,7 +586,8 @@ def variant(
             doesn't meet the additional constraints
         when (spack.spec.Spec, bool): optional condition on which the
             variant applies
-
+        sticky (bool): the variant should not be changed by the concretizer to
+            find a valid concrete spec.
     Raises:
         DirectiveError: if arguments passed to the directive are invalid
     """
@@ -658,7 +661,7 @@ def variant(
             when_specs += orig_when
 
         pkg.variants[name] = (spack.variant.Variant(
-            name, default, description, values, multi, validator
+            name, default, description, values, multi, validator, sticky
         ), when_specs)
     return _execute_variant
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -855,6 +855,9 @@ class SpackSolverSetup(object):
             for value in sorted(values):
                 self.gen.fact(fn.variant_possible_value(pkg.name, name, value))
 
+            if variant.sticky:
+                self.gen.fact(fn.variant_sticky(pkg.name, name))
+
             self.gen.newline()
 
         # conflicts

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -403,6 +403,14 @@ variant(Package, Variant) :- variant_condition(ID, Package, Variant),
    build(Package),
    error("Unsatisfied conditional variants cannot take on a variant value").
 
+% if a variant is sticky and not set its value is the default value
+variant_value(Package, Variant, Value) :-
+  variant(Package, Variant),
+  not variant_set(Package, Variant),
+  variant_sticky(Package, Variant),
+  variant_default_value(Package, Variant, Value),
+  build(Package).
+
 % one variant value for single-valued variants.
 1 {
   variant_value(Package, Variant, Value)
@@ -524,6 +532,7 @@ variant_single_value(Package, "dev_path")
 % spec or some package sets it, and without this, clingo will give
 % warnings like 'info: atom does not occur in any rule head'.
 #defined variant/2.
+#defined variant_sticky/2.
 #defined variant_set/3.
 #defined variant_condition/3.
 #defined variant_single_value/2.

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -416,3 +416,13 @@ mpi:
         ):
             s = Spec('somevirtual').concretized()
             assert s.name == 'some-virtual-preferred'
+
+    @pytest.mark.regression('26721,19736')
+    def test_sticky_variant_accounts_for_packages_yaml(self):
+        with spack.config.override(
+                'packages:sticky-variant', {
+                    'variants': '+allow-gcc'
+                }
+        ):
+            s = Spec('sticky-variant %gcc').concretized()
+            assert s.satisfies('%gcc') and s.satisfies('+allow-gcc')

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -42,7 +42,9 @@ class Variant(object):
             description,
             values=(True, False),
             multi=False,
-            validator=None):
+            validator=None,
+            sticky=False
+    ):
         """Initialize a package variant.
 
         Args:
@@ -56,6 +58,8 @@ class Variant(object):
             multi (bool): whether multiple CSV are allowed
             validator (callable): optional callable used to enforce
                 additional logic on the set of values being validated
+            sticky (bool): if true the variant is set to the default value at
+                concretization time
         """
         self.name = name
         self.default = default
@@ -88,6 +92,7 @@ class Variant(object):
 
         self.multi = multi
         self.group_validator = validator
+        self.sticky = sticky
 
     def validate_or_raise(self, vspec, pkg=None):
         """Validate a variant spec against this package variant. Raises an

--- a/var/spack/repos/builtin.mock/packages/sticky-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/sticky-variant/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack import *
+
+
+class StickyVariant(AutotoolsPackage):
+    """Package with a sticky variant and a conflict"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    variant('allow-gcc', description='', default=False, sticky=True)
+
+    conflicts('%gcc', when='~allow-gcc')

--- a/var/spack/repos/builtin.mock/packages/sticky-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/sticky-variant/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -25,6 +25,14 @@ from spack import *
 #    format returned by platform.system() and 'arch' by platform.machine()
 
 _versions = {
+    '11.6.2': {
+        'Linux-aarch64': ('b20c014c6bba36b13c50da167ad42e9bd1cea24f3b6297b495ea129c0889f36e', 'https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux_sbsa.run'),
+        'Linux-x86_64': ('99b7a73dcc52a52cef4c1fceb4a60c3015ac9b6404082c1677d9efdaba1d4593', 'https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run'),
+        'Linux-ppc64le': ('869232ff8dbf295a71609738ac9e1b0079ca75597b427f1c026f42b36896afe8', 'https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux_ppc64le.run')},
+    '11.6.1': {
+        'Linux-aarch64': ('80586b003d58030004d465f5331dc69ee26c95a29516fb2488ff10f034139cb2', 'https://developer.download.nvidia.com/compute/cuda/11.6.1/local_installers/cuda_11.6.1_510.47.03_linux_sbsa.run'),
+        'Linux-x86_64': ('ab219afce00b74200113269866fbff75ead037bcfc23551a8338c2684c984d7e', 'https://developer.download.nvidia.com/compute/cuda/11.6.1/local_installers/cuda_11.6.1_510.47.03_linux.run'),
+        'Linux-ppc64le': ('ef762efbc00b67d572823c6ec338cc2c0cf0c096f41e6bce18e8d4501f260956', 'https://developer.download.nvidia.com/compute/cuda/11.6.1/local_installers/cuda_11.6.1_510.47.03_linux_ppc64le.run')},
     '11.6.0': {
         'Linux-aarch64': ('5898579f5e59b708520883cb161089f5e4f3426158d1e9f973c49d224085d1d2', 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_510.39.01_linux_sbsa.run'),
         'Linux-x86_64': ('1783da6d63970786040980b57fa3cb6420142159fc7d0e66f8f05c4905d98c83', 'https://developer.download.nvidia.com/compute/cuda/11.6.0/local_installers/cuda_11.6.0_510.39.01_linux.run'),
@@ -37,6 +45,14 @@ _versions = {
         'Linux-aarch64': ('6ea9d520cc956cc751a5ac54f4acc39109627f4e614dd0b1a82cc86f2aa7d8c4', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_sbsa.run'),
         'Linux-x86_64': ('ae0a1693d9497cf3d81e6948943e3794636900db71c98d58eefdacaf7f1a1e4c', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run'),
         'Linux-ppc64le': ('95baefdc5adf165189407b119861ffb2e9800fd94d7fc81d10fb81ed36dc12db', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_ppc64le.run')},
+    '11.4.4': {
+        'Linux-aarch64': ('c5c08531e48e8fdc2704fa1c1f7195f2c7edd2ee10a466d0e24d05b77d109435', 'https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux_sbsa.run'),
+        'Linux-x86_64': ('44545a7abb4b66dfc201dcad787b5e8352e5b7ddf3e3cc5b2e9177af419c25c8', 'https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux.run'),
+        'Linux-ppc64le': ('c71cd4e6c05fde11c0485369a73e7f356080e7a18f0e3ad7244e8fc03a9dd3e2', 'https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux_ppc64le.run')},
+    '11.4.3': {
+        'Linux-aarch64': ('e02db34a487ea3de3eec9db80efd09f12eb69d55aca686cecaeae96a9747b1d4', 'https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_linux_sbsa.run'),
+        'Linux-x86_64': ('749183821ffc051e123f12ebdeb171b263d55b86f0dd7c8f23611db1802d6c37', 'https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_linux.run'),
+        'Linux-ppc64le': ('08f29cc3ed0b3b82dd9b007186237be2352bb552f99230c450a25e768f5754ee', 'https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_linux_ppc64le.run')},
     '11.4.2': {
         'Linux-aarch64': ('f2c4a52e06329606c8dfb7c5ea3f4cb4c0b28f9d3fdffeeb734fcc98daf580d8', 'https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux_sbsa.run'),
         'Linux-x86_64': ('bbd87ca0e913f837454a796367473513cddef555082e4d86ed9a38659cc81f0a', 'https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run'),
@@ -107,6 +123,8 @@ _versions = {
         'Linux-x86_64': ('08411d536741075131a1858a68615b8b73c51988e616e83b835e4632eea75eec', 'https://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_linux.run')},
     '6.5.14': {
         'Linux-x86_64': ('f3e527f34f317314fe8fcd8c85f10560729069298c0f73105ba89225db69da48', 'https://developer.download.nvidia.com/compute/cuda/6_5/rel/installers/cuda_6.5.14_linux_64.run')},
+    '6.0.37': {
+        'Linux-x86_64': ('991e436c7a6c94ec67cf44204d136adfef87baa3ded270544fa211179779bc40', '//developer.download.nvidia.com/compute/cuda/6_0/rel/installers/cuda_6.0.37_linux_64.run')},
 }
 
 

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -142,6 +142,8 @@ class Cuda(Package):
     conflicts('arch=darwin-mojave-x86_64')
 
     variant('dev', default=False, description='Enable development dependencies, i.e to use cuda-gdb')
+    variant('allow-unsupported-compilers', default=False, sticky=True,
+            description='Allow unsupported host compiler and CUDA version combinations')
 
     depends_on('libxml2', when='@10.1.243:')
     # cuda-gdb needed libncurses.so.5 before 11.4.0

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -22,6 +22,10 @@ from spack.util.prefix import Prefix
 #  - package key must be in the form '{os}-{arch}' where 'os' is in the
 #    format returned by platform.system() and 'arch' by platform.machine()
 _versions = {
+    '22.3': {
+        'Linux-aarch64': ('e0ea1cbb726556f6879f4b5dfe17238f8e7680c772368577945a85c0e08328f0', 'https://developer.download.nvidia.com/hpc-sdk/22.3/nvhpc_2022_223_Linux_aarch64_cuda_multi.tar.gz'),
+        'Linux-ppc64le': ('5e80db6010adc85fe799dac961ae69e43fdf18d35243666c96a70ecdb80bd280', 'https://developer.download.nvidia.com/hpc-sdk/22.3/nvhpc_2022_223_Linux_ppc64le_cuda_multi.tar.gz'),
+        'Linux-x86_64': ('bc60a6faf2237bf20550718f71079a714563fa85df62c341cb833f70eb2fe7bb', 'https://developer.download.nvidia.com/hpc-sdk/22.3/nvhpc_2022_223_Linux_x86_64_cuda_multi.tar.gz')},
     '22.2': {
         'Linux-aarch64': ('a8241d1139a768d9a0066d1853748160e4098253024e17e997983884d0d33a19', 'https://developer.download.nvidia.com/hpc-sdk/22.2/nvhpc_2022_222_Linux_aarch64_cuda_multi.tar.gz'),
         'Linux-ppc64le': ('f84f72423452968d5bbe02e297f188682c4759864a736a72b32acb3433db3a26', 'https://developer.download.nvidia.com/hpc-sdk/22.2/nvhpc_2022_222_Linux_ppc64le_cuda_multi.tar.gz'),


### PR DESCRIPTION
Cherry-picked https://github.com/spack/spack/pull/28630 and then updated CUDA and NVHPC recipes with upstream develop.