### PR TITLE
SpatialIndex requires MPI.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/spatial-index/package.py
+++ b/bluebrain/repo-bluebrain/packages/spatial-index/package.py
@@ -40,7 +40,8 @@ class SpatialIndex(PythonPackage):
     depends_on("py-numpy-quaternion", type=("build", "run"), when="@0.2.1:")
     depends_on("py-numpy", type=("build", "run"))
 
-    # TODO make these unconditional dependencies once the multi index lands.
+    # TODO Update the `when=*` when releasing a new version
+    # of `spatial-index`.
     depends_on("mpi", type=("build", "run"), when="@develop")
     depends_on("py-mpi4py", type=("build", "run"), when="@develop")
 

--- a/bluebrain/repo-bluebrain/packages/spatial-index/package.py
+++ b/bluebrain/repo-bluebrain/packages/spatial-index/package.py
@@ -40,6 +40,10 @@ class SpatialIndex(PythonPackage):
     depends_on("py-numpy-quaternion", type=("build", "run"), when="@0.2.1:")
     depends_on("py-numpy", type=("build", "run"))
 
+    # TODO make these unconditional dependencies once the multi index lands.
+    depends_on("mpi", type=("build", "run"), when="@develop")
+    depends_on("py-mpi4py", type=("build", "run"), when="@develop")
+
     @run_after('install')
     def install_headers(self):
         install_tree('include', self.prefix.include)


### PR DESCRIPTION
The current development version of SpatialIndex requires MPI. This commit adds both MPI and `mpi4py` as dependencies.