### PR TITLE
julia: remove customization

### DIFF
--- a/bluebrain/repo-patches/packages/julia/package.py
+++ b/bluebrain/repo-patches/packages/julia/package.py
@@ -1,8 +1,0 @@
-from spack.pkg.builtin.julia import Julia as BuiltinJulia
-
-
-class Julia(BuiltinJulia):
-    __doc__ = BuiltinJulia.__doc__
-
-    def setup_run_environment(self, env):
-        env.prepend_path("LD_LIBRARY_PATH", self.prefix.lib.julia)


### PR DESCRIPTION
Setting LD_LIBRARY_PATH to a path with heavily vendored libraries breaks
all kinds of things. Don't hand users a loaded gun pointing at their
foot.
