### PR TITLE
Fix for py-vascpy package build errors

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-vascpy/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-vascpy/package.py
@@ -11,6 +11,7 @@ class PyVascpy(PythonPackage):
     datasets """
 
     homepage = "https://github.com/BlueBrain/vascpy"
+    git      = "git@github.com:BlueBrain/vascpy.git"
     url      = "https://pypi.io/packages/source/v/vascpy/vascpy-0.1.0.tar.gz"
 
     version("develop", branch="main")


### PR DESCRIPTION
Some of our PRs are failing because `py-vascpy` does not have the `git` URL set appropriately ([see example](https://github.com/BlueBrain/spack/runs/6080484357?check_suite_focus=true#step:8:414)):

```
E           spack.fetch_strategy.FetcherConflict: py-vascpy version 'develop' has extra arguments: 'branch'
E               Valid arguments for a url fetcher are: 
E               'url', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512', and 'checksum'
```

The change here includes the proper URL for Git, so that Spack can checkout `branch=main` accordingly.