### PR TITLE
Added tqdm as dependency on SpatialIndex

### DIFF
--- a/bluebrain/repo-bluebrain/packages/spatial-index/package.py
+++ b/bluebrain/repo-bluebrain/packages/spatial-index/package.py
@@ -41,6 +41,7 @@ class SpatialIndex(PythonPackage):
     depends_on("py-mvdtool~mpi", type=("build", "run"))
     depends_on("py-numpy-quaternion", type=("build", "run"), when="@0.2.1:")
     depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-tqdm", when="@0.5.3:")
 
     depends_on("boost@1.79.0:", when="@0.5.2:")
     depends_on("mpi", when="@0.5.2:")


### PR DESCRIPTION
Simple MR to add `tqdm` to the dependencies for new versions of `spatial_index`.