### PR TITLE
Build common C++ libraries with multiple compilers.

### DIFF
--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -8,7 +8,7 @@ spack:
         - caliper
         - gmsh
         - hdf5+mpi%gcc@11.2.0
-        - highfive+mpi
+        - highfive+mpi%gcc@11.2.0
         - neuron+mpi~debug%intel
         - omega-h
         - petsc+int64+mpi

--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -7,7 +7,7 @@ spack:
         - boost
         - caliper
         - gmsh
-        - hdf5+mpi
+        - hdf5+mpi%gcc@11.2.0
         - highfive+mpi
         - neuron+mpi~debug%intel
         - omega-h
@@ -30,14 +30,25 @@ spack:
       projections:
         all: '{name}/{version}'
         'omega-h+gmsh': '{name}/{version}-gmsh'
+
+  definitions:
+    - compilers: ['%gcc@11.2.0', '%gcc@9.4.0', 'clang']
   specs:
     - boost+python
     - caliper+cuda cuda_arch=70
     - gmsh+metis+mpi+oce+openmp+shared
     - hdf5+mpi
-    - highfive+mpi
+    - matrix:
+      - [highfive+mpi]
+      - [$compilers]
     - hypre+int64+mpi
+    - matrix:
+      - [libsonata+mpi]
+      - [$compilers]
     - metis+int64
+    - matrix:
+      - [morphio+mpi]
+      - [$compilers]
     - neuron+mpi~debug%intel
     - omega-h+trilinos
     - omega-h+gmsh+trilinos

--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -32,7 +32,7 @@ spack:
         'omega-h+gmsh': '{name}/{version}-gmsh'
 
   definitions:
-    - compilers: ['%gcc@11.2.0', '%gcc@9.4.0', 'clang']
+    - compilers: ['%gcc@11.2.0', '%gcc@9.4.0', '%clang']
   specs:
     - boost+python
     - caliper+cuda cuda_arch=70


### PR DESCRIPTION
In order to speed up CI which checks that the circuit-building tools can be compiled by several compilers, it would be nice to pre-compile some of the dependencies. The common dependencies are `libsonata`, `morphio` and `highfive`. These will now be built with three different compilers. 