### PR TITLE
node-js: remove version pin.

### DIFF
--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -59,8 +59,6 @@ packages:
     externals:
     - spec: m4@1.4.16
       prefix: /usr
-  node-js:
-    version: [14.13.0]
   omega-h:
     variants: +trilinos
   opencv:


### PR DESCRIPTION
I have no recollection any longer why this was required.