### PR TITLE
Make pylibsonata build when dependencies bring MPI

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-libsonata/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-libsonata/package.py
@@ -31,4 +31,5 @@ class PyLibsonata(PythonPackage):
     depends_on('py-numpy@1.17:', type=('build', 'run'))
     depends_on('py-setuptools', type='build', when='@0.1:')
     depends_on('py-setuptools-scm', type='build', when='@0.1:')
-    depends_on('mpi', when='^hdf5+mpi')
+    # Needed on Mac/clang
+    depends_on('mpi', when='^hdf5+mpi platform=darwin')

--- a/bluebrain/repo-bluebrain/packages/py-libsonata/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-libsonata/package.py
@@ -31,3 +31,4 @@ class PyLibsonata(PythonPackage):
     depends_on('py-numpy@1.17:', type=('build', 'run'))
     depends_on('py-setuptools', type='build', when='@0.1:')
     depends_on('py-setuptools-scm', type='build', when='@0.1:')
+    depends_on('mpi', when='^hdf5+mpi')


### PR DESCRIPTION
This is likely a nuance between systems, but on Mac+clang this is required to build py-libsonata in an mpi-enabled stack

```
* **Spack:** 0.17.1
* **Python:** 3.9.13
* **Platform:** darwin-catalina-cannonlake
* **Concretizer:** clingo
```