### PR TITLE
Patch pagebuffer check in `H5Fopen`.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/hdf5/package.py
+++ b/bluebrain/repo-bluebrain/packages/hdf5/package.py
@@ -1,0 +1,15 @@
+from spack.package import *
+from spack.pkg.builtin.hdf5 import Hdf5 as BuiltinHdf5
+
+
+class Hdf5(BuiltinHdf5):
+    __doc__ = BuiltinHdf5.__doc__
+
+    variant('page_buffer_patch', default=False, when="@1.12.1",
+            description='Enable the page buffer in parallel HDF5.')
+
+    # Modifies the check that page buffering is incompatible with parallel
+    # HDF5. The issue is that it should also work with the parallel version
+    # of the library, but only if one doesn't ask for MPI-IO.
+    patch('page-buffer-check-on-file-open_v1.12.1.patch', when="@1.12.1+page_buffer_patch+mpi",
+          sha256="379c30fab7abb88e95d6e65c318baaeb3f7443290ad3fab4cfc5bcaa9a3f0a25")

--- a/bluebrain/repo-bluebrain/packages/hdf5/page-buffer-check-on-file-open_v1.12.1.patch
+++ b/bluebrain/repo-bluebrain/packages/hdf5/page-buffer-check-on-file-open_v1.12.1.patch
@@ -1,0 +1,18 @@
+diff --git i/src/H5Fint.c w/src/H5Fint.c
+index a8039b2e85..504d75ede2 100644
+--- i/src/H5Fint.c
++++ w/src/H5Fint.c
+@@ -1946,8 +1946,11 @@ H5F_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id)
+             HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL,
+                         "collective metadata writes are not supported with page buffering")
+ 
+-        /* Temporary: fail file create when page buffering feature is enabled for parallel */
+-        HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "page buffering is disabled for parallel")
++        /* The pagebuffer isn't compatible with MPI-IO. */
++        if (H5Pget_driver(fapl_id) == H5FD_MPIO)
++            HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL,
++                        "MPIO is not supported with page buffering")
++
+ #endif /* H5_HAVE_PARALLEL */
+         /* Query for other page buffer cache properties */
+         if (H5P_get(a_plist, H5F_ACS_PAGE_BUFFER_MIN_META_PERC_NAME, &page_buf_min_meta_perc) < 0)


### PR DESCRIPTION
The pagebuffer should be compatible with pHDF5, as long as one doesn't use MPIO. This commit allows one request patching HDF5 to weaThe pagebuffer should be compatible with pHDF5, as long as one doesn't use MPIO. This commit allows one request patching HDF5 to weaken the check. The variant is called `+page_buffer_patch`.
    
This is only supported for HDF5 `v1.12.1`. It's used in the context of reading morphologies from single-file HDF5 morphology containers. One application that requires this is TD. The variant is called `+page_buffer_patch`.