### PR TITLE
Deploy upcoming 9.0a release

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -37,7 +37,6 @@ spack:
     - neuron%nvhpc+coreneuron+tests+gpu
     - neuron%nvhpc+tests+gpu+openmp+coreneuron
     - neuron%nvhpc+tests+gpu+openmp+nmodl+sympy+coreneuron
-    - model-neocortex%intel
     - nest@2.20.1
     - neurodamus-core~common%intel
     - neurodamus-core+common

--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -26,7 +26,7 @@ spack:
         - unit-test-translator
       projections:
         all: '{name}/{version}'
-        +knl: '{name}-knl/{version}'
+        ^neuron+knl: '{name}-knl/{version}'
         +common: '{name}/{version}-commonmods'
         +plasticity: '{name}-plasticity/{version}'
         +ngv+metabolism: '{name}-multiscale/{version}'

--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -26,31 +26,30 @@ spack:
         - unit-test-translator
       projections:
         all: '{name}/{version}'
-        ^coreneuron+knl: '{name}-knl/{version}'
+        +knl: '{name}-knl/{version}'
         +common: '{name}/{version}-commonmods'
         +plasticity: '{name}-plasticity/{version}'
         +ngv+metabolism: '{name}-multiscale/{version}'
   specs:
     - asciitoh5@1.0
-    - coreneuron%intel+tests
-    - coreneuron%intel+tests+nmodl+sympy
-    - coreneuron%nvhpc+tests+gpu+openmp
-    - coreneuron%nvhpc+tests+gpu+openmp+nmodl+sympy
+    - neuron%intel+tests+coreneuron
+    - neuron%intel+tests+nmodl+sympy+coreneuron
+    - neuron%nvhpc+coreneuron+tests+gpu
+    - neuron%nvhpc+tests+gpu+openmp+coreneuron
+    - neuron%nvhpc+tests+gpu+openmp+nmodl+sympy+coreneuron
     - model-neocortex%intel
     - nest@2.20.1
     - neurodamus-core~common%intel
     - neurodamus-core+common
     - neurodamus-hippocampus+coreneuron+caliper%intel
-    - neurodamus-hippocampus+coreneuron+caliper%intel^coreneuron+knl
+    - neurodamus-hippocampus+coreneuron+caliper%intel^neuron+knl
     - neurodamus-mousify+coreneuron+caliper%intel
     - neurodamus-neocortex+coreneuron+caliper%intel
-    - neurodamus-neocortex+coreneuron+caliper%intel^coreneuron+knl
+    - neurodamus-neocortex+coreneuron+caliper%intel^neuron+knl
     - neurodamus-neocortex+plasticity+coreneuron+caliper%intel
     - neurodamus-neocortex+ngv+metabolism+caliper%intel
     - neurodamus-thalamus+coreneuron+caliper%intel
-    - neurodamus-thalamus+coreneuron+caliper%intel^coreneuron+knl
-    - neuron%intel+coreneuron+tests
-    - neuron%nvhpc+coreneuron+tests ^coreneuron+gpu~shared
+    - neurodamus-thalamus+coreneuron+caliper%intel^neuron+knl
     - neuron%intel+debug
     - nmodl
     - parquet-converters

--- a/bluebrain/repo-bluebrain/packages/model-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/model-neocortex/package.py
@@ -16,7 +16,8 @@ class ModelNeocortex(SimModel):
     homepage = "https://bbpgitlab.epfl.ch/hpc/sim/models/neocortex"
     git      = "ssh://git@bbpgitlab.epfl.ch/hpc/sim/models/neocortex.git"
 
-    version('develop', branch='master', submodules=True, clean=False)
+    version('develop', branch='main', submodules=True, clean=False)
+    version('1.9', tag='1.9', submodules=True, clean=False)
     version('1.1', tag='1.1', submodules=True, clean=False)
     version('0.3', tag='0.3-1', submodules=True, clean=False)
     version('0.2', tag='0.2', submodules=True, clean=False)

--- a/bluebrain/repo-bluebrain/packages/model-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/model-neocortex/package.py
@@ -14,7 +14,7 @@ class ModelNeocortex(SimModel):
     """
 
     homepage = "https://bbpgitlab.epfl.ch/hpc/sim/models/neocortex"
-    git      = "ssh://git@bbpgitlab.epfl.ch/hpc/sim/models/neocortex.git"
+    git = "ssh://git@bbpgitlab.epfl.ch/hpc/sim/models/neocortex.git"
 
     version('develop', branch='main', submodules=True, clean=False)
     version('1.9', tag='1.9', submodules=True, clean=False)

--- a/bluebrain/repo-bluebrain/packages/model-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/model-neocortex/package.py
@@ -17,6 +17,7 @@ class ModelNeocortex(SimModel):
     git = "ssh://git@bbpgitlab.epfl.ch/hpc/sim/models/neocortex.git"
 
     version('develop', branch='main', submodules=True, clean=False)
+    version('1.10', tag='1.10', submodules=True, clean=False)
     version('1.9', tag='1.9', submodules=True, clean=False)
     version('1.1', tag='1.1', submodules=True, clean=False)
     version('0.3', tag='0.3-1', submodules=True, clean=False)

--- a/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
@@ -34,7 +34,7 @@ class NeurodamusNeocortex(NeurodamusModel):
 
     # IMPORTANT: Register new versions only using version_from_model_*
     # Final version name is combined e.g. "1.0-3.0.1"
-    version_from_model_ndpy_dep('1.10a')
+    version_from_model_ndpy_dep('1.10')
     version_from_model_ndpy_dep('1.9')
     version_from_model_ndpy_dep('1.8')
     version_from_model_ndpy_dep('1.7')

--- a/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
@@ -34,6 +34,7 @@ class NeurodamusNeocortex(NeurodamusModel):
 
     # IMPORTANT: Register new versions only using version_from_model_*
     # Final version name is combined e.g. "1.0-3.0.1"
+    version_from_model_ndpy_dep('1.10a')
     version_from_model_ndpy_dep('1.9')
     version_from_model_ndpy_dep('1.8')
     version_from_model_ndpy_dep('1.7')

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -16,6 +16,7 @@ class Nmodl(CMakePackage):
     # 0.3.1 > 0.3.0.20220110 > 0.3.0 > 0.3b > 0.3 to Spack
     version("develop", branch="master", submodules=True)
     version("llvm", branch="llvm", submodules=True)
+    version("0.5.a", commit="94cba1c")
     version("0.4.0", tag="0.4")
     # This is the merge commit of #875, which allows catch2 etc. to be dependencies
     version("0.3.0.20220531", commit="d63a061ee01b1fd6b14971644bb7fa3efeee20b0")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -269,7 +269,7 @@ class Neuron(CMakePackage):
             args.extend(options)
 
         if self.spec.satisfies("@:8.99+coreneuron"):
-            args.extend(["-DCORENEURON_DIR={}".format(self.spec["coreneuron"].prefix)])
+            args.append(self.define("CORENEURON_DIR", self.spec["coreneuron"].prefix))
 
         return args
 

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -267,7 +267,7 @@ class Neuron(CMakePackage):
                 options.append('-DCORENRN_ENABLE_GPU=ON')
 
             args.extend(options)
-        
+
         if self.spec.satisfies("@:8.99+coreneuron"):
             args.extend(["-DCORENEURON_DIR={}".format(self.spec["coreneuron"].prefix)])
 

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,7 +31,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
-    version("9.a1", commit="b3c4b4f")
+    version("9.0.a1", commit="b3c4b4f")
     version("8.2.2a", commit="eb19ae0")
     version("8.2.1", tag="8.2.1")
     version("8.2.0", tag="8.2.0")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,6 +31,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
+    version("9.a1", commit="b3c4b4f")
     version("8.2.2a", commit="eb19ae0")
     version("8.2.1", tag="8.2.1")
     version("8.2.0", tag="8.2.0")
@@ -65,6 +66,7 @@ class Neuron(CMakePackage):
 
     # extra variants from coreneuron recipe
     variant('gpu', default=False, description="Enable GPU build")
+    variant('knl', default=False, description="Enable KNL specific flags")
     variant('unified', default=False, description="Enable Unified Memory with GPU build")
     variant('openmp', default=False, description="Enable OpenMP support")
     variant('report', default=True, description="Enable SONATA and binary reports")
@@ -183,6 +185,10 @@ class Neuron(CMakePackage):
             compilation_flags += ['-g', '-O0']
             # Remove default flags (RelWithDebInfo etc.)
             args.append("-DCMAKE_BUILD_TYPE=Custom")
+
+        if "%intel" in self.spec and "+knl" in self.spec:
+            compilation_flags.append('-xMIC-AVX512')
+
         if "+mod-compatibility" in self.spec:
             args.append("-DNRN_ENABLE_MOD_COMPATIBILITY:BOOL=ON")
         if "+binary" in self.spec and '@:8.0.999' in self.spec:

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -267,6 +267,9 @@ class Neuron(CMakePackage):
                 options.append('-DCORENRN_ENABLE_GPU=ON')
 
             args.extend(options)
+        
+        if self.spec.satisfies("@:8.99+coreneuron"):
+            args.extend(["-DCORENEURON_DIR={}".format(self.spec["coreneuron"].prefix)])
 
         return args
 


### PR DESCRIPTION
Also add knl variant in order to enable deployment of KNL modules. We will remove this variant when CMake of NEURON handles cross-compiling aspects where nocmodl should be compiled without ARCH specific optimization flags.

- [x] Merge PR and add new neocortex tag from: https://bbpgitlab.epfl.ch/hpc/sim/models/neocortex/-/merge_requests/12