### PR TITLE
(py-)libsonata: rely on PyPI rather than Git for releases

### DIFF
--- a/bluebrain/repo-bluebrain/packages/libsonata/package.py
+++ b/bluebrain/repo-bluebrain/packages/libsonata/package.py
@@ -15,13 +15,14 @@ class Libsonata(CMakePackage):
     """
     homepage = "https://github.com/BlueBrain/libsonata"
     git = "https://github.com/BlueBrain/libsonata.git"
+    url = "https://pypi.io/packages/source/l/libsonata/libsonata-0.1.14.tar.gz"
 
-    version('develop', branch='master', submodules=False, get_full_repo=True)
-    version('0.1.14', tag='v0.1.14', submodules=False, get_full_repo=True)
-    version('0.1.13', tag='v0.1.13', submodules=False, get_full_repo=True)
-    version('0.1.12', tag='v0.1.12', submodules=False, get_full_repo=True)
-    version('0.1.11', tag='v0.1.11', submodules=False, get_full_repo=True)
-    version('0.1.10', tag='v0.1.10', submodules=False, get_full_repo=True)
+    version('develop', branch='master')
+    version('0.1.14', sha256='a5c75df1c3ef6fac10d92fb6781643e0834e5c35debe77693686dab8bfcf221f')
+    version('0.1.13', sha256='8263938e49b501c477f626b4c25e0c74e91152268830c69aabc96eeb263c6eea')
+    version('0.1.12', sha256='f0fa0f3b129d28e41b337ce2c39c3604990752de8e485327ec9df3bf0360e9c1')
+    version('0.1.11', sha256='95f302818971fec3f19ef18febd5c31c580490692138c8e4fe3534104d88b5e0')
+    version('0.1.10', sha256='7ef9f911f7ea31da5ff5306d8372ec194d223850aede0878ac2a921ce049bbb2')
 
     variant('mpi', default=True, description="Enable MPI backend")
 

--- a/bluebrain/repo-bluebrain/packages/py-libsonata/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-libsonata/package.py
@@ -11,15 +11,16 @@ class PyLibsonata(PythonPackage):
 
     homepage = "https://github.com/BlueBrain/libsonata"
     git = "https://github.com/BlueBrain/libsonata.git"
+    pypi = "libsonata/libsonata-0.1.14.tar.gz"
 
     submodules = True
 
     version('develop', branch='master')
-    version('0.1.14', tag='v0.1.14')
-    version('0.1.13', tag='v0.1.13')
-    version('0.1.12', tag='v0.1.12')
-    version('0.1.11', tag='v0.1.11')
-    version('0.1.10', tag='v0.1.10')
+    version('0.1.14', sha256='a5c75df1c3ef6fac10d92fb6781643e0834e5c35debe77693686dab8bfcf221f')
+    version('0.1.13', sha256='8263938e49b501c477f626b4c25e0c74e91152268830c69aabc96eeb263c6eea')
+    version('0.1.12', sha256='f0fa0f3b129d28e41b337ce2c39c3604990752de8e485327ec9df3bf0360e9c1')
+    version('0.1.11', sha256='95f302818971fec3f19ef18febd5c31c580490692138c8e4fe3534104d88b5e0')
+    version('0.1.10', sha256='7ef9f911f7ea31da5ff5306d8372ec194d223850aede0878ac2a921ce049bbb2')
 
     depends_on('cmake@3.3:', type='build')
     depends_on('hdf5')


### PR DESCRIPTION
Saves us some trouble patching the Git archive caching, which does not
take differing submodule settings into account.  The PyPI tarballs also
preserve the necessary git information.
