### PR TITLE
git: use external ssh

### DIFF
--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -65,6 +65,11 @@ packages:
     variants: ~kokkos~trilinos
   opencv:
     variants: ~gtk~vtk
+  openssh:
+    version: [9.1p1]
+    externals:
+    - spec: openssh@9.1p1
+      prefix: /usr
   openssl:
     version: [1.0.2k]
     externals:


### PR DESCRIPTION
Should help with some of the issues we have seen with the git module,
and replace any kerberos warnings.

(backported from new deployment)