### PR TITLE
modules: don't autoload as many modules, but include all modifications

### DIFF
--- a/bluebrain/repo-bluebrain/packages/brion/package.py
+++ b/bluebrain/repo-bluebrain/packages/brion/package.py
@@ -93,9 +93,6 @@ class Brion(CMakePackage):
                 if os.path.isdir(pathname):
                     env.prepend_path('PYTHONPATH', pathname)
 
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)
-
     def build(self, spec, prefix):
         with working_dir(self.build_directory):
             ninja()

--- a/bluebrain/repo-bluebrain/packages/py-vascpy/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-vascpy/package.py
@@ -27,6 +27,3 @@ class PyVascpy(PythonPackage):
     depends_on("py-morphio@3.0.0:", type=("build", "run"))
     depends_on("py-libsonata@0.1.8:", type=("build", "run"))
     depends_on("py-click@8.0.0:", type=("build", "run"))
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        env.prepend_path('PATH', self.prefix.bin)

--- a/bluebrain/repo-patches/packages/gdk-pixbuf/package.py
+++ b/bluebrain/repo-patches/packages/gdk-pixbuf/package.py
@@ -69,11 +69,6 @@ class GdkPixbuf(Package):
         env.prepend_path("GI_TYPELIB_PATH",
                          join_path(self.prefix.lib, 'girepository-1.0'))
 
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        env.prepend_path("XDG_DATA_DIRS", self.prefix.share)
-        env.prepend_path("GI_TYPELIB_PATH",
-                         join_path(self.prefix.lib, 'girepository-1.0'))
-
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):
             meson_args = std_meson_args + ['-Dman={0}'.format('+man' in spec)]

--- a/bluebrain/repo-patches/packages/mariadb-c-client/package.py
+++ b/bluebrain/repo-patches/packages/mariadb-c-client/package.py
@@ -1,9 +1,0 @@
-from spack import *
-from spack.pkg.builtin.mariadb_c_client import MariadbCClient as BuiltinMariadbCClient
-
-
-class MariadbCClient(BuiltinMariadbCClient):
-    __doc__ = BuiltinMariadbCClient.__doc__
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        env.prepend_path("LD_LIBRARY_PATH", join_path(self.prefix, "lib/mariadb"))

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -517,7 +517,6 @@ class Neuron(CMakePackage):
             env.set("MPICXX_CXX", self.compiler.cxx)
         if self.spec.satisfies("+python"):
             env.prepend_path("PYTHONPATH", self.spec.prefix.lib.python)
-            env.prepend_path("PYTHONPATH", self.spec.prefix.lib.python)
 
     def setup_dependent_package(self, module, dependent_spec):
         dependent_spec.package.neuron_basedir = self.basedir

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -517,9 +517,6 @@ class Neuron(CMakePackage):
             env.set("MPICXX_CXX", self.compiler.cxx)
         if self.spec.satisfies("+python"):
             env.prepend_path("PYTHONPATH", self.spec.prefix.lib.python)
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        if self.spec.satisfies("+python"):
             env.prepend_path("PYTHONPATH", self.spec.prefix.lib.python)
 
     def setup_dependent_package(self, module, dependent_spec):

--- a/bluebrain/repo-patches/packages/py-jinja2-cli/package.py
+++ b/bluebrain/repo-patches/packages/py-jinja2-cli/package.py
@@ -17,6 +17,3 @@ class PyJinja2Cli(PythonPackage):
     depends_on('py-setuptools', type=('build', 'run'))
 
     depends_on('py-jinja2', type='run')
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        env.prepend_path('PATH', self.prefix.bin)

--- a/bluebrain/repo-patches/packages/py-pyspark/package.py
+++ b/bluebrain/repo-patches/packages/py-pyspark/package.py
@@ -16,7 +16,3 @@ class PyPyspark(BuiltinPyPyspark):
     def setup_run_environment(self, env):
         env.set('PYSPARK_PYTHON', self.spec['python'].command.path)
         env.set('PYSPARK_DRIVER_PYTHON', self.spec['python'].command.path)
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        env.set('PYSPARK_PYTHON', self.spec['python'].command.path)
-        env.set('PYSPARK_DRIVER_PYTHON', self.spec['python'].command.path)

--- a/bluebrain/repo-patches/packages/py-rtree/package.py
+++ b/bluebrain/repo-patches/packages/py-rtree/package.py
@@ -1,8 +1,0 @@
-from spack.pkg.builtin.py_rtree import PyRtree as BuiltinPyRtree
-
-
-class PyRtree(BuiltinPyRtree):
-    __doc__ = BuiltinPyRtree.__doc__
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)

--- a/bluebrain/repo-patches/packages/py-shapely/package.py
+++ b/bluebrain/repo-patches/packages/py-shapely/package.py
@@ -5,6 +5,3 @@ class PyShapely(BuiltinPyShapely):
     __doc__ = BuiltinPyShapely.__doc__
 
     setup_run_environment = BuiltinPyShapely.setup_build_environment
-
-    def setup_dependent_run_environment(self, env, dependent_spec):
-        self.setup_run_environment(env)

--- a/bluebrain/sysconfig/bluebrain5/modules.yaml
+++ b/bluebrain/sysconfig/bluebrain5/modules.yaml
@@ -15,8 +15,7 @@ modules:
     projections:
       all: '{name}/{version}'
     all:
-      autoload: 'all'
-      load_only_generated: true
+      autoload: 'external'
     gcc:
       environment:
         set:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -849,12 +849,7 @@ def _make_runnable(pkg, env):
             env.prepend_path('PATH', bin_dir)
 
 
-def modifications_from_dependencies(
-    spec,
-    context,
-    custom_mods_only=True,
-    exclude_default_mods_for=None
-):
+def modifications_from_dependencies(spec, context, custom_mods_only=True):
     """Returns the environment modifications that are required by
     the dependencies of a spec and also applies modifications
     to this spec's package at module scope, if need be.
@@ -894,9 +889,6 @@ def modifications_from_dependencies(
             "got: {0}".format(context))
 
     env = EnvironmentModifications()
-
-    if not exclude_default_mods_for:
-        exclude_default_mods_for = []
 
     # Note: see computation of 'custom_mod_deps' and 'exe_deps' later in this
     # function; these sets form the building blocks of those collections.
@@ -954,7 +946,7 @@ def modifications_from_dependencies(
         # For callers that want both custom and default modifications, we want
         # to perform the default modifications here (this groups custom
         # and default modifications together on a per-package basis).
-        if not custom_mods_only and dep not in exclude_default_mods_for:
+        if not custom_mods_only:
             default_modifications_for_dep(dep)
 
         # Perform custom modifications here (PrependPath actions performed in

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -849,7 +849,12 @@ def _make_runnable(pkg, env):
             env.prepend_path('PATH', bin_dir)
 
 
-def modifications_from_dependencies(spec, context, custom_mods_only=True):
+def modifications_from_dependencies(
+    spec,
+    context,
+    custom_mods_only=True,
+    exclude_default_mods_for=None
+):
     """Returns the environment modifications that are required by
     the dependencies of a spec and also applies modifications
     to this spec's package at module scope, if need be.
@@ -889,6 +894,9 @@ def modifications_from_dependencies(spec, context, custom_mods_only=True):
             "got: {0}".format(context))
 
     env = EnvironmentModifications()
+
+    if not exclude_default_mods_for:
+        exclude_default_mods_for = []
 
     # Note: see computation of 'custom_mod_deps' and 'exe_deps' later in this
     # function; these sets form the building blocks of those collections.
@@ -946,7 +954,7 @@ def modifications_from_dependencies(spec, context, custom_mods_only=True):
         # For callers that want both custom and default modifications, we want
         # to perform the default modifications here (this groups custom
         # and default modifications together on a per-package basis).
-        if not custom_mods_only:
+        if not custom_mods_only and dep not in exclude_default_mods_for:
             default_modifications_for_dep(dep)
 
         # Perform custom modifications here (PrependPath actions performed in

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -540,7 +540,7 @@ class BaseConfiguration(object):
     @property
     def specs_to_load(self):
         """List of specs that should be loaded in the module file."""
-        return self._create_list_for('autoload', external=True)
+        return self._create_list_for('autoload', external_only=True)
 
     @property
     def literals_to_load(self):
@@ -557,14 +557,17 @@ class BaseConfiguration(object):
         """List of variables that should be left unmodified."""
         return self.conf.get('filter', {}).get('environment_blacklist', {})
 
-    def _create_list_for(self, what, external=False):
+    def _create_list_for(self, what, external_only=False):
         whitelist = []
         for item in self.conf[what]:
             conf = type(self)(item, self.name)
-            if not conf.blacklisted:
-                whitelist.append(item)
-            # Attempt to allow auto-loading for external modules
-            elif external and item.external and item.external_modules:
+            # BlueBrain: regular environment modifications are in the
+            # module themselves, thus one needs to only load external
+            # dependencies
+            if external_only:
+                if item.external and item.external_modules:
+                    whitelist.append(item)
+            elif not conf.blacklisted:
                 whitelist.append(item)
         return whitelist
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -135,7 +135,7 @@ def dependencies(spec, request='all'):
     """
     if request not in ('none', 'direct', 'external', 'all'):
         message = "Wrong value for argument 'request' : "
-        message += "should be one of ('none', 'direct', 'extenral', 'all')"
+        message += "should be one of ('none', 'direct', 'external', 'all')"
         raise tty.error(message + " [current value is '%s']" % request)
 
     if request == 'none':

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -746,12 +746,10 @@ class BaseContext(tengine.Context):
         # First do some setup for all dependencies, then execute
         # modifications
         for dep in set(spec.traverse(root=False, deptype='run')):
-            dpkg = dep.package
-            dpkg.setup_dependent_package(spec.package.module, spec)
+            dep.package.setup_dependent_package(spec.package.module, spec)
         for dep in set(spec.traverse(root=False, deptype='run')):
             if not (dep.external and dep.external_modules):
-                dpkg = dep.package
-                dpkg.setup_run_environment(env)
+                dep.package.setup_run_environment(env)
                 if os.path.isdir(dep.prefix.bin):
                     env.prepend_path('PATH', dep.prefix.bin)
 

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -36,7 +36,9 @@ dictionary_of_strings = {
     'type': 'object', 'patternProperties': {r'\w[\w-]*': {'type': 'string'}}
 }
 
-dependency_selection = {'type': 'string', 'enum': ['none', 'direct', 'all']}
+dependency_selection = {
+    'type': 'string', 'enum': ['none', 'direct', 'external', 'all']
+}
 
 module_file_configuration = {
     'type': 'object',
@@ -62,10 +64,6 @@ module_file_configuration = {
         },
         'autoload': dependency_selection,
         'prerequisites': dependency_selection,
-        'load_only_generated': {
-            'type': 'boolean',
-            'default': False
-        },
         'conflict': array_of_strings,
         'load': array_of_strings,
         'suffixes': {


### PR DESCRIPTION
Upstream Spack generates a module for every package. Thus PATH etc get
modified by autoloaded modules.

We generate only a few modules, leading to PATH containing only the top
level software, but not necessarily all dependencies.

This patch removes a bunch of our modifications to the module
generation where we were accounting for concurrently generated modules,
reducing the diff to upstream.

New modifications make sure that modules are generated with _all_
environment modifications, including PATH, for run dependencies.
External software will still be autoloaded as modules, but not software
within the same "package tree" as the current one.

Hopefully fixes BSD-262, BSD-267.
