### PR TITLE
m4: do not use system version on BB5.

### DIFF
--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -54,11 +54,6 @@ packages:
     externals:
     - spec: libtool@2.4.2
       prefix: /usr
-  m4:
-    version: [1.4.16]
-    externals:
-    - spec: m4@1.4.16
-      prefix: /usr
   node-js:
     version: [14.13.0]
   omega-h:


### PR DESCRIPTION
`m4` is a runtime dependency of `bison`, so `/usr/bin` is added to `PATH` by the `bison` module after https://github.com/BlueBrain/spack/pull/1560.

This is annoying and forces you to be careful about module load order:
```console
[olupton@bbpv2 ~]$ module load unstable bison git
[olupton@bbpv2 ~]$ git --version
git version 2.31.1
[olupton@bbpv2 ~]$ module purge
[olupton@bbpv2 ~]$ module load unstable git bison
[olupton@bbpv2 ~]$ git --version
git version 1.8.3.1
```

Hopefully this lazy fix will be sufficient.