### PR TITLE
neuron: cleanup variants, fix caliper, add sanitizers.

### DIFF
--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -71,6 +71,7 @@ class Neuron(CMakePackage):
     depends_on('ninja', type='build')
 
     depends_on("bison",     type="build")
+    depends_on("caliper",   type=("build", "run"), when="+caliper")
     depends_on("flex",      type="build")
     depends_on("pkgconfig", type="build")
 

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -47,9 +47,14 @@ class Neuron(CMakePackage):
     variant("mpi",        default=True,  description="Enable MPI parallelism")
     variant("profile",    default=False, description="Enable Tau profiling")
     variant("python",     default=True,  description="Enable python")
-    variant("rx3d",       default=True,  description="Enable cython translated 3-d rxd.")
-    variant("sanitizers", default="None", description="Enable runtime sanitizers",
-                          multi=True,    values=("None", "address", "leak", "undefined"))
+    variant("rx3d", default=True, description="Enable cython translated 3-d rxd.")
+    variant(
+        "sanitizers",
+        default="None",
+        description="Enable runtime sanitizers",
+        multi=True,
+        values=("None", "address", "leak", "undefined"),
+    )
     variant("tests",      default=False, description="Enable unit tests")
     variant("model_tests", default="None", description="Enable detailed model tests included in neuron", multi=True, values=("None", "olfactory", "channel-benchmark", "tqperf-heavy"))
     variant("legacy-unit", default=True,   description="Enable legacy units")
@@ -108,12 +113,16 @@ class Neuron(CMakePackage):
             args.append('-DNRN_ENABLE_MODEL_TESTS=' + ",".join(
                 model for model in self.spec.variants["model_tests"].value))
         if self.spec.variants["sanitizers"].value != ("None",):
-            if self.compiler.name == 'clang':
-                args.append("-DLLVM_SYMBOLIZER_PATH="
-                            + os.path.join(os.path.dirname(self.compiler.cxx),
-                                           "llvm-symbolizer"))
-            args.append("-DNRN_SANITIZERS="
-                        + ",".join(self.spec.variants["sanitizers"].value))
+            if self.compiler.name == "clang":
+                args.append(
+                    "-DLLVM_SYMBOLIZER_PATH="
+                    + os.path.join(
+                        os.path.dirname(self.compiler.cxx), "llvm-symbolizer"
+                    )
+                )
+            args.append(
+                "-DNRN_SANITIZERS=" + ",".join(self.spec.variants["sanitizers"].value)
+            )
         if "+mpi" in self.spec:
             args.append("-DNRN_ENABLE_MPI=ON")
             if "~coreneuron" in self.spec:

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -40,30 +40,17 @@ class Neuron(CMakePackage):
     conflicts("~binary", when='@8.0.999:')
     variant("coreneuron", default=False, description="Enable CoreNEURON support")
     variant("mod-compatibility",  default=True, description="Enable CoreNEURON compatibility for MOD files")
-    variant("cross-compile",  default=False, description="Build for cross-compile environment")
     variant("debug",          default=False, description="Build with flags -g -O0")
     variant("interviews", default=False, description="Enable GUI with INTERVIEWS")
     variant("legacy-fr",  default=True,  description="Use original faraday, R, etc. instead of 2019 nist constants")
     variant("memacs",     default=True,  description="Enable use of memacs")
     variant("mpi",        default=True,  description="Enable MPI parallelism")
-    variant("multisend",  default=True,  description="Enable multi-send spike exchange")
     variant("profile",    default=False, description="Enable Tau profiling")
     variant("python",     default=True,  description="Enable python")
-    variant(
-        "pysetup",
-        default=True,
-        description="Build Python module with setup.py",
-    )
-    variant("rx3d",       default=True,  description="Enable cython translated 3-d rxd. Depends on pysetup")
-    variant("shared",     default=True,  description="Build shared libraries")
+    variant("rx3d",       default=True,  description="Enable cython translated 3-d rxd.")
     variant("tests",      default=False, description="Enable unit tests")
     variant("model_tests", default="None", description="Enable detailed model tests included in neuron", multi=True, values=("None", "olfactory", "channel-benchmark", "tqperf-heavy"))
     variant("legacy-unit", default=True,   description="Enable legacy units")
-
-    variant("codechecks", default=False,
-            description="Perform additional code checks like "
-                        "formatting or static analysis")
-
     variant("caliper", default=False, description="Add LLNL/Caliper support")
 
     # Build with `ninja` instead of `make`
@@ -85,7 +72,6 @@ class Neuron(CMakePackage):
 
     depends_on("mpi",         when="+mpi")
     depends_on("py-mpi4py",   when="+mpi+python+tests")
-    depends_on("ncurses",     when="~cross-compile")
     depends_on("python@2.6:", when="+python", type=("build", "link", "run"))
     depends_on("py-pytest",   when="+python+tests")
     # Numpy is required for Vector.as_numpy()
@@ -98,8 +84,6 @@ class Neuron(CMakePackage):
     depends_on("coreneuron~legacy-unit+caliper", when="+coreneuron~legacy-unit+caliper")
     depends_on("py-pytest-cov", when="+tests@8:")
 
-    conflicts("~shared",  when="+python")
-    conflicts("+pysetup", when="~python")
     conflicts("+rx3d",    when="~python")
 
     # ==============================================

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -48,6 +48,7 @@ class Neuron(CMakePackage):
     variant("profile",    default=False, description="Enable Tau profiling")
     variant("python",     default=True,  description="Enable python")
     variant("rx3d",       default=True,  description="Enable cython translated 3-d rxd.")
+    variant("sanitizers", default="None",description="Enable runtime sanitizers", multi=True, values=("None", "address", "leak", "undefined"))
     variant("tests",      default=False, description="Enable unit tests")
     variant("model_tests", default="None", description="Enable detailed model tests included in neuron", multi=True, values=("None", "olfactory", "channel-benchmark", "tqperf-heavy"))
     variant("legacy-unit", default=True,   description="Enable legacy units")
@@ -105,6 +106,10 @@ class Neuron(CMakePackage):
         if self.spec.variants['model_tests'].value != ("None",):
             args.append('-DNRN_ENABLE_MODEL_TESTS=' + ",".join(
                 model for model in self.spec.variants["model_tests"].value))
+        if self.spec.variants["sanitizers"].value != ("None",):
+            if self.compiler.name == 'clang':
+                args.append("-DLLVM_SYMBOLIZER_PATH=" + os.path.join(os.path.dirname(self.compiler.cxx), 'llvm-symbolizer'))
+            args.append("-DNRN_SANITIZERS=" + ",".join(self.spec.variants["sanitizers"].value))
         if "+mpi" in self.spec:
             args.append("-DNRN_ENABLE_MPI=ON")
             if "~coreneuron" in self.spec:

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -48,7 +48,8 @@ class Neuron(CMakePackage):
     variant("profile",    default=False, description="Enable Tau profiling")
     variant("python",     default=True,  description="Enable python")
     variant("rx3d",       default=True,  description="Enable cython translated 3-d rxd.")
-    variant("sanitizers", default="None",description="Enable runtime sanitizers", multi=True, values=("None", "address", "leak", "undefined"))
+    variant("sanitizers", default="None", description="Enable runtime sanitizers",
+                          multi=True,    values=("None", "address", "leak", "undefined"))
     variant("tests",      default=False, description="Enable unit tests")
     variant("model_tests", default="None", description="Enable detailed model tests included in neuron", multi=True, values=("None", "olfactory", "channel-benchmark", "tqperf-heavy"))
     variant("legacy-unit", default=True,   description="Enable legacy units")
@@ -108,8 +109,11 @@ class Neuron(CMakePackage):
                 model for model in self.spec.variants["model_tests"].value))
         if self.spec.variants["sanitizers"].value != ("None",):
             if self.compiler.name == 'clang':
-                args.append("-DLLVM_SYMBOLIZER_PATH=" + os.path.join(os.path.dirname(self.compiler.cxx), 'llvm-symbolizer'))
-            args.append("-DNRN_SANITIZERS=" + ",".join(self.spec.variants["sanitizers"].value))
+                args.append("-DLLVM_SYMBOLIZER_PATH="
+                            + os.path.join(os.path.dirname(self.compiler.cxx),
+                                           "llvm-symbolizer"))
+            args.append("-DNRN_SANITIZERS="
+                        + ",".join(self.spec.variants["sanitizers"].value))
         if "+mpi" in self.spec:
             args.append("-DNRN_ENABLE_MPI=ON")
             if "~coreneuron" in self.spec:

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -79,6 +79,7 @@ class Neuron(CMakePackage):
 
     depends_on("mpi",         when="+mpi")
     depends_on("py-mpi4py",   when="+mpi+python+tests")
+    depends_on("ncurses")
     depends_on("python@2.6:", when="+python", type=("build", "link", "run"))
     depends_on("py-pytest",   when="+python+tests")
     # Numpy is required for Vector.as_numpy()


### PR DESCRIPTION
- Remove variants that didn't do anything (anymore): `codechecks`, `cross-compile`, `multisend`, `pysetup`, `shared`.
- Depend on `caliper` when the `+caliper` variant is set.
- Add a new `sanitizers` variant for enabling ASan/LSan/UBSan.