### PR TITLE
Fix bug in build_neurodamus.sh script for neurodamus modules

### DIFF
--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -131,7 +131,7 @@ class NeurodamusModel(SimModel):
                     mod_fil = core_prefix.lib.mod.join(aux_mod.strip())
                     if os.path.isfile(mod_fil):
                         shutil.copy(mod_fil, 'mod_core')
-                        core_nrn_mods.add(aux_mod)
+                        core_nrn_mods.add(aux_mod.strip())
             with working_dir(core_prefix.lib.mod):
                 all_mods = set(f for f in os.listdir() if f.endswith(".mod"))
             with open(join_path('mod', 'neuron_only_mods.txt'), 'w') as blackl:


### PR DESCRIPTION
  * list of additional mod files are read from file and those contain trailing newline char
  * comparison done between two list was returning undesired list of mod files due to leading newline char