### PR TITLE
[core]neuron@8.2.0, nmodl@0.4.0

### DIFF
--- a/bluebrain/repo-bluebrain/packages/coreneuron/package.py
+++ b/bluebrain/repo-bluebrain/packages/coreneuron/package.py
@@ -21,6 +21,7 @@ class Coreneuron(CMakePackage):
     git      = "git@bbpgitlab.epfl.ch:hpc/coreneuron.git"
 
     version('develop', branch='master')
+    version('8.2.0', tag='8.2.0')
     # 1.0.1 > 1.0.0.20210519 > 1.0 as far as Spack is concerned
     version('1.0.0.20220304', commit='2d08705')
     version('1.0.0.20220218', commit='102ebde')
@@ -78,6 +79,7 @@ class Coreneuron(CMakePackage):
     depends_on('caliper~mpi', when='@1.0.0.20210519:+caliper~mpi')
 
     # nmodl specific dependency
+    depends_on('nmodl@0.4.0:', when='@8.2:+nmodl')
     depends_on('nmodl@0.3.0:', when='@1.0:+nmodl')
     depends_on('nmodl@0.3b', when='@:0.22+nmodl')
     depends_on('ispc', when='+ispc')

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -16,6 +16,7 @@ class Nmodl(CMakePackage):
     # 0.3.1 > 0.3.0.20220110 > 0.3.0 > 0.3b > 0.3 to Spack
     version("develop", branch="master", submodules=True)
     version("llvm", branch="llvm", submodules=True)
+    version("0.4.0", tag="0.4")
     # This is the merge commit of #875, which allows catch2 etc. to be dependencies
     version("0.3.0.20220531", commit="d63a061ee01b1fd6b14971644bb7fa3efeee20b0")
     # For deployment; nmodl@0.3.0%nvhpc@21.11 doesn't build with eigen/intrinsics errors

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,6 +31,8 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
+    version("8.2.0", tag="8.2.0")
+    version("8.1.0", tag="8.1.0")
     version("8.0.2", tag="8.0.2")
     version("8.0.1", tag="8.0.1")
     version("8.0.0", tag="8.0.0")
@@ -152,7 +154,7 @@ class Neuron(CMakePackage):
             compilation_flags.append('-DR123_USE_INTRIN_H=0')
         # Added in https://github.com/neuronsimulator/nrn/pull/1574, this
         # improves ccache performance in CI builds.
-        if self.spec.satisfies('@develop'):
+        if self.spec.satisfies('@8.2:'):
             compilation_flags.append('-DNRN_AVOID_ABSOLUTE_PATHS=ON')
         # Pass Spack's target architecture flags in explicitly so that they're
         # saved to the nrnivmodl Makefile.


### PR DESCRIPTION
Add new releases of NEURON and CoreNEURON, and a new version of NMODL that is required by the new CoreNEURON version.