### PR TITLE
Boost 1.79.0 (second attempt)

### DIFF
--- a/bluebrain/repo-bluebrain/packages/touchdetector/package.py
+++ b/bluebrain/repo-bluebrain/packages/touchdetector/package.py
@@ -62,6 +62,11 @@ class Touchdetector(CMakePackage):
     depends_on('mvapich2', when='+asan@develop')
     depends_on('mvapich2', when='+ubsan@develop')
 
+    # Boost 1.79.0 deprecated and broke the includes related to `fs::ofstream`
+    # which is used by TD. See,
+    #    https://www.boost.org/users/history/version_1_79_0.html
+    conflicts('boost@1.79.0', when='@:5.6.1')
+
     # Old dependencies
     depends_on('hpctools~openmp', when='~openmp@:4.4')
     depends_on('hpctools+openmp', when='+openmp@:4.4')

--- a/bluebrain/repo-patches/packages/stat/package.py
+++ b/bluebrain/repo-patches/packages/stat/package.py
@@ -8,6 +8,15 @@ class Stat(BuiltinStat):
     # That commit is 4.1.0 + a bunch of fixes, PYTHONPATH handling incuded
     version('4.1.0-2021-12-02', commit='ff48de751f7716133cfb95a912ee8787da9acbeb')
 
+    # We observed that stat won't build against Boost
+    # version 1.79.0. The build error did not make any sense
+    # and we were unable to solve the issue properly.
+    #
+    # The conflicting package was `stat@4.1.0-2021-12-02`.
+    # Banning all versions of `stat` to not have to visit this issue; unless
+    # it's actually needed.
+    conflicts('boost@1.79')
+
     depends_on('py-xdot@1.0', type=('build', 'run'), when='@4.0.1: +gui')
 
     patch('fix-pango.patch', when='@4.1.0:')

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -26,6 +26,7 @@ class Boost(Package):
     maintainers = ['hainest']
 
     version('develop', branch='develop', submodules=True)
+    version('1.79.0', sha256='475d589d51a7f8b3ba2ba4eda022b170e562ca3b760ee922c146b6c65856ef39')
     version('1.78.0', sha256='8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc')
     version('1.77.0', sha256='fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854')
     version('1.76.0', sha256='f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41')


### PR DESCRIPTION
Since #1611 is failing for very strange reasons, I'm trying a new PR.

This PR bumps Boost to version `1.79.0`. I found the following problems:
- `stat` doesn't build against `1.79.0` since I wasn't able to find the issue I've set every version of `stat` to be in conflict with `1.79.0`.
- `TouchDetector` uses `boost::filesystem::ofstream` which has been deprecated in `1.79.0` and therefore, TD can't be built against this version because Boost decided to no longer include it in the common header. Therefore, all versions prior to `5.7.0` (upcoming) are in conflict with Boost `1.79.0`.