### PR TITLE
force ~shared so we don't deploy coreneuron@develop

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -48,7 +48,7 @@ spack:
     - neurodamus-thalamus+coreneuron%intel^coreneuron+caliper
     - neurodamus-thalamus+coreneuron%intel^coreneuron+caliper+knl
     - neuron%intel+coreneuron+tests
-    - neuron%nvhpc+coreneuron+tests ^coreneuron+gpu
+    - neuron%nvhpc+coreneuron+tests ^coreneuron+gpu~shared
     - neuron%intel+debug
     - nmodl
     - parquet-converters


### PR DESCRIPTION
https://github.com/BlueBrain/spack/pull/1646 accidentally led to `coreneuron@develop` being deployed, which was a mistake and leads to various unintended consequences.

This is because we request `coreneuron+gpu`, and `+shared` is set by default, but `+gpu+shared` conflicts with versions older than `develop`.

cc: @pramodk @matz-e 