### PR TITLE
neurodamus-core: add 3.4.0.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/neurodamus-core/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-core/package.py
@@ -23,6 +23,7 @@ class NeurodamusCore(SimModel):
     git      = "git@bbpgitlab.epfl.ch:hpc/sim/neurodamus-core.git"
 
     version('develop', branch='main', get_full_repo=False)
+    version('3.4.0',  tag='3.4.0', get_full_repo=False)
     version('3.3.4',  tag='3.3.4', get_full_repo=False)
     version('3.3.3',  tag='3.3.3', get_full_repo=False)
     version('3.3.2',  tag='3.3.2', get_full_repo=False)

--- a/bluebrain/repo-bluebrain/packages/neurodamus-hippocampus/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-hippocampus/package.py
@@ -24,4 +24,5 @@ class NeurodamusHippocampus(NeurodamusModel):
     # IMPORTANT: Register new versions only using version_from_model_*
     # Final version name is combined e.g. "1.0-3.0.1"
     version_from_model_ndpy_dep('1.7')
+    version_from_model_ndpy_dep('1.6')
     version_from_model_core_dep('1.5', '3.3.4')

--- a/bluebrain/repo-bluebrain/packages/neurodamus-hippocampus/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-hippocampus/package.py
@@ -23,5 +23,5 @@ class NeurodamusHippocampus(NeurodamusModel):
     version('develop', branch='main', submodules=True, get_full_repo=True)
     # IMPORTANT: Register new versions only using version_from_model_*
     # Final version name is combined e.g. "1.0-3.0.1"
-    version_from_model_ndpy_dep('1.6')
+    version_from_model_ndpy_dep('1.7')
     version_from_model_core_dep('1.5', '3.3.4')

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -57,7 +57,7 @@ class NeurodamusModel(SimModel):
     resource(
         name='common_mods',
         git='git@bbpgitlab.epfl.ch:hpc/sim/models/common.git',
-        commit='face73b63cb2490bd92bb491d4e25d308dea0dde',
+        tag='2.6',
         destination='common_latest'
     )
 

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -57,7 +57,7 @@ class NeurodamusModel(SimModel):
     resource(
         name='common_mods',
         git='git@bbpgitlab.epfl.ch:hpc/sim/models/common.git',
-        tag='2.5',
+        commit='face73b63cb2490bd92bb491d4e25d308dea0dde',
         destination='common_latest'
     )
 

--- a/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
@@ -29,6 +29,7 @@ class NeurodamusNeocortex(NeurodamusModel):
     # IMPORTANT: Register new versions only using version_from_model_*
     # Final version name is combined e.g. "1.0-3.0.1"
     version_from_model_ndpy_dep('1.7')
+    version_from_model_ndpy_dep('1.6')
     version_from_model_core_dep('1.5', '3.3.4')
 
     @run_before('build_model')

--- a/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
@@ -28,7 +28,7 @@ class NeurodamusNeocortex(NeurodamusModel):
     version('develop', branch='main', submodules=True, get_full_repo=True)
     # IMPORTANT: Register new versions only using version_from_model_*
     # Final version name is combined e.g. "1.0-3.0.1"
-    version_from_model_ndpy_dep('1.6')
+    version_from_model_ndpy_dep('1.7')
     version_from_model_core_dep('1.5', '3.3.4')
 
     @run_before('build_model')

--- a/bluebrain/repo-bluebrain/packages/neurodamus-thalamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-thalamus/package.py
@@ -29,7 +29,7 @@ class NeurodamusThalamus(NeurodamusModel):
     resource(
         name="neocortex",
         git="git@bbpgitlab.epfl.ch:hpc/sim/models/neocortex.git",
-        commit="4bc7ba58db83b962ccd80b36bde5d938986f13cc",
+        tag="1.7",
         when="@1.6:",
     )
 

--- a/bluebrain/repo-bluebrain/packages/neurodamus-thalamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-thalamus/package.py
@@ -29,7 +29,7 @@ class NeurodamusThalamus(NeurodamusModel):
     resource(
         name="neocortex",
         git="git@bbpgitlab.epfl.ch:hpc/sim/models/neocortex.git",
-        tag="1.6",
+        commit="4bc7ba58db83b962ccd80b36bde5d938986f13cc",
         when="@1.6:",
     )
 


### PR DESCRIPTION
I believe this is needed for compatibility with NEURON versions including https://github.com/neuronsimulator/nrn/pull/1597.
The changes for compatibility were committed some time ago, but the tags/recipes were never created/updated.