### PR TITLE
allow sympy 1.9 and 1.10 in nmodl

### DIFF
--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -47,7 +47,7 @@ class Nmodl(CMakePackage):
     depends_on('python@3.6.0:')
     depends_on('py-jinja2@2.10:')
     depends_on('py-pytest@4.0.0:')
-    depends_on('py-sympy@1.3:1.8')
+    depends_on('py-sympy@1.3:')
     depends_on('py-pyyaml@3.13:')
 
     def cmake_args(self):


### PR DESCRIPTION
nmodl was fixed for sympy 1.9 and 1.10. The limit is not necessary anymore