### PR TITLE
Prepare support for SHM file transfer in py-neurodamus

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -48,6 +48,7 @@ class PyNeurodamus(PythonPackage):
     depends_on('py-morphio',       type='run', when='@2.6.0:')
     # Scipy is optional. Latest won't build well %intel, only @1.5.4 will
     depends_on('py-scipy',         type='run', when='+all_deps@2.5.3:')
+    depends_on('py-psutil',        type='run', when='@2.12.0:')
 
     @run_after('install')
     def install_files(self):


### PR DESCRIPTION
The goal of this PR is to allow the SHM file transfer implementation to work due to a required `py-psutil` dependency. We will split the merge into two: one to allow the GitLab MR to be merged, and thereafter to introduce a new version to deploy the changes on BB5.