### PR TITLE
Use HTTPS not SSH for Ultraliser.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/ultraliser/package.py
+++ b/bluebrain/repo-bluebrain/packages/ultraliser/package.py
@@ -10,9 +10,10 @@ class Ultraliser(CMakePackage):
     """Mesh and volume reconstruction of neuroscientific models
     """
     homepage = "https://github.com/BlueBrain/Ultraliser"
-    git = "git@github.com:BlueBrain/Ultraliser.git"
+    git = "https://github.com/BlueBrain/Ultraliser.git"
 
-    version('0.3.0', tag='v0.3.0')
+    version('develop', branch="master")
+    version('0.3.0', tag="v0.3.0")
 
     depends_on('libtiff')
     depends_on('ilmbase')


### PR DESCRIPTION
Switches the URL to use HTTPS to checkout the git repository, not SSH. Also adds a target `'develop'`.