### PR TITLE
Explicitly pin neuron version when mixing gcc and intel compilers

### DIFF
--- a/bluebrain/deployment/environments/applications_nse.yaml
+++ b/bluebrain/deployment/environments/applications_nse.yaml
@@ -52,7 +52,7 @@ spack:
     - emsim
     - gene-expression-volume
     - placement-algorithm
-    - psp-validation%gcc ^neuron%intel
+    - psp-validation%gcc ^neuron@8.2.2a%intel
     - py-archngv
     - py-atlas-building-tools
     - py-bbp-analysis-framework
@@ -62,10 +62,10 @@ spack:
     - py-bluepysnap
     - py-currentscape
     - py-entity-management
-    - py-minis-validation%gcc ^neuron%intel
+    - py-minis-validation%gcc ^neuron@8.2.2a%intel
     - py-morphio
     - py-morphology-repair-workflow
-    - py-morph-tool%gcc ^neuron%intel
+    - py-morph-tool%gcc ^neuron@8.2.2a%intel
     - py-region-grower
-    - py-sonata-network-reduction%gcc ^neuron%intel^py-ipython%gcc
+    - py-sonata-network-reduction%gcc ^neuron@8.2.2a%intel^py-ipython%gcc
     - regiodesics

--- a/bluebrain/deployment/environments/applications_science.yaml
+++ b/bluebrain/deployment/environments/applications_science.yaml
@@ -48,11 +48,11 @@ spack:
     - py-atlinter
     - py-bba-datafetch
     - py-bba-webexporter
-    - py-bglibpy%gcc ^py-bluepy%gcc ^neuron%intel
+    - py-bglibpy%gcc ^py-bluepy%gcc ^neuron@8.2.2a%intel
     - py-bluepyefe
     - py-bluepyemodel
-    - py-bluepymm%gcc ^neuron%intel
-    - py-bluepyopt%gcc ^neuron%intel
+    - py-bluepymm%gcc ^neuron@8.2.2a%intel
+    - py-bluepyopt%gcc ^neuron@8.2.2a%intel
     - py-bluepyparallel
     - py-data-integrity-check
     - py-efel


### PR DESCRIPTION
* In #1777 we have made coreneuron optional for upcoming neuron > 8 releases:
```
    depends_on("coreneuron+legacy-unit~caliper", when="@:8.99+coreneuron+legacy-unit~caliper")
    ...
```
* Because of this change, spack is now preferring develop version of neuron when we mix gcc and intel:

```
$ spack spec -I py-bluepyopt%gcc ^neuron%intel
Input spec
--------------------------------
 -   py-bluepyopt%gcc
 -       ^neuron%intel

Concretized
--------------------------------
 -   py-bluepyopt@1.10.38%gcc@11.2.0+neuron patches=dc37639246b3a3320c840f1c4f635940b8510a896a667d4707c3d355d9c6fb81 arch=linux-rhel7-skylake
 -       ^neuron@develop%intel@2021.4.0+binary~caliper~codegenopt+coreneuron~debug~gpu~interviews~ipo+legacy-fr+legacy-unit+memacs+mod-compatibility+mpi~nmodl~openmp+python+report+rx3d+shared~sympy~sympyopt~tests~unified build_type=RelWithDebInfo model_tests=None patches=708cb04826b394a858069d93e8c08e1e81e914c23e1ef3da0486e8233834ff6c sanitizers=None arch=linux-rhel7-skylake
```
  but with single compiler, it uses last release correctly

```
$ spack spec -I py-bluepyopt ^neuron%intel
Input spec
--------------------------------
 -   py-bluepyopt
 -       ^neuron%intel

Concretized
--------------------------------
 -   py-bluepyopt@1.10.38%intel@2021.4.0+neuron patches=dc37639246b3a3320c840f1c4f635940b8510a896a667d4707c3d355d9c6fb81 arch=linux-rhel7-skylake
 -       ^neuron@8.2.1%intel@2021.4.0+binary~caliper~codegenopt+coreneuron~debug~gpu~interviews~ipo+legacy-fr+legacy-unit+memacs+mod-compatibility+mpi~nmodl~openmp+python+report+rx3d+shared~sympy~sympyopt~tests~unified build_type=RelWithDebInfo model_tests=None patches=708cb04826b394a858069d93e8c08e1e81e914c23e1ef3da0486e8233834ff6c sanitizers=None arch=linux-rhel7-skylake
 -           ^bison@3.8.2%intel@2021.4.0 arch=linux-rhel7-skylake
```
* I tried various spec changes in neuron and coreneuron by simplifying recipes but don't see any satisfactory change to force spack to use last release than develop. It seems like using upstream versions for common package like `ninja` also changes spack preference. (related to python dependency)
* So as part of this PR, pin the last release whenever we are mixing compilers. ANYWAY, this will be removed with #1781.

- [ ] NOTE: this PR is just to see all packages will be built without `neuron@develop`. I will introduce change in neuron recipe to test the same.