### PR TITLE
Update TouchDetector recipe for new build system.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/touchdetector/package.py
+++ b/bluebrain/repo-bluebrain/packages/touchdetector/package.py
@@ -90,10 +90,10 @@ class Touchdetector(CMakePackage):
         ]
 
         if self.spec.satisfies('@:5.6.1'):
-             args += [
-                 '-DCMAKE_C_COMPILER={0}'.format(self.spec['mpi'].mpicc),
-                 '-DCMAKE_CXX_COMPILER={0}'.format(self.spec['mpi'].mpicxx),
-             ]
+            args += [
+                '-DCMAKE_C_COMPILER={0}'.format(self.spec['mpi'].mpicc),
+                '-DCMAKE_CXX_COMPILER={0}'.format(self.spec['mpi'].mpicxx),
+            ]
 
         if self.spec.satisfies('@develop'):
             use_tests = self.spec.satisfies('@develop') or '+tests' in self.spec

--- a/bluebrain/repo-bluebrain/packages/touchdetector/package.py
+++ b/bluebrain/repo-bluebrain/packages/touchdetector/package.py
@@ -86,26 +86,28 @@ class Touchdetector(CMakePackage):
 
     def cmake_args(self):
         args = [
-            '-DUSE_OPENMP:BOOL={0}'.format('+openmp' in self.spec),
+            self.define_from_variant('USE_OPENMP', 'openmp'),
         ]
 
         if self.spec.satisfies('@:5.6.1'):
             args += [
-                '-DCMAKE_C_COMPILER={0}'.format(self.spec['mpi'].mpicc),
-                '-DCMAKE_CXX_COMPILER={0}'.format(self.spec['mpi'].mpicxx),
+                self.define('CMAKE_C_COMPILER', self.spec['mpi'].mpicc),
+                self.define('CMAKE_CXX_COMPILER', self.spec['mpi'].mpicxx),
             ]
 
         if self.spec.satisfies('@develop'):
             use_tests = self.spec.satisfies('@develop') or '+tests' in self.spec
             args += [
-                '-DENABLE_CALIPER:BOOL={0}'.format('+caliper' in self.spec),
-                '-DENABLE_ASAN:BOOL={0}'.format('+asan' in self.spec),
-                '-DENABLE_UBSAN:BOOL={0}'.format('+ubsan' in self.spec),
-                '-DENABLE_BENCHMARKS:BOOL={0}'.format('+benchmarks' in self.spec),
-                '-DENABLE_TESTS:BOOL={0}'.format(use_tests),
+                self.define_from_variant('ENABLE_CALIPER', 'caliper'),
+                self.define_from_variant('ENABLE_ASAN', 'asan'),
+                self.define_from_variant('ENABLE_UBSAN', 'ubsan'),
+                self.define_from_variant('ENABLE_BENCHMARKS', 'benchmarks'),
+                self.define('ENABLE_TESTS', use_tests),
             ]
 
             if '+clang-tidy' in self.spec:
-                args += ['-DCMAKE_CXX_CLANG_TIDY=clang-tidy']
+                self.args.append(
+                    self.define('CMAKE_CXX_CLANG_TIDY', 'clang-tidy'),
+                )
 
         return args

--- a/bluebrain/repo-bluebrain/packages/touchdetector/package.py
+++ b/bluebrain/repo-bluebrain/packages/touchdetector/package.py
@@ -39,7 +39,7 @@ class Touchdetector(CMakePackage):
     variant('asan', default=False, description='Enables AdressSanitizer')
     variant('ubsan', default=False, description='Enables UndefinedBehaviourSanitizer')
     variant('clang-tidy', default=False, description='Enables static analysis with clang-tidy')
-    variant('tests', default=False, description='Enables building and running tests')
+    variant('tests', default=False, description='Enables building tests')
     variant('benchmarks', default=False, description='Enables benchmarks')
 
     depends_on('cmake', type='build')

--- a/bluebrain/repo-bluebrain/packages/touchdetector/package.py
+++ b/bluebrain/repo-bluebrain/packages/touchdetector/package.py
@@ -39,7 +39,7 @@ class Touchdetector(CMakePackage):
     variant('asan', default=False, description='Enables AdressSanitizer')
     variant('ubsan', default=False, description='Enables UndefinedBehaviourSanitizer')
     variant('clang-tidy', default=False, description='Enables static analysis with clang-tidy')
-    variant('tests', default=True, description='Enables building and running tests')
+    variant('tests', default=False, description='Enables building and running tests')
     variant('benchmarks', default=False, description='Enables benchmarks')
 
     depends_on('cmake', type='build')
@@ -96,12 +96,13 @@ class Touchdetector(CMakePackage):
              ]
 
         if self.spec.satisfies('@develop'):
+            use_tests = self.spec.satisfies('@develop') or '+tests' in self.spec
             args += [
                 '-DENABLE_CALIPER:BOOL={0}'.format('+caliper' in self.spec),
                 '-DENABLE_ASAN:BOOL={0}'.format('+asan' in self.spec),
                 '-DENABLE_UBSAN:BOOL={0}'.format('+ubsan' in self.spec),
                 '-DENABLE_BENCHMARKS:BOOL={0}'.format('+benchmarks' in self.spec),
-                '-DENABLE_TESTS:BOOL={0}'.format('+tests' in self.spec),
+                '-DENABLE_TESTS:BOOL={0}'.format(use_tests),
             ]
 
             if '+clang-tidy' in self.spec:

--- a/bluebrain/repo-bluebrain/packages/touchdetector/package.py
+++ b/bluebrain/repo-bluebrain/packages/touchdetector/package.py
@@ -39,8 +39,8 @@ class Touchdetector(CMakePackage):
     variant('asan', default=False, description='Enables AdressSanitizer')
     variant('ubsan', default=False, description='Enables UndefinedBehaviourSanitizer')
     variant('clang-tidy', default=False, description='Enables static analysis with clang-tidy')
-    variant('tests', default=False, description='Enables building tests')
-    variant('benchmarks', default=False, description='Enables benchmarks')
+    variant('test', default=False, description='Enables building tests')
+    variant('benchmark', default=False, description='Enables benchmarks')
 
     depends_on('cmake', type='build')
     depends_on('ninja', type='build')
@@ -57,7 +57,7 @@ class Touchdetector(CMakePackage):
     depends_on('nlohmann-json', when='@5.3.3:')
     depends_on('intel-oneapi-tbb', when='@develop')
     depends_on('caliper@master+mpi', when='+caliper@develop')
-    depends_on('benchmark', when='+benchmarks@develop')
+    depends_on('benchmark', when='+benchmark@develop')
 
     depends_on('mvapich2', when='+asan@develop')
     depends_on('mvapich2', when='+ubsan@develop')
@@ -96,12 +96,12 @@ class Touchdetector(CMakePackage):
             ]
 
         if self.spec.satisfies('@develop'):
-            use_tests = self.spec.satisfies('@develop') or '+tests' in self.spec
+            use_tests = self.spec.satisfies('@develop') or '+test' in self.spec
             args += [
                 self.define_from_variant('ENABLE_CALIPER', 'caliper'),
                 self.define_from_variant('ENABLE_ASAN', 'asan'),
                 self.define_from_variant('ENABLE_UBSAN', 'ubsan'),
-                self.define_from_variant('ENABLE_BENCHMARKS', 'benchmarks'),
+                self.define_from_variant('ENABLE_BENCHMARKS', 'benchmark'),
                 self.define('ENABLE_TESTS', use_tests),
             ]
 


### PR DESCRIPTION
TD has a new build system, this PR enables using the new system. It introduces new variants `+asan`, `+ubsan` `+clang-tidy` for the corresponding code-quality tools. Furthermore, `+tests`, `+benchmarks` which enable the tests and benchmarks respectively.

It stops using the MPI wrappers, only because `clang-tidy` doesn't build with the wrappers. Feedback/insight into this change would be very welcome.