### PR TITLE
Make neurodamus self aware of its versions and auto set LATEST_STABLE

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -12,8 +12,6 @@ class PyNeurodamus(PythonPackage):
     homepage = "https://bbpteam.epfl.ch/project/spaces/display/BGLIB/Neurodamus"
     git      = "git@bbpgitlab.epfl.ch:hpc/sim/neurodamus-py.git"
 
-    LATEST_STABLE = '2.11.3'  # Use for neurodamus-models
-
     version('develop', branch='main', submodules=True)
     version('2.11.3',  tag='2.11.3', submodules=True)
     version('2.11.2',  tag='2.11.2', submodules=True)
@@ -63,3 +61,16 @@ class PyNeurodamus(PythonPackage):
     def setup_run_environment(self, env):
         PythonPackage.setup_run_environment(self, env)
         env.set('NEURODAMUS_PYTHON', self.prefix.share)
+
+    LATEST_STABLE = 'develop'  # Use for neurodamus-models (updated below)
+
+
+# Update LATEST_STABLE
+# Note: Directives are lazyly executed. The `versions` attr is only avail now
+_all_versions = sorted(PyNeurodamus.versions)
+_max_version = None
+if _all_versions:
+    _max_version = _all_versions[-1]
+    if _max_version.isdevelop() and len(_all_versions) > 1:
+        _max_version = _all_versions[-2]
+    PyNeurodamus.LATEST_STABLE = _max_version.string


### PR DESCRIPTION
## The problem

Neurodamus models versions depend on the versions of the underlying core/neurodamus-py e.g. `1.7-2.11.3`
The models were picking up this version from `PyNeurodamus.LATEST_STABLE` variable, manually set, which could lead to people forgetting about updating it.

## This PR

Fixes the problem by inspecting the class attributes and retrieve the latest stable version, if avail.

### Potential regression

When not stable versions are available it will default to "develop". Before it would always point to the manually set stable version, which is however what we are eliminating.
This shouldn't be a problem anymore since CI doesn't rely anymore on patching the recipes to remove the stable versions.