### PR TITLE
Add new versions of morpho-kit.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/morpho-kit/package.py
+++ b/bluebrain/repo-bluebrain/packages/morpho-kit/package.py
@@ -13,13 +13,17 @@ class MorphoKit(CMakePackage):
     git      = "git@bbpgitlab.epfl.ch:hpc/morpho-kit.git"
 
     version('develop', branch='main', submodules=True, get_full_repo=True)
+    version('0.3.3', tag='0.3.3', submodules=True, get_full_repo=True)
     version('0.3.2', tag='v0.3.2', submodules=True, get_full_repo=True)
+    version('0.3.1', tag='v0.3.1', submodules=True, get_full_repo=True)
+    version('0.3.0', tag='v0.3.0', submodules=True, get_full_repo=True)
     version('0.2.0', tag='v0.2.0', submodules=True, get_full_repo=True)
 
     depends_on('cmake@3.2:', type='build')
     depends_on('morphio@2.3.9:')
     depends_on('cli11', when='@0.3.3:')      # for utilities
     depends_on('libsonata', when='@0.3.3:')  # for utilities
+    depends_on('highfive@2.4.0:', when='@0.3.3:')  # for utilities
 
     depends_on('boost', when='@0.2.0')
 


### PR DESCRIPTION
Version 0.3.3 requires the HighFive `2.4.0` or newer.