### PR TITLE
neurodamus: add support for on-line LFP calculations (HPE-MPI v2.22.hmpt)

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -5,7 +5,6 @@ spack:
     tcl:
       whitelist:
         - asciitoh5
-        - model-neocortex
         - nest
         - neurodamus-core
         - neurodamus-hippocampus
@@ -35,7 +34,6 @@ spack:
     - coreneuron%intel+tests+nmodl+sympy
     - coreneuron%nvhpc+tests+gpu+openmp
     - coreneuron%nvhpc+tests+gpu+openmp+nmodl+sympy
-    - model-neocortex%intel
     - nest@2.20.1
     - neurodamus-core~common%intel
     - neurodamus-core+common

--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -109,7 +109,7 @@ spack:
     - help2man
     - hpctoolkit
     - hpcviewer
-    - hpe-mpi@2.25.hmpt
+    - hpe-mpi@2.22.hmpt
     - intel-mkl
     # Leads to issues down the line, where it is preferred over hpe-mpi
     # #providers

--- a/bluebrain/repo-bluebrain/packages/coreneuron/package.py
+++ b/bluebrain/repo-bluebrain/packages/coreneuron/package.py
@@ -16,12 +16,12 @@ class Coreneuron(CMakePackage):
     and optimal performance."""
 
     homepage = "https://github.com/BlueBrain/CoreNeuron"
-    url      = "https://github.com/BlueBrain/CoreNeuron"
+    url = "https://github.com/BlueBrain/CoreNeuron"
     # This simplifies testing the gitlab-pipelines repository:
-    git      = "git@bbpgitlab.epfl.ch:hpc/coreneuron.git"
+    git = "git@bbpgitlab.epfl.ch:hpc/coreneuron.git"
 
     version('develop', branch='master')
-    version('8.2.1.2022.03.10_lfp', branch='sandbox/jblanco/lfp')
+    version('8.2.1.2022.03.10_lfp', commit='e5b42505e38fac181676904a4899753ce9d85893')
     version('8.2.1_lfp', branch='sandbox/jblanco/lfp')
     version('8.2.1', tag='8.2.1')
     version('8.2.0', tag='8.2.0')

--- a/bluebrain/repo-bluebrain/packages/coreneuron/package.py
+++ b/bluebrain/repo-bluebrain/packages/coreneuron/package.py
@@ -21,6 +21,7 @@ class Coreneuron(CMakePackage):
     git      = "git@bbpgitlab.epfl.ch:hpc/coreneuron.git"
 
     version('develop', branch='master')
+    version('8.2.1.2022.03.10_lfp', branch='sandbox/jblanco/lfp')
     version('8.2.1_lfp', branch='sandbox/jblanco/lfp')
     version('8.2.1', tag='8.2.1')
     version('8.2.0', tag='8.2.0')

--- a/bluebrain/repo-bluebrain/packages/coreneuron/package.py
+++ b/bluebrain/repo-bluebrain/packages/coreneuron/package.py
@@ -28,7 +28,7 @@ class Coreneuron(CMakePackage):
     version('1.0', tag='1.0')
     version('0.22', tag='0.22', submodules=True)
 
-    variant('gpu', default=False, description="Enable GPU build")
+    variant('gpu', default=False, description="Enable GPU build") 
     variant('unified', default=False, description="Enable Unified Memory with GPU build")
     variant('knl', default=False, description="Enable KNL specific flags")
     variant('mpi', default=True, description="Enable MPI support")

--- a/bluebrain/repo-bluebrain/packages/coreneuron/package.py
+++ b/bluebrain/repo-bluebrain/packages/coreneuron/package.py
@@ -21,6 +21,7 @@ class Coreneuron(CMakePackage):
     git      = "git@bbpgitlab.epfl.ch:hpc/coreneuron.git"
 
     version('develop', branch='master')
+    version('8.2.1_lfp', branch='sandbox/jblanco/lfp')
     version('8.2.1', tag='8.2.1')
     version('8.2.0', tag='8.2.0')
     # 1.0.1 > 1.0.0.20220304 > 1.0 as far as Spack is concerned
@@ -28,7 +29,7 @@ class Coreneuron(CMakePackage):
     version('1.0', tag='1.0')
     version('0.22', tag='0.22', submodules=True)
 
-    variant('gpu', default=False, description="Enable GPU build") 
+    variant('gpu', default=False, description="Enable GPU build")
     variant('unified', default=False, description="Enable Unified Memory with GPU build")
     variant('knl', default=False, description="Enable KNL specific flags")
     variant('mpi', default=True, description="Enable MPI support")

--- a/bluebrain/repo-bluebrain/packages/libsonata-report/package.py
+++ b/bluebrain/repo-bluebrain/packages/libsonata-report/package.py
@@ -17,6 +17,7 @@ class LibsonataReport(CMakePackage):
     git = "https://github.com/BlueBrain/libsonatareport.git"
 
     version('develop', branch='master', submodules=False, get_full_repo=True)
+    version('1.1.1_lfp', branch='sandbox/jblanco/lfp', submodules=False)
     version('1.1.1', tag='1.1.1', submodules=False)
     version('1.1', tag='1.1', submodules=False)
     version('1.0.0.20220218', commit='905641', submodules=False)

--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "git@bbpgitlab.epfl.ch:hpc/sim/neurodamus-py.git"
 
     version('develop', branch='main', submodules=True)
+    version('2.12.3.2022.03.10_lfp', branch='sandbox/jblanco/lfp', submodules=True)
     version('2.12.3_lfp', branch='sandbox/jblanco/lfp', submodules=True)
     version('2.12.3',  tag='2.12.3', submodules=True)
     version('2.12.2',  tag='2.12.2', submodules=True)

--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git      = "git@bbpgitlab.epfl.ch:hpc/sim/neurodamus-py.git"
 
     version('develop', branch='main', submodules=True)
+    version('2.12.3_lfp', branch='sandbox/jblanco/lfp', submodules=True)
     version('2.12.3',  tag='2.12.3', submodules=True)
     version('2.12.2',  tag='2.12.2', submodules=True)
     version('2.12.1',  tag='2.12.1', submodules=True)

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,6 +31,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
+    version("8.2.1.2022.03.10_lfp", branch="sandbox/jblanco/lfp")
     version("8.2.1_lfp", branch="sandbox/jblanco/lfp")
     version("8.2.1", tag="8.2.1")
     version("8.2.0", tag="8.2.0")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,7 +31,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
-    version("8.2.1.2022.03.10_lfp", branch="sandbox/jblanco/lfp")
+    version("8.2.1.2022.03.10_lfp", commit="10ee643a9d40237a491121b62cb108c3dcb8af29")
     version("8.2.1_lfp", branch="sandbox/jblanco/lfp")
     version("8.2.1", tag="8.2.1")
     version("8.2.0", tag="8.2.0")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,6 +31,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
+    version("8.2.1_lfp", branch="sandbox/jblanco/lfp")
     version("8.2.1", tag="8.2.1")
     version("8.2.0", tag="8.2.0")
     version("8.1.0", tag="8.1.0")


### PR DESCRIPTION
This Draft PR is created to test the On-line LFP changes of #1657 with HPE-MPI v2.22.hmpt to fix a memory issue due to a potential regression in HPE-MPI v2.25.hmpt that is under investigation.