### PR TITLE
TouchDetector: fix typo related to caliper

### DIFF
--- a/bluebrain/repo-bluebrain/packages/touchdetector/package.py
+++ b/bluebrain/repo-bluebrain/packages/touchdetector/package.py
@@ -102,7 +102,7 @@ class Touchdetector(CMakePackage):
                 self.define('CMAKE_CXX_COMPILER', self.spec['mpi'].mpicxx),
             ]
 
-        if self.spec.satisfies('@5.7.0'):
+        if self.spec.satisfies('@5.7.0:'):
             use_tests = self.spec.satisfies('@develop') or '+test' in self.spec
             args += [
                 self.define_from_variant('ENABLE_CALIPER', 'caliper'),


### PR DESCRIPTION
I think this is needed to also have Caliper support on `develop`.