### PR TITLE
Update py-neurodamus and NEURON version

### DIFF
--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -54,7 +54,7 @@ class NeurodamusModel(SimModel):
     resource(
         name='common_mods',
         git='ssh://git@bbpgitlab.epfl.ch/hpc/sim/models/common.git',
-        tag='2.6.1',
+        branch='magkanar/clear_rngs',
         destination='common_latest'
     )
 

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -54,7 +54,7 @@ class NeurodamusModel(SimModel):
     resource(
         name='common_mods',
         git='ssh://git@bbpgitlab.epfl.ch/hpc/sim/models/common.git',
-        branch='magkanar/clear_rngs',
+        tag='2.6.2',
         destination='common_latest'
     )
 

--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -13,7 +13,7 @@ class PyNeurodamus(PythonPackage):
     git = "ssh://git@bbpgitlab.epfl.ch/hpc/sim/neurodamus-py.git"
 
     version('develop', branch='main', submodules=True)
-    version('2.12.9',  branch='magkanar/clear_model', submodules=True)
+    version('2.12.9',  tag='2.12.9', submodules=True)
     version('2.12.8',  tag='2.12.8', submodules=True)
     version('2.12.7',  tag='2.12.7', submodules=True)
     version('2.12.6',  tag='2.12.6', submodules=True)

--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git = "ssh://git@bbpgitlab.epfl.ch/hpc/sim/neurodamus-py.git"
 
     version('develop', branch='main', submodules=True)
+    version('2.12.9',  branch='magkanar/clear_model', submodules=True)
     version('2.12.8',  tag='2.12.8', submodules=True)
     version('2.12.7',  tag='2.12.7', submodules=True)
     version('2.12.6',  tag='2.12.6', submodules=True)

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,6 +31,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
+    version("8.2.2a", commit="eb19ae0")
     version("8.2.1", tag="8.2.1")
     version("8.2.0", tag="8.2.0")
     version("8.1.0", tag="8.1.0")


### PR DESCRIPTION
- Update `py-neurodamus` version with improvements in model clean up
- Use new `common` tag with improvements in synapse freeing
- Update `neuron` version with updates on version `8.2.1` related to model cleanup