### PR TITLE
Add boost version 1.79.0.

### DIFF
--- a/bluebrain/repo-patches/packages/stat/package.py
+++ b/bluebrain/repo-patches/packages/stat/package.py
@@ -8,6 +8,15 @@ class Stat(BuiltinStat):
     # That commit is 4.1.0 + a bunch of fixes, PYTHONPATH handling incuded
     version('4.1.0-2021-12-02', commit='ff48de751f7716133cfb95a912ee8787da9acbeb')
 
+    # We observed that stat won't build against Boost
+    # version 1.79.0. The build error did not make any sense
+    # and we were unable to solve the issue properly.
+    #
+    # The conflicting package was `stat@4.1.0-2021-12-02`.
+    # Banning all versions of `stat` to not have to visit this issue; unless
+    # it's actually needed.
+    conflicts('boost@1.79')
+
     depends_on('py-xdot@1.0', type=('build', 'run'), when='@4.0.1: +gui')
 
     patch('fix-pango.patch', when='@4.1.0:')

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -26,6 +26,7 @@ class Boost(Package):
     maintainers = ['hainest']
 
     version('develop', branch='develop', submodules=True)
+    version('1.79.0', sha256='475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39')
     version('1.78.0', sha256='8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc')
     version('1.77.0', sha256='fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854')
     version('1.76.0', sha256='f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41')


### PR DESCRIPTION
I've copied the line from upstream spack. Version 1.79.0 fixes a bug in `boost::rtree` related to deserialization.