### PR TITLE
neurondamus: properly add py-neurondamus as a run dependency.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -36,7 +36,7 @@ def version_from_model_ndpy_dep(model_v, ndamus_v=PYNEURODAMUS_DEFAULT_V):
     """
     this_version = model_v + "-" + ndamus_v  # e.g. 1.1-3.0.2
     version(this_version, tag=model_v, submodules=True, get_full_repo=True)
-    depends_on('py-neurodamus@' + ndamus_v, type='build',
+    depends_on('py-neurodamus@' + ndamus_v, type=('build', 'run'),
                when='@' + this_version)
 
 
@@ -60,8 +60,9 @@ class NeurodamusModel(SimModel):
 
     # Now we depend on neurodamus-py
     # However don't depend on it at runtime just yet, we still want to use
-    # use neurodamus-py from GCC stack for compat with other py libs (bglibpy)
-    depends_on('py-neurodamus@develop', type='build', when='@develop')
+    # use neurodamus-py from GCC stack for compatibility with other Python
+    # libs (bglibpy)
+    depends_on('py-neurodamus@develop', type=('build', 'run'), when='@develop')
 
     # Note: We dont request link to MPI so that mpicc can do what is best
     # and dont rpath it so we stay dynamic.


### PR DESCRIPTION
Also curtail unnecessary shortspeak and spell out words that shan't be
abbreviated.
