### PR TITLE
Omega-h: update deployment spec / new variant

### DIFF
--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -39,8 +39,7 @@ spack:
     - hypre+int64+mpi
     - metis+int64
     - neuron+mpi~debug%intel
-    - omega-h+trilinos
-    - omega-h+gmsh+trilinos
+    - omega-h+gmsh+kokkos
     - petsc~int64+mpi
     - petsc+int64+mpi
     - py-breathe

--- a/bluebrain/repo-patches/packages/omega-h/package.py
+++ b/bluebrain/repo-patches/packages/omega-h/package.py
@@ -42,11 +42,13 @@ class OmegaH(CMakePackage):
     variant('symbols', default=True, description='Compile C++ with debug symbols')
     variant('warnings', default=False, description='Compile C++ with warnings')
     variant('gmsh', default=False, description='Use Gmsh C++ API')
+    variant('kokkos', default=False, description='Use Kokkos')
 
     depends_on('gmsh', when='+examples')
     depends_on('gmsh@4.4.1:', when='+gmsh')
     depends_on('mpi', when='+mpi')
     depends_on('trilinos +kokkos', when='+trilinos')
+    depends_on('kokkos', when='+kokkos')
     depends_on('zlib', when='+zlib')
 
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86610
@@ -82,6 +84,8 @@ class OmegaH(CMakePackage):
             args.append('-DOmega_h_USE_Trilinos:BOOL=ON')
         if '+gmsh' in self.spec:
             args.append('-DOmega_h_USE_Gmsh:BOOL=ON')
+        if '+kokkos' in self.spec:
+            args.append('-DOmega_h_USE_Kokkos:BOOL=ON')
         if '+zlib' in self.spec:
             args.append('-DOmega_h_USE_ZLIB:BOOL=ON')
             args.append('-DZLIB_ROOT:PATH={0}'.format(

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -48,6 +48,8 @@ packages:
       prefix: /usr
   julia:
     variants: +external_llvm
+  kokkos:
+    variants: +openmp
   libtool:
     buildable: false  # different versions interact badly with autohell
     version: [2.4.2]
@@ -60,7 +62,7 @@ packages:
     - spec: m4@1.4.16
       prefix: /usr
   omega-h:
-    variants: +trilinos
+    variants: +kokkos
   opencv:
     variants: ~gtk~vtk
   openssl:
@@ -118,8 +120,6 @@ packages:
       prefix: /usr
   timemory:
     variants: +mpi~cuda+cupti+caliper~gperftools~python@3.0.0a
-  trilinos:
-    variants: +kokkos+teuchos+openmp~amesos~hypre~superlu-dist~mumps~metis~suite-sparse
   all:
     compiler: [gcc@11.2.0]
     target: [skylake]


### PR DESCRIPTION
* add variant to only enable Kokkos
* default deployment on BB5 relies only on Kokkos, not Trilinos

This change may lighten a little the deployment as now Omega_h only depends on Kokkos, not the whole Trilinos suite.