### PR TITLE
Neurodamus: Set Caliper environment by default 

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -40,15 +40,14 @@ spack:
     - nest@2.20.1
     - neurodamus-core~common%intel
     - neurodamus-core+common
-    - neurodamus-hippocampus+coreneuron%intel^coreneuron+caliper
-    - neurodamus-hippocampus+coreneuron%intel^coreneuron+caliper+knl
-    - neurodamus-mousify+coreneuron%intel^coreneuron+caliper
-    - neurodamus-neocortex+coreneuron%intel^coreneuron+caliper
-    - neurodamus-neocortex+coreneuron%intel^coreneuron+caliper+knl
-    - neurodamus-neocortex+coreneuron+plasticity%intel^coreneuron+caliper
-    - neurodamus-neocortex+ngv+metabolism%intel
-    - neurodamus-thalamus+coreneuron%intel^coreneuron+caliper
-    - neurodamus-thalamus+coreneuron%intel^coreneuron+caliper+knl
+    - neurodamus-hippocampus+coreneuron+caliper%intel^coreneuron
+    - neurodamus-hippocampus+coreneuron+caliper%intel^coreneuron+knl
+    - neurodamus-mousify+coreneuron+caliper%intel^coreneuron
+    - neurodamus-neocortex+coreneuron+caliper%intel^coreneuron
+    - neurodamus-neocortex+coreneuron+caliper%intel^coreneuron+knl
+    - neurodamus-neocortex+coreneuron+caliper+plasticity%intel^coreneuron
+    - neurodamus-thalamus+coreneuron+caliper%intel^coreneuron
+    - neurodamus-thalamus+coreneuron+caliper%intel^coreneuron+knl
     - neuron%intel+coreneuron+tests
     - neuron%nvhpc+coreneuron+tests ^coreneuron+gpu~shared
     - neuron%intel+debug

--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -45,7 +45,8 @@ spack:
     - neurodamus-mousify+coreneuron+caliper%intel
     - neurodamus-neocortex+coreneuron+caliper%intel
     - neurodamus-neocortex+coreneuron+caliper%intel^coreneuron+knl
-    - neurodamus-neocortex+coreneuron+caliper+plasticity%intel
+    - neurodamus-neocortex+plasticity+coreneuron+caliper%intel
+    - neurodamus-neocortex+ngv+metabolism+caliper%intel
     - neurodamus-thalamus+coreneuron+caliper%intel
     - neurodamus-thalamus+coreneuron+caliper%intel^coreneuron+knl
     - neuron%intel+coreneuron+tests

--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -40,13 +40,13 @@ spack:
     - nest@2.20.1
     - neurodamus-core~common%intel
     - neurodamus-core+common
-    - neurodamus-hippocampus+coreneuron+caliper%intel^coreneuron
+    - neurodamus-hippocampus+coreneuron+caliper%intel
     - neurodamus-hippocampus+coreneuron+caliper%intel^coreneuron+knl
-    - neurodamus-mousify+coreneuron+caliper%intel^coreneuron
-    - neurodamus-neocortex+coreneuron+caliper%intel^coreneuron
+    - neurodamus-mousify+coreneuron+caliper%intel
+    - neurodamus-neocortex+coreneuron+caliper%intel
     - neurodamus-neocortex+coreneuron+caliper%intel^coreneuron+knl
-    - neurodamus-neocortex+coreneuron+caliper+plasticity%intel^coreneuron
-    - neurodamus-thalamus+coreneuron+caliper%intel^coreneuron
+    - neurodamus-neocortex+coreneuron+caliper+plasticity%intel
+    - neurodamus-thalamus+coreneuron+caliper%intel
     - neurodamus-thalamus+coreneuron+caliper%intel^coreneuron+knl
     - neuron%intel+coreneuron+tests
     - neuron%nvhpc+coreneuron+tests ^coreneuron+gpu~shared

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -237,23 +237,23 @@ class NeurodamusModel(SimModel):
         # ENV variables to enable Caliper with certain settings
         if '+caliper' in self.spec:
             env.set('CORENEURON_CALI_ENABLED', "true")  # Needed for slurm.taskprolog
-            env.set('CALI_CHANNEL_FLUSH_ON_EXIT', "false")
+            env.set('CALI_CHANNEL_FLUSH_ON_EXIT', "true")
             env.set('CALI_MPIREPORT_LOCAL_CONFIG', "SELECT sum(sum#time.duration), \
                                                         inclusive_sum(sum#time.duration) \
                                                     GROUP BY prop:nested")
             env.set('CALI_MPIREPORT_CONFIG',
                     "SELECT annotation, \
                         mpi.function, \
-                        min(sum#sum#time.duration) as 'exclusive_time_rank_min', \
-                        max(sum#sum#time.duration) as 'exclusive_time_rank_max', \
-                        avg(sum#sum#time.duration) as 'exclusive_time_rank_avg', \
-                        min(inclusive#sum#time.duration) AS 'inclusive_time_rank_min', \
-                        max(inclusive#sum#time.duration) AS 'inclusive_time_rank_max', \
-                        avg(inclusive#sum#time.duration) AS 'inclusive_time_rank_avg', \
-                        percent_total(sum#sum#time.duration) AS 'Exclusive time %', \
-                        inclusive_percent_total(sum#sum#time.duration) AS 'Inclusive time %' \
+                        min(sum#sum#time.duration) as \\\"exclusive_time_rank_min\\\", \
+                        max(sum#sum#time.duration) as \\\"exclusive_time_rank_max\\\", \
+                        avg(sum#sum#time.duration) as \\\"exclusive_time_rank_avg\\\", \
+                        min(inclusive#sum#time.duration) AS \\\"inclusive_time_rank_min\\\", \
+                        max(inclusive#sum#time.duration) AS \\\"inclusive_time_rank_max\\\", \
+                        avg(inclusive#sum#time.duration) AS \\\"inclusive_time_rank_avg\\\", \
+                        percent_total(sum#sum#time.duration) AS \\\"Exclusive time %\\\", \
+                        inclusive_percent_total(sum#sum#time.duration) AS \\\"Inclusive time %\\\" \
                     GROUP BY prop:nested FORMAT json")
-            env.set('CALI_SERVICES_ENABLE', "aggregate,event,mpi,mpireport,nvtx,timestamp")
+            env.set('CALI_SERVICES_ENABLE', "aggregate,event,mpi,mpireport,timestamp")
             env.set('CALI_MPI_BLACKLIST',
                     "MPI_Comm_rank,MPI_Comm_size,MPI_Wtick,MPI_Wtime")  # Ignore
 

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -242,19 +242,21 @@ class NeurodamusModel(SimModel):
             env.set('CALI_MPIREPORT_LOCAL_CONFIG', "SELECT sum(sum#time.duration), \
                                                         inclusive_sum(sum#time.duration) \
                                                     GROUP BY prop:nested")
-            env.set('CALI_MPIREPORT_CONFIG', "SELECT annotation, \
-                                                    mpi.function, \
-                                                    min(sum#sum#time.duration) as \"exclusive_time_rank_min\", \
-                                                    max(sum#sum#time.duration) as \"exclusive_time_rank_max\", \
-                                                    avg(sum#sum#time.duration) as \"exclusive_time_rank_avg\", \
-                                                    min(inclusive#sum#time.duration) AS \"inclusive_time_rank_min\", \
-                                                    max(inclusive#sum#time.duration) AS \"inclusive_time_rank_max\", \
-                                                    avg(inclusive#sum#time.duration) AS \"inclusive_time_rank_avg\", \
-                                                    percent_total(sum#sum#time.duration) AS \"Exclusive time %\", \
-                                                    inclusive_percent_total(sum#sum#time.duration) AS \"Inclusive time %\" \
-                                              GROUP BY prop:nested FORMAT json")
+            env.set('CALI_MPIREPORT_CONFIG',
+                    "SELECT annotation, \
+                        mpi.function, \
+                        min(sum#sum#time.duration) as \"exclusive_time_rank_min\", \
+                        max(sum#sum#time.duration) as \"exclusive_time_rank_max\", \
+                        avg(sum#sum#time.duration) as \"exclusive_time_rank_avg\", \
+                        min(inclusive#sum#time.duration) AS \"inclusive_time_rank_min\", \
+                        max(inclusive#sum#time.duration) AS \"inclusive_time_rank_max\", \
+                        avg(inclusive#sum#time.duration) AS \"inclusive_time_rank_avg\", \
+                        percent_total(sum#sum#time.duration) AS \"Exclusive time %\", \
+                        inclusive_percent_total(sum#sum#time.duration) AS \"Inclusive time %\" \
+                    GROUP BY prop:nested FORMAT json")
             env.set('CALI_SERVICES_ENABLE', "aggregate,event,mpi,mpireport,nvtx,timestamp")
-            env.set('CALI_MPI_BLACKLIST', "MPI_Comm_rank,MPI_Comm_size,MPI_Wtick,MPI_Wtime")  # Ignore
+            env.set('CALI_MPI_BLACKLIST',
+                    "MPI_Comm_rank,MPI_Comm_size,MPI_Wtick,MPI_Wtime")  # Ignore
 
 
 _BUILD_NEURODAMUS_TPL = """#!/bin/sh

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -245,14 +245,14 @@ class NeurodamusModel(SimModel):
             env.set('CALI_MPIREPORT_CONFIG',
                     "SELECT annotation, \
                         mpi.function, \
-                        min(sum#sum#time.duration) as \"exclusive_time_rank_min\", \
-                        max(sum#sum#time.duration) as \"exclusive_time_rank_max\", \
-                        avg(sum#sum#time.duration) as \"exclusive_time_rank_avg\", \
-                        min(inclusive#sum#time.duration) AS \"inclusive_time_rank_min\", \
-                        max(inclusive#sum#time.duration) AS \"inclusive_time_rank_max\", \
-                        avg(inclusive#sum#time.duration) AS \"inclusive_time_rank_avg\", \
-                        percent_total(sum#sum#time.duration) AS \"Exclusive time %\", \
-                        inclusive_percent_total(sum#sum#time.duration) AS \"Inclusive time %\" \
+                        min(sum#sum#time.duration) as 'exclusive_time_rank_min', \
+                        max(sum#sum#time.duration) as 'exclusive_time_rank_max', \
+                        avg(sum#sum#time.duration) as 'exclusive_time_rank_avg', \
+                        min(inclusive#sum#time.duration) AS 'inclusive_time_rank_min', \
+                        max(inclusive#sum#time.duration) AS 'inclusive_time_rank_max', \
+                        avg(inclusive#sum#time.duration) AS 'inclusive_time_rank_avg', \
+                        percent_total(sum#sum#time.duration) AS 'Exclusive time %', \
+                        inclusive_percent_total(sum#sum#time.duration) AS 'Inclusive time %' \
                     GROUP BY prop:nested FORMAT json")
             env.set('CALI_SERVICES_ENABLE', "aggregate,event,mpi,mpireport,nvtx,timestamp")
             env.set('CALI_MPI_BLACKLIST',

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -47,9 +47,10 @@ class NeurodamusModel(SimModel):
     """
 
     # NOTE: Several variants / dependencies come from SimModel
-    variant('synapsetool', default=True,  description="Enable SynapseTool reader (for edges)")
-    variant('mvdtool',     default=True,  description="Enable MVDTool reader (for nodes)")
+    variant('synapsetool', default=True,      description="Enable SynapseTool reader (for edges)")
+    variant('mvdtool',     default=True,      description="Enable MVDTool reader (for nodes)")
     variant('common_mods', default='default', description="Source of common mods. '': no change, other string: alternate path")
+    variant('caliper',     default=False,     description="Enable Caliper instrumentation in CoreNEURON")
 
     resource(
         name='common_mods',
@@ -75,6 +76,7 @@ class NeurodamusModel(SimModel):
     depends_on('reportinglib+profile', when='+profile')
     depends_on('synapsetool+mpi', when='+synapsetool')
     depends_on('py-mvdtool+mpi', type='run', when='+mvdtool')
+    depends_on('coreneuron+caliper', when='+caliper')
 
     # NOTE: With Spack chain we no longer require support for external libs.
     # However, in some setups (notably tests) some libraries might still be
@@ -231,6 +233,28 @@ class NeurodamusModel(SimModel):
                 env.set('NRNMECH_LIB_PATH', libnrnmech_name)
             else:
                 env.set('BGLIBPY_MOD_LIBRARY_PATH', libnrnmech_name)
+
+        # ENV variables to enable Caliper with certain settings
+        if '+caliper' in self.spec:
+            env.set('CORENEURON_CALI_ENABLED', "true")  # Needed for slurm.taskprolog
+            env.set('CALI_CHANNEL_FLUSH_ON_EXIT', "false")
+            env.set('CALI_MPIREPORT_FILENAME', "caliper.json")
+            env.set('CALI_MPIREPORT_LOCAL_CONFIG', "SELECT sum(sum#time.duration), \
+                                                        inclusive_sum(sum#time.duration) \
+                                                    GROUP BY prop:nested")
+            env.set('CALI_MPIREPORT_CONFIG', "SELECT annotation, \
+                                                    mpi.function, \
+                                                    min(sum#sum#time.duration) as \"exclusive_time_rank_min\", \
+                                                    max(sum#sum#time.duration) as \"exclusive_time_rank_max\", \
+                                                    avg(sum#sum#time.duration) as \"exclusive_time_rank_avg\", \
+                                                    min(inclusive#sum#time.duration) AS \"inclusive_time_rank_min\", \
+                                                    max(inclusive#sum#time.duration) AS \"inclusive_time_rank_max\", \
+                                                    avg(inclusive#sum#time.duration) AS \"inclusive_time_rank_avg\", \
+                                                    percent_total(sum#sum#time.duration) AS \"Exclusive time %\", \
+                                                    inclusive_percent_total(sum#sum#time.duration) AS \"Inclusive time %\" \
+                                              GROUP BY prop:nested FORMAT json")
+            env.set('CALI_SERVICES_ENABLE', "aggregate,event,mpi,mpireport,nvtx,timestamp")
+            env.set('CALI_MPI_BLACKLIST', "MPI_Comm_rank,MPI_Comm_size,MPI_Wtick,MPI_Wtime")  # Ignore
 
 
 _BUILD_NEURODAMUS_TPL = """#!/bin/sh

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -238,7 +238,6 @@ class NeurodamusModel(SimModel):
         if '+caliper' in self.spec:
             env.set('CORENEURON_CALI_ENABLED', "true")  # Needed for slurm.taskprolog
             env.set('CALI_CHANNEL_FLUSH_ON_EXIT', "false")
-            env.set('CALI_MPIREPORT_FILENAME', "caliper.json")
             env.set('CALI_MPIREPORT_LOCAL_CONFIG', "SELECT sum(sum#time.duration), \
                                                         inclusive_sum(sum#time.duration) \
                                                     GROUP BY prop:nested")

--- a/bluebrain/repo-bluebrain/packages/sim-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/sim-model/package.py
@@ -34,6 +34,7 @@ class SimModel(Package):
 
     variant('coreneuron',  default=False, description="Enable CoreNEURON Support")
     variant('profile',     default=False, description="Enable profiling using Tau")
+    variant('caliper',     default=False, description="Enable Caliper instrumentation")
 
     # neuron/corenrn get linked automatically when using nrnivmodl[-core]
     # Dont duplicate the link dependency (only 'build' and 'run')
@@ -42,6 +43,8 @@ class SimModel(Package):
     depends_on('neuron+profile', when='+profile', type=('build', 'run'))
     depends_on('coreneuron+profile', when='+coreneuron+profile', type=('build', 'run'))
     depends_on('tau', when='+profile')
+    depends_on('neuron+caliper', when='+caliper', type=('build', 'run'))
+    depends_on('coreneuron+caliper', when='+coreneuron+caliper', type=('build', 'run'))
     depends_on('gettext', when='^neuron+binary')
 
     conflicts('^neuron~python', when='+coreneuron')
@@ -219,6 +222,29 @@ class SimModel(Package):
         if os.path.isdir(self.prefix.lib.python):
             env.prepend_path('PYTHONPATH', self.prefix.lib.python)
         env.set('{}_ROOT'.format(self.name.upper().replace("-", "_")), self.prefix)
+
+        # ENV variables to enable Caliper with certain settings
+        if '+caliper' in self.spec:
+            env.set('NEURODAMUS_CALI_ENABLED', "true")  # Needed for slurm.taskprolog
+            env.set('CALI_CHANNEL_FLUSH_ON_EXIT', "true")
+            env.set('CALI_MPIREPORT_LOCAL_CONFIG', "SELECT sum(sum#time.duration), \
+                                                        inclusive_sum(sum#time.duration) \
+                                                    GROUP BY prop:nested")
+            env.set('CALI_MPIREPORT_CONFIG',
+                    "SELECT annotation, \
+                        mpi.function, \
+                        min(sum#sum#time.duration) as exclusive_time_rank_min, \
+                        max(sum#sum#time.duration) as exclusive_time_rank_max, \
+                        avg(sum#sum#time.duration) as exclusive_time_rank_avg, \
+                        min(inclusive#sum#time.duration) AS inclusive_time_rank_min, \
+                        max(inclusive#sum#time.duration) AS inclusive_time_rank_max, \
+                        avg(inclusive#sum#time.duration) AS inclusive_time_rank_avg, \
+                        percent_total(sum#sum#time.duration) AS exclusive_time_pct, \
+                        inclusive_percent_total(sum#sum#time.duration) AS inclusive_time_pct \
+                    GROUP BY prop:nested FORMAT json")
+            env.set('CALI_SERVICES_ENABLE', "aggregate,event,mpi,mpireport,timestamp")
+            env.set('CALI_MPI_BLACKLIST',
+                    "MPI_Comm_rank,MPI_Comm_size,MPI_Wtick,MPI_Wtime")  # Ignore
 
     def setup_build_environment(self, env):
         self._setup_build_environment_common(env)

--- a/bluebrain/repo-bluebrain/packages/sim-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/sim-model/package.py
@@ -226,6 +226,7 @@ class SimModel(Package):
         # ENV variables to enable Caliper with certain settings
         if '+caliper' in self.spec:
             env.set('NEURODAMUS_CALI_ENABLED', "true")  # Needed for slurm.taskprolog
+            env.set('CALI_MPIREPORT_FILENAME', "/dev/null")  # Prevents 'stdout' output
             env.set('CALI_CHANNEL_FLUSH_ON_EXIT', "true")
             env.set('CALI_MPIREPORT_LOCAL_CONFIG', "SELECT sum(sum#time.duration), \
                                                         inclusive_sum(sum#time.duration) \


### PR DESCRIPTION
The idea behind this PR is to configure the Caliper environment for Neurodamus simulations. The `+caliper` variant allows us to enable Caliper in all the modules that depend on it (e.g., `neurodamus-hippocampus`, `neurodamus-neocortex`, and so on). We then configure the runtime environment to set the Caliper ENV variables after loading the module.

Changes into the `taskprolog` / `taskepilog` / `epilog` scripts of SLURM have been necessary to support this feature on BB5.

### Important
The output of Caliper is going to be ignored unless:

1. You define a different `CALI_MPIREPORT_FILENAME`.
2. You let the default and let BB5 set a filename for you, in which case the Caliper output will be stored in projXX.