### PR TITLE
Omega-h: update BB5 deployment spec

### DIFF
--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -39,6 +39,7 @@ spack:
     - hypre+int64+mpi
     - metis+int64
     - neuron+mpi~debug%intel
+    - omega-h+gmsh
     - omega-h+gmsh+kokkos
     - petsc~int64+mpi
     - petsc+int64+mpi

--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -40,7 +40,6 @@ spack:
     - metis+int64
     - neuron+mpi~debug%intel
     - omega-h+gmsh
-    - omega-h+gmsh+kokkos
     - petsc~int64+mpi
     - petsc+int64+mpi
     - py-breathe

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -62,7 +62,7 @@ packages:
     - spec: m4@1.4.16
       prefix: /usr
   omega-h:
-    variants: +kokkos
+    variants: ~kokkos~trilinos
   opencv:
     variants: ~gtk~vtk
   openssl:


### PR DESCRIPTION
* `~kokkos~trilinos` by default
* cache the versions with and without kokkos