### PR TITLE
Add common repo version to the neurodamus models

### DIFF
--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -32,7 +32,11 @@ def version_from_model_core_dep(model_v, core_v):
                when='@' + this_version)
 
 
-def version_from_model_ndpy_dep(model_v, ndamus_v=PYNEURODAMUS_DEFAULT_V, common_v=COMMON_DEFAULT_V):
+def version_from_model_ndpy_dep(
+    model_v,
+    ndamus_v=PYNEURODAMUS_DEFAULT_V,
+    common_v=COMMON_DEFAULT_V
+):
     """New version scheme following dependency on neurodamus-py and common
     """
     this_version = model_v + "-" + ndamus_v + "-" + common_v  # e.g. 1.1-3.0.2-2.6.4

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -40,6 +40,13 @@ def version_from_model_ndpy_dep(model_v, ndamus_v=PYNEURODAMUS_DEFAULT_V):
                when='@' + this_version)
 
 
+def custom_version_from_model_ndpy_dep(spack_model_version_name, model_v, ndamus_v=PYNEURODAMUS_DEFAULT_V):
+    this_version = spack_model_version_name + "-" + ndamus_v  # e.g. 1.1-3.0.2
+    version(this_version, tag=model_v, submodules=True, get_full_repo=True)
+    depends_on('py-neurodamus@' + ndamus_v, type=('build', 'run'),
+               when='@' + this_version)
+
+
 class NeurodamusModel(SimModel):
     """An 'abstract' base package for Simulation Models. Therefore no version.
        Eventually in the future Models are independent entities,

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -17,6 +17,7 @@ from .sim_model import SimModel, copy_all, make_link
 _CORENRN_MODLIST_FNAME = "coreneuron_modlist.txt"
 _BUILD_NEURODAMUS_FNAME = "build_neurodamus.sh"
 PYNEURODAMUS_DEFAULT_V = PyNeurodamus.LATEST_STABLE
+COMMON_DEFAULT_V = "2.6.4"
 
 
 def version_from_model_core_dep(model_v, core_v):
@@ -31,17 +32,10 @@ def version_from_model_core_dep(model_v, core_v):
                when='@' + this_version)
 
 
-def version_from_model_ndpy_dep(model_v, ndamus_v=PYNEURODAMUS_DEFAULT_V):
-    """New version scheme following dependency on neurodamus-py
+def version_from_model_ndpy_dep(model_v, ndamus_v=PYNEURODAMUS_DEFAULT_V, common_v=COMMON_DEFAULT_V):
+    """New version scheme following dependency on neurodamus-py and common
     """
-    this_version = model_v + "-" + ndamus_v  # e.g. 1.1-3.0.2
-    version(this_version, tag=model_v, submodules=True, get_full_repo=True)
-    depends_on('py-neurodamus@' + ndamus_v, type=('build', 'run'),
-               when='@' + this_version)
-
-
-def custom_version_from_model_ndpy_dep(spack_model_version_name, model_v, ndamus_v=PYNEURODAMUS_DEFAULT_V):
-    this_version = spack_model_version_name + "-" + ndamus_v  # e.g. 1.1-3.0.2
+    this_version = model_v + "-" + ndamus_v + "-" + common_v  # e.g. 1.1-3.0.2-2.6.4
     version(this_version, tag=model_v, submodules=True, get_full_repo=True)
     depends_on('py-neurodamus@' + ndamus_v, type=('build', 'run'),
                when='@' + this_version)
@@ -61,7 +55,7 @@ class NeurodamusModel(SimModel):
     resource(
         name='common_mods',
         git='ssh://git@bbpgitlab.epfl.ch/hpc/sim/models/common.git',
-        tag='2.6.4',
+        tag=COMMON_DEFAULT_V,
         destination='common_latest'
     )
 

--- a/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
@@ -35,7 +35,6 @@ class NeurodamusNeocortex(NeurodamusModel):
 
     # IMPORTANT: Register new versions only using version_from_model_*
     # Final version name is combined e.g. "1.0-3.0.1"
-    custom_version_from_model_ndpy_dep('1.10.1', '1.10')
     version_from_model_ndpy_dep('1.10')
     version_from_model_ndpy_dep('1.9')
     version_from_model_ndpy_dep('1.8')

--- a/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
@@ -11,7 +11,6 @@ from .neurodamus_model import (
     make_link,
     version_from_model_core_dep,
     version_from_model_ndpy_dep,
-    custom_version_from_model_ndpy_dep,
 )
 
 

--- a/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
@@ -34,6 +34,7 @@ class NeurodamusNeocortex(NeurodamusModel):
 
     # IMPORTANT: Register new versions only using version_from_model_*
     # Final version name is combined e.g. "1.0-3.0.1"
+    custom_version_from_model_ndpy_dep('1.10.1', '1.10')
     version_from_model_ndpy_dep('1.10')
     version_from_model_ndpy_dep('1.9')
     version_from_model_ndpy_dep('1.8')

--- a/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-neocortex/package.py
@@ -11,6 +11,7 @@ from .neurodamus_model import (
     make_link,
     version_from_model_core_dep,
     version_from_model_ndpy_dep,
+    custom_version_from_model_ndpy_dep,
 )
 
 

--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -13,7 +13,7 @@ class PyNeurodamus(PythonPackage):
     git = "ssh://git@bbpgitlab.epfl.ch/hpc/sim/neurodamus-py.git"
 
     version('develop', branch='main', submodules=True)
-    version('2.12.11',  tag='2.12.10', submodules=True)
+    version('2.12.11',  tag='2.12.11', submodules=True)
     version('2.12.10',  tag='2.12.10', submodules=True)
     version('2.12.9',  tag='2.12.9', submodules=True)
     version('2.12.8',  tag='2.12.8', submodules=True)

--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     git = "ssh://git@bbpgitlab.epfl.ch/hpc/sim/neurodamus-py.git"
 
     version('develop', branch='main', submodules=True)
+    version('2.12.11',  tag='2.12.10', submodules=True)
     version('2.12.10',  tag='2.12.10', submodules=True)
     version('2.12.9',  tag='2.12.9', submodules=True)
     version('2.12.8',  tag='2.12.8', submodules=True)


### PR DESCRIPTION
- Fixes issue with unable to deploy new `neurodamus-<model>`s packages if there are only changes in `common`
- This should be cleaned when rewriting the spack recipes of the `neurodamus-<model>`s