### PR TITLE
neuron: add build_type=FastDebug variant, drop old debug variant

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -49,7 +49,7 @@ spack:
     - neurodamus-neocortex+ngv+metabolism+caliper%intel
     - neurodamus-thalamus+coreneuron+caliper%intel
     - neurodamus-thalamus+coreneuron+caliper%intel^neuron+knl
-    - neuron%intel+coreneuron+debug build_type=Debug
+    - neuron%intel+coreneuron build_type=Debug
     - nmodl
     - parquet-converters
     - py-basalt@0.2.9

--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -9,7 +9,7 @@ spack:
         - gmsh
         - hdf5+mpi
         - highfive+mpi
-        - neuron+mpi~debug%intel
+        - neuron+mpi%intel
         - omega-h
         - petsc+int64+mpi
         - py-cgal-pybind
@@ -38,7 +38,7 @@ spack:
     - highfive+mpi
     - hypre+int64+mpi
     - metis+int64
-    - neuron+mpi~debug%intel
+    - neuron+mpi%intel
     - omega-h+gmsh
     - petsc~int64+mpi
     - petsc+int64+mpi

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -52,7 +52,6 @@ class Neuron(CMakePackage):
     )
     variant("coreneuron", default=True, description="Enable CoreNEURON support")
     variant("mod-compatibility",  default=True, description="Enable CoreNEURON compatibility for MOD files")
-    variant("debug",          default=False, description="Build with flags -g -O0")
     variant("interviews", default=False, description="Enable GUI with INTERVIEWS")
     variant("legacy-fr",  default=True,  description="Use original faraday, R, etc. instead of 2019 nist constants")
     variant("memacs",     default=True,  description="Enable use of memacs")
@@ -115,11 +114,6 @@ class Neuron(CMakePackage):
     depends_on("coreneuron~legacy-unit~caliper", when="@:8.99+coreneuron~legacy-unit~caliper")
     depends_on("coreneuron+legacy-unit+caliper", when="@:8.99+coreneuron+legacy-unit+caliper")
     depends_on("coreneuron~legacy-unit+caliper", when="@:8.99+coreneuron~legacy-unit+caliper")
-
-    # TODO: if +debug variant is used (e.g. in CIs), we have to make sure
-    # coreneuron with Debug build is used. This can be removed when we
-    # remove +debug variant from this recipe.
-    depends_on("coreneuron build_type=Debug", when="@:8.99+coreneuron+debug")
 
     # dependencies from coreneuron package
     depends_on('python', type=('build', 'run'))
@@ -188,11 +182,7 @@ class Neuron(CMakePackage):
         if "+python" in self.spec:
             args.append("-DPYTHON_EXECUTABLE:FILEPATH="
                         + self.spec["python"].command.path)
-        if "+debug" in self.spec:
-            compilation_flags += ['-g', '-O0']
-            # Remove default flags (RelWithDebInfo etc.)
-            args.append("-DCMAKE_BUILD_TYPE=Custom")
-        elif self.spec.variants["build_type"].value == "FastDebug":
+        if self.spec.variants["build_type"].value == "FastDebug":
             # Do *not* add -DNDEBUG, so assertions are enabled
             # Good debug information and stack traces
             compilation_flags.append("-g")
@@ -226,13 +216,12 @@ class Neuron(CMakePackage):
             args.append("-DNRN_AVOID_ABSOLUTE_PATHS=ON")
         # Pass Spack's target architecture flags in explicitly so that they're
         # saved to the nrnivmodl Makefile.
-        if "~debug" in self.spec:
-            compilation_flags.append(
-                self.spec.architecture.target.optimization_flags(self.spec.compiler)
-            )
-            if "%intel" in self.spec:
-                # icpc: command line warning #10121: overriding '-march=skylake' with '-march=skylake'
-                compilation_flags.append("-diag-disable=10121")
+        compilation_flags.append(
+            self.spec.architecture.target.optimization_flags(self.spec.compiler)
+        )
+        if "%intel" in self.spec:
+            # icpc: command line warning #10121: overriding '-march=skylake' with '-march=skylake'
+            compilation_flags.append("-diag-disable=10121")
         compilation_flags = " ".join(compilation_flags)
         args.append("-DCMAKE_C_FLAGS=" + compilation_flags)
         args.append("-DCMAKE_CXX_FLAGS=" + compilation_flags)


### PR DESCRIPTION
Intent is to use `build_type=FastDebug` in at least some of our CI plans.