### PR TITLE
nmodl: avoid submodules

### DIFF
--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -80,8 +80,8 @@ class Nmodl(CMakePackage):
         options = []
 
         if spec.satisfies("@0.3.0.20220531:"):
-            # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from the
-            # Spack dependency graph.
+            # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from
+            # the Spack dependency graph.
             options += [
                 "-DNMODL_3RDPARTY_USE_CATCH2=OFF",
                 "-DNMODL_3RDPARTY_USE_CLI11=OFF",

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -16,8 +16,14 @@ class Nmodl(CMakePackage):
     # 0.3.1 > 0.3.0.20220110 > 0.3.0 > 0.3b > 0.3 to Spack
     version("develop", branch="master", submodules=True)
     version("llvm", branch="llvm", submodules=True)
+    # This is the merge commit of #875, which allows catch2 etc. to be dependencies
+    version("0.3.0.20220531", commit="d63a061ee01b1fd6b14971644bb7fa3efeee20b0")
     # For deployment; nmodl@0.3.0%nvhpc@21.11 doesn't build with eigen/intrinsics errors
-    version("0.3.0.20220110", commit="9e0a6f260ac2e6fad068a39ea3bdf7aa7a6f4ee0")
+    version(
+        "0.3.0.20220110",
+        commit="9e0a6f260ac2e6fad068a39ea3bdf7aa7a6f4ee0",
+        preferred=True,
+    )
     version("0.3.0", tag="0.3")
     version("0.3b", commit="c30ea06", submodules=True)
     version("0.3a", commit="86fc52d", submodules=True)
@@ -38,49 +44,52 @@ class Nmodl(CMakePackage):
 
     conflicts(
         "+llvm",
-        when="@0.2:0.3.0.20220110",
+        when="@0.2:0.3.0.20220531,develop",
         msg="cannot enable LLVM backend outside of llvm version",
     )
     conflicts(
         "+llvm_cuda",
-        when="@0.2:0.3.0.20220110",
+        when="@0.2:0.3.0.20220531,develop",
         msg="cannot enable CUDA LLVM backend outside of llvm version",
     )
 
     # 0.3b includes #270 and #318 so should work with bison 3.6+
     depends_on("bison@3.0:3.4.99", when="@:0.3a", type="build")
     depends_on("bison@3.0.5:", when="@0.3b:", type="build")
-    depends_on("catch2@2")
-    depends_on("cli11")
+    depends_on("catch2@2", when="@0.3.0.20220531:")
+    depends_on("cli11", when="@0.3.0.20220531:")
     depends_on("cmake@3.17.0:", when="@llvm", type="build")
     depends_on("cmake@3.15.0:", when="@0.3.0.20220110:", type="build")
     depends_on("cmake@3.3.0:", when="@:0.3", type="build")
     depends_on("flex@2.6:", type="build")
     # Need +pic when building Python bindings as in that case we link fmt into a shared
     # library
-    depends_on("fmt", when="~python")
-    depends_on("fmt+pic", when="+python")
-    depends_on("nlohmann-json")
+    depends_on("fmt", when="@0.3.0.20220531: ~python")
+    depends_on("fmt+pic", when="@0.3.0.20220531: +python")
+    depends_on("nlohmann-json", when="@0.3.0.20220531:")
     depends_on("python@3.6.0:")
     depends_on("py-jinja2@2.10:")
-    depends_on("py-pybind11")
+    depends_on("py-pybind11", when="@0.3.0.20220531:")
     depends_on("py-pytest@4.0.0:")
     depends_on("py-sympy@1.3:")
     depends_on("py-pyyaml@3.13:")
-    depends_on("spdlog")
+    depends_on("spdlog", when="@0.3.0.20220531:")
 
     def cmake_args(self):
         spec = self.spec
-        # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from the
-        # Spack dependency graph.
-        options = [
-            "-DNMODL_3RDPARTY_USE_CATCH2=OFF",
-            "-DNMODL_3RDPARTY_USE_CLI11=OFF",
-            "-DNMODL_3RDPARTY_USE_FMT=OFF",
-            "-DNMODL_3RDPARTY_USE_JSON=OFF",
-            "-DNMODL_3RDPARTY_USE_PYBIND11=OFF",
-            "-DNMODL_3RDPARTY_USE_SPDLOG=OFF",
-        ]
+        options = []
+
+        if spec.satisfies("@0.3.0.20220531:"):
+            # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from the
+            # Spack dependency graph.
+            options += [
+                "-DNMODL_3RDPARTY_USE_CATCH2=OFF",
+                "-DNMODL_3RDPARTY_USE_CLI11=OFF",
+                "-DNMODL_3RDPARTY_USE_FMT=OFF",
+                "-DNMODL_3RDPARTY_USE_JSON=OFF",
+                "-DNMODL_3RDPARTY_USE_PYBIND11=OFF",
+                "-DNMODL_3RDPARTY_USE_SPDLOG=OFF",
+            ]
 
         if "+python" in spec:
             options.append("-DNMODL_ENABLE_PYTHON_BINDINGS=ON")

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -56,7 +56,8 @@ class Nmodl(CMakePackage):
     depends_on("cmake@3.15.0:", when="@0.3.0.20220110:", type="build")
     depends_on("cmake@3.3.0:", when="@:0.3", type="build")
     depends_on("flex@2.6:", type="build")
-    # Need +pic when building Python bindings as in that case we link fmt into a shared library
+    # Need +pic when building Python bindings as in that case we link fmt into a shared
+    # library
     depends_on("fmt", when="~python")
     depends_on("fmt+pic", when="+python")
     depends_on("nlohmann-json")
@@ -70,7 +71,8 @@ class Nmodl(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from the Spack dependency graph.
+        # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from the
+        # Spack dependency graph.
         options = [
             "-DNMODL_3RDPARTY_USE_CATCH2=OFF",
             "-DNMODL_3RDPARTY_USE_CLI11=OFF",

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -19,11 +19,7 @@ class Nmodl(CMakePackage):
     # This is the merge commit of #875, which allows catch2 etc. to be dependencies
     version("0.3.0.20220531", commit="d63a061ee01b1fd6b14971644bb7fa3efeee20b0")
     # For deployment; nmodl@0.3.0%nvhpc@21.11 doesn't build with eigen/intrinsics errors
-    version(
-        "0.3.0.20220110",
-        commit="9e0a6f260ac2e6fad068a39ea3bdf7aa7a6f4ee0",
-        preferred=True,
-    )
+    version("0.3.0.20220110", commit="9e0a6f260ac2e6fad068a39ea3bdf7aa7a6f4ee0")
     version("0.3.0", tag="0.3")
     version("0.3b", commit="c30ea06", submodules=True)
     version("0.3a", commit="86fc52d", submodules=True)

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -7,85 +7,103 @@ from spack import *
 
 
 class Nmodl(CMakePackage):
-    """Code Generation Framework For NEURON MODeling Language """
+    """Code Generation Framework For NEURON MODeling Language"""
 
     homepage = "https://github.com/BlueBrain/nmodl.git"
-    url      = "https://github.com/BlueBrain/nmodl.git"
-    git      = "https://github.com/BlueBrain/nmodl.git"
+    url = "https://github.com/BlueBrain/nmodl.git"
+    git = "https://github.com/BlueBrain/nmodl.git"
 
     # 0.3.1 > 0.3.0.20220110 > 0.3.0 > 0.3b > 0.3 to Spack
-    version('develop', branch='master', submodules=True)
-    version('llvm', branch='llvm', submodules=True)
+    version("develop", branch="master", submodules=True)
+    version("llvm", branch="llvm", submodules=True)
     # For deployment; nmodl@0.3.0%nvhpc@21.11 doesn't build with eigen/intrinsics errors
-    version('0.3.0.20220110', commit='9e0a6f260ac2e6fad068a39ea3bdf7aa7a6f4ee0')
-    version('0.3.0', tag='0.3')
-    version('0.3b', commit="c30ea06", submodules=True)
-    version('0.3a', commit="86fc52d", submodules=True)
-    version('0.2', tag='0.2', submodules=True)
+    version("0.3.0.20220110", commit="9e0a6f260ac2e6fad068a39ea3bdf7aa7a6f4ee0")
+    version("0.3.0", tag="0.3")
+    version("0.3b", commit="c30ea06", submodules=True)
+    version("0.3a", commit="86fc52d", submodules=True)
+    version("0.2", tag="0.2", submodules=True)
 
     variant("legacy-unit", default=True, description="Enable legacy units")
     variant("python", default=False, description="Enable python bindings")
     variant("llvm", default=False, description="Enable llvm codegen")
-    variant("llvm_cuda", default=False, description="Enable llvm codegen with CUDA backend")
+    variant(
+        "llvm_cuda", default=False, description="Enable llvm codegen with CUDA backend"
+    )
 
     # Build with `ninja` instead of `make`
-    generator = 'Ninja'
-    depends_on('ninja', type='build')
-    depends_on('llvm', when='+llvm')
-    depends_on('cuda', when='+llvm_cuda')
+    generator = "Ninja"
+    depends_on("ninja", type="build")
+    depends_on("llvm", when="+llvm")
+    depends_on("cuda", when="+llvm_cuda")
 
-    conflicts('+llvm', when='@0.2:0.3.0.20220110', msg='cannot enable LLVM backend outside of llvm version')
-    conflicts('+llvm_cuda', when='@0.2:0.3.0.20220110', msg='cannot enable CUDA LLVM backend outside of llvm version')
+    conflicts(
+        "+llvm",
+        when="@0.2:0.3.0.20220110",
+        msg="cannot enable LLVM backend outside of llvm version",
+    )
+    conflicts(
+        "+llvm_cuda",
+        when="@0.2:0.3.0.20220110",
+        msg="cannot enable CUDA LLVM backend outside of llvm version",
+    )
 
     # 0.3b includes #270 and #318 so should work with bison 3.6+
-    depends_on('bison@3.0:3.4.99', when='@:0.3a', type='build')
-    depends_on('bison@3.0.5:', when='@0.3b:', type='build')
-    depends_on('cmake@3.17.0:', when='@llvm', type='build')
-    depends_on('cmake@3.15.0:', when='@0.3.0.20220110:', type='build')
-    depends_on('cmake@3.3.0:', when='@:0.3', type='build')
-    depends_on('flex@2.6:', type='build')
-    depends_on('python@3.6.0:')
-    depends_on('py-jinja2@2.10:')
-    depends_on('py-pytest@4.0.0:')
-    depends_on('py-sympy@1.3:')
-    depends_on('py-pyyaml@3.13:')
+    depends_on("bison@3.0:3.4.99", when="@:0.3a", type="build")
+    depends_on("bison@3.0.5:", when="@0.3b:", type="build")
+    depends_on("catch2@2")
+    depends_on("cli11")
+    depends_on("cmake@3.17.0:", when="@llvm", type="build")
+    depends_on("cmake@3.15.0:", when="@0.3.0.20220110:", type="build")
+    depends_on("cmake@3.3.0:", when="@:0.3", type="build")
+    depends_on("flex@2.6:", type="build")
+    # Need +pic when building Python bindings as in that case we link fmt into a shared library
+    depends_on("fmt", when="~python")
+    depends_on("fmt+pic", when="+python")
+    depends_on("nlohmann-json")
+    depends_on("python@3.6.0:")
+    depends_on("py-jinja2@2.10:")
+    depends_on("py-pybind11")
+    depends_on("py-pytest@4.0.0:")
+    depends_on("py-sympy@1.3:")
+    depends_on("py-pyyaml@3.13:")
+    depends_on("spdlog")
 
     def cmake_args(self):
         spec = self.spec
-        options = []
+        # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from the Spack dependency graph.
+        options = [
+            "-DNMODL_3RDPARTY_USE_CATCH2=OFF",
+            "-DNMODL_3RDPARTY_USE_CLI11=OFF",
+            "-DNMODL_3RDPARTY_USE_FMT=OFF",
+            "-DNMODL_3RDPARTY_USE_JSON=OFF",
+            "-DNMODL_3RDPARTY_USE_PYBIND11=OFF",
+            "-DNMODL_3RDPARTY_USE_SPDLOG=OFF",
+        ]
 
         if "+python" in spec:
-            options.append('-DNMODL_ENABLE_PYTHON_BINDINGS=ON')
+            options.append("-DNMODL_ENABLE_PYTHON_BINDINGS=ON")
         else:
-            options.append('-DNMODL_ENABLE_PYTHON_BINDINGS=OFF')
-
-        # installation with pgi fails when debug symbols are added
-        if '%pgi' in spec:
-            options.append('-DCMAKE_BUILD_TYPE=Release')
-        else:
-            options.append('-DCMAKE_BUILD_TYPE=RelWithDebInfo')
+            options.append("-DNMODL_ENABLE_PYTHON_BINDINGS=OFF")
 
         if "+legacy-unit" in spec:
-            options.append('-DNMODL_ENABLE_LEGACY_UNITS=ON')
+            options.append("-DNMODL_ENABLE_LEGACY_UNITS=ON")
 
         if "+llvm" in spec:
-            options.append('-DNMODL_ENABLE_LLVM=ON')
-        else:
-            options.append('-DNMODL_ENABLE_LLVM=OFF')
+            options.append("-DNMODL_ENABLE_LLVM=ON")
 
         if "+llvm_cuda" in spec:
-            options.append('-DNMODL_ENABLE_LLVM_CUDA=ON')
+            options.append("-DNMODL_ENABLE_LLVM_CUDA=ON")
 
         return options
 
     def setup_build_environment(self, env):
-        if '@:0.3b' in self.spec:
-            env.prepend_path('PYTHONPATH', self.prefix.lib.python)
+        if "@:0.3b" in self.spec:
+            env.prepend_path("PYTHONPATH", self.prefix.lib.python)
         else:
-            env.prepend_path('PYTHONPATH', self.prefix.lib)
+            env.prepend_path("PYTHONPATH", self.prefix.lib)
 
     def setup_run_environment(self, env):
-        if '@:0.3b' in self.spec:
-            env.prepend_path('PYTHONPATH', self.prefix.lib.python)
+        if "@:0.3b" in self.spec:
+            env.prepend_path("PYTHONPATH", self.prefix.lib.python)
         else:
-            env.prepend_path('PYTHONPATH', self.prefix.lib)
+            env.prepend_path("PYTHONPATH", self.prefix.lib)

--- a/bluebrain/repo-bluebrain/packages/touchdetector/package.py
+++ b/bluebrain/repo-bluebrain/packages/touchdetector/package.py
@@ -44,7 +44,7 @@ class Touchdetector(CMakePackage):
 
     depends_on('cmake', type='build')
     depends_on('ninja', type='build')
-    depends_on('catch2', when='@5.0.2:')
+    depends_on('catch2@2', when='@5.0.2:')
     depends_on('eigen', when='@4.5:')
     depends_on('fmt@:5.999', when='@4.5:')
     depends_on('morpho-kit', when='@5.2:')

--- a/var/spack/repos/builtin/packages/catch2/package.py
+++ b/var/spack/repos/builtin/packages/catch2/package.py
@@ -19,8 +19,11 @@ class Catch2(CMakePackage):
     version('develop', branch='devel')
 
     # Releases
+    version('3.0.1',          sha256='8c4173c68ae7da1b5b505194a0c2d6f1b2aef4ec1e3e7463bde451f26bbaf4e7')
+    version('3.0.0-preview4', sha256='2458d47d923b65ab611656cb7669d1810bcc4faa62e4c054a7405b1914cd4aee')
     version('3.0.0-preview3', sha256='06a4f903858f21c553e988f8b76c9c6915d1f95f95512d6a58c421e02a2c4975')
-    version('2.13.7',         sha256='3cdb4138a072e4c0290034fe22d9f0a80d3bcfb8d7a8a5c49ad75d3a5da24fae', preferred=True)
+    version('2.13.8',         sha256='b9b592bd743c09f13ee4bf35fc30eeee2748963184f6bea836b146e6cc2a585a')
+    version('2.13.7',         sha256='3cdb4138a072e4c0290034fe22d9f0a80d3bcfb8d7a8a5c49ad75d3a5da24fae')
     version('2.13.6',         sha256='48dfbb77b9193653e4e72df9633d2e0383b9b625a47060759668480fdf24fbd4')
     version('2.13.5',         sha256='7fee7d643599d10680bfd482799709f14ed282a8b7db82f54ec75ec9af32fa76')
     version('2.13.4',         sha256='e7eb70b3d0ac2ed7dcf14563ad808740c29e628edde99e973adad373a2b5e4df')

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -14,6 +14,8 @@ class Fmt(CMakePackage):
     homepage = "https://fmt.dev/"
     url      = "https://github.com/fmtlib/fmt/releases/download/7.1.3/fmt-7.1.3.zip"
 
+    version('8.1.1', sha256='23778bad8edba12d76e4075da06db591f3b0e3c6c04928ced4a7282ca3400e5d')
+    version('8.1.0', sha256='d8e9f093b2241c3a9fc3895e23231ef9de00c762cfa0a9c65e4748755bc352ae')
     version('8.0.1', sha256='a627a56eab9554fc1e5dd9a623d0768583b3a383ff70a4312ba68f94c9d415bf')
     version('7.1.3', sha256='5d98c504d0205f912e22449ecdea776b78ce0bb096927334f80781e720084c9f')
     version('7.1.2', sha256='4d6968ab7c01e95cc76df136755703defb985105a117b83057e4fd5d53680ea7')

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -25,6 +25,8 @@ class PyPybind11(CMakePackage, PythonPackage):
     maintainers = ['ax3l']
 
     version('master', branch='master')
+    version('2.9.1', sha256='c6160321dc98e6e1184cc791fbeadd2907bb4a0ce0e447f2ea4ff8ab56550913')
+    version('2.9.0', sha256='057fb68dafd972bc13afb855f3b0d8cf0fa1a78ef053e815d9af79be7ff567cb')
     version('2.8.1', sha256='f1bcc07caa568eb312411dde5308b1e250bd0e1bc020fae855bf9f43209940cc')
     version('2.8.0', sha256='9ca7770fc5453b10b00a4a2f99754d7a29af8952330be5f5602e7c2635fa3e79')
     version('2.7.1', sha256='616d1c42e4cf14fa27b2a4ff759d7d7b33006fdc5ad8fd603bb2c22622f27020')
@@ -42,9 +44,12 @@ class PyPybind11(CMakePackage, PythonPackage):
     version('2.1.1', sha256='f2c6874f1ea5b4ad4ffffe352413f7d2cd1a49f9050940805c2a082348621540')
     version('2.1.0', sha256='2860f2b8d0c9f65f0698289a161385f59d099b7ead1bf64e8993c486f2b93ee0')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('ninja', type='build')
+    depends_on('py-setuptools@42:', type='build')
     depends_on('py-pytest', type='test')
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
+    depends_on('cmake@3.13:', type='build')
+    depends_on('cmake@3.18:', type='build', when='@2.6.0:')
 
     # compiler support
     conflicts('%gcc@:4.7')

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -49,15 +49,21 @@ class Spdlog(CMakePackage):
     depends_on('cmake@3.2:', when='@:1.7.0', type='build')
     depends_on('cmake@3.10:', when='@1.8.0:', type='build')
 
+    depends_on('fmt@5.3:')
+    depends_on('fmt@7:', when='@1.7:')
+    depends_on('fmt@8:', when='@1.9:')
+
     def cmake_args(self):
         args = []
 
         if self.spec.version >= Version('1.4.0'):
             args.extend([
                 self.define_from_variant('SPDLOG_BUILD_SHARED', 'shared'),
+                self.define('SPDLOG_FMT_EXTERNAL', 'ON'),
                 # tests and examples
                 self.define('SPDLOG_BUILD_TESTS', self.run_tests),
-                self.define('SPDLOG_BUILD_EXAMPLE', self.run_tests)
+                self.define('SPDLOG_BUILD_EXAMPLE', self.run_tests),
+
             ])
 
         return args


### PR DESCRIPTION
Depend on (and use the external copy of): catch2, cli11, fmt,
nlohmann-json, pybind11, spdlog. Also format the recipe with black.