### PR TITLE
[core]neuron: pass -march and -mtune explicitly

### DIFF
--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -184,6 +184,11 @@ class Neuron(CMakePackage):
         # improves ccache performance in CI builds.
         if self.spec.satisfies('@develop'):
             compilation_flags.append('-DNRN_AVOID_ABSOLUTE_PATHS=ON')
+        # Pass Spack's target architecture flags in explicitly so that they're
+        # saved to the nrnivmodl Makefile.
+        compilation_flags.append(
+            self.spec.architecture.target.optimization_flags(self.spec.compiler)
+        )
         compilation_flags = ' '.join(compilation_flags)
         args.append("-DCMAKE_C_FLAGS=" + compilation_flags)
         args.append("-DCMAKE_CXX_FLAGS=" + compilation_flags)


### PR DESCRIPTION
Both NEURON and CoreNEURON try and write the compilation flags used to compile them into Makefiles that are included in their installations.

Spack's wrappers can defeat this by quietly passing extra arguments to the actual compiler. This PR passes some of those extra arguments directly to CMake so they can be saved to the Makefiles. This means that inside the Spack build `-march` and `-mtune` are passed twice.