### PR TITLE
Make HighFive patchable to allow PageBuffer in pHDF5.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/brion/package.py
+++ b/bluebrain/repo-bluebrain/packages/brion/package.py
@@ -48,7 +48,8 @@ class Brion(CMakePackage):
     # TODO: bzip2 is a dependency of boost. Needed here because of linking
     # issue (libboost_iostreams.so.1.68.0 not finding libbz2.so)
     depends_on('bzip2')
-    depends_on('highfive@2.3.1 +boost', when='@3.3.8:')
+    depends_on('highfive +boost', when='@3.3.9:')
+    depends_on('highfive@2.3.1 +boost', when='@3.3.8')
     depends_on('highfive@2.2.2 +boost', when='@3.3.2:3.3.7')
     depends_on('highfive@2.2.1 +boost', when='@:3.3.1')
     depends_on('mvdtool')

--- a/bluebrain/repo-bluebrain/packages/morpho-kit/package.py
+++ b/bluebrain/repo-bluebrain/packages/morpho-kit/package.py
@@ -31,8 +31,7 @@ class MorphoKit(CMakePackage):
     # The HighFive update is needed for paged HDF5 features. Unfortunately, the
     # page buffer is artificially unsupported in pHDF5. Hence, we depend on a
     # particular, patched version of HDF5.
-    depends_on('highfive@2.6.0:', when='@0.3.5:')
-    depends_on('hdf5@1.12.1:+page_buffer_patch', when='@0.3.5:')
+    depends_on('highfive@2.6.2: +mpi+page_buffer_patch', when='@0.3.5:')
 
     # MPI is needed for the morphology merger.
     depends_on('mpi', when='@0.3.5:')

--- a/bluebrain/repo-patches/packages/highfive/package.py
+++ b/bluebrain/repo-patches/packages/highfive/package.py
@@ -41,16 +41,27 @@ class Highfive(CMakePackage):
     variant('mpi', default=True,  description='Support MPI')
     variant('eigen', default=False, description='Support Eigen')
     variant('xtensor', default=False, description='Support xtensor')
+    variant('page_buffer_patch', default=False, when="@2.6.2",
+            description='Allow using the pagebuffer with pHDF5.')
 
     # Develop builds tests which require boost
     conflicts('~boost', when='@develop')
 
     depends_on('boost @1.41: +serialization+system', when='+boost')
     depends_on('hdf5 ~mpi', when='~mpi')
-    depends_on('hdf5 +mpi', when='+mpi')
+    depends_on('hdf5 +mpi', when='+mpi~page_buffer_patch')
+
+    # Using the page buffer with pHDF5 requires HDF5 to be patched. This
+    # patch is currently only available for one version.
+    depends_on('hdf5@1.12.1 +page_buffer_patch+mpi', when='+mpi+page_buffer_patch')
+
     depends_on('eigen', when='+eigen')
     depends_on('xtensor', when='+xtensor')
     depends_on('mpi', when='+mpi')
+
+    # Enables the `PageBufferSize` property list also when building against pHDF5.
+    patch('remove-page-buffer-phdf5-check_v2.6.2.patch', when="+page_buffer_patch+mpi",
+          sha256="72a74f603bc957a9069c8e20abe28f303c4cab36d5d0e23bdcd6c6636fefe1f0")
 
     def cmake_args(self):
         return [

--- a/bluebrain/repo-patches/packages/highfive/remove-page-buffer-phdf5-check_v2.6.2.patch
+++ b/bluebrain/repo-patches/packages/highfive/remove-page-buffer-phdf5-check_v2.6.2.patch
@@ -1,0 +1,47 @@
+diff --git i/deps/catch2 w/deps/catch2
+index 182c910..216713a 160000
+--- i/deps/catch2
++++ w/deps/catch2
+@@ -1 +1 @@
+-Subproject commit 182c910b4b63ff587a3440e08f84f70497e49a81
++Subproject commit 216713a4066b79d9803d374f261ccb30c0fb451f
+diff --git i/include/highfive/H5PropertyList.hpp w/include/highfive/H5PropertyList.hpp
+index 916e903..b3848f7 100644
+--- i/include/highfive/H5PropertyList.hpp
++++ w/include/highfive/H5PropertyList.hpp
+@@ -327,7 +327,6 @@ class FileSpacePageSize {
+     hsize_t _page_size;
+ };
+ 
+-#ifndef H5_HAVE_PARALLEL
+ /// \brief Set size of the page buffer.
+ ///
+ /// Please, consult the upstream documentation of
+@@ -360,7 +359,6 @@ class PageBufferSize {
+     unsigned _min_raw;
+ };
+ #endif
+-#endif
+ 
+ /// \brief Set hints as to how many links to expect and their average length
+ ///
+diff --git i/include/highfive/bits/H5PropertyList_misc.hpp w/include/highfive/bits/H5PropertyList_misc.hpp
+index a41707a..dcbba05 100644
+--- i/include/highfive/bits/H5PropertyList_misc.hpp
++++ w/include/highfive/bits/H5PropertyList_misc.hpp
+@@ -110,7 +110,6 @@ inline void FileSpacePageSize::apply(const hid_t list) const {
+     }
+ }
+ 
+-#ifndef H5_HAVE_PARALLEL
+ inline PageBufferSize::PageBufferSize(size_t page_buffer_size,
+                                       unsigned min_meta_percent,
+                                       unsigned min_raw_percent)
+@@ -124,7 +123,6 @@ inline void PageBufferSize::apply(const hid_t list) const {
+     }
+ }
+ #endif
+-#endif
+ 
+ #ifdef H5_HAVE_PARALLEL
+ 


### PR DESCRIPTION
Since unpatched pHDF5 and the page buffer are incompatible, HighFive uses an compile time guard for `PageBufferSize` when it detects that pHDF5 is used.

Therefore, this adds the patch required to remove those guards when patching HDF5. Then the MorphoKit recipe is updated to use the patched version of HighFive.

In a new spack environment, `morpho-kit@master` builds on its branch that adds the page buffered reading, with the new recipe for `morpho-kit`.