### PR TITLE
Update NEURON version

### DIFF
--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,6 +31,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
+    version("9.0.a2", commit="89f7dab")
     version("9.0.a1", commit="b3c4b4f")
     version("8.2.2a", commit="eb19ae0")
     version("8.2.1", tag="8.2.1")


### PR DESCRIPTION
Update NEURON version to newer commit from `master` that includes https://github.com/neuronsimulator/nrn/commit/89f7dab32167768056ba0dc86ae244f116cefa11 which fixes issues with NGV simulations like the following: https://bbpgitlab.epfl.ch/hpc/sim/blueconfigs/-/jobs/473279