### PR TITLE
deploy: NEURON with FastDebug

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -49,7 +49,7 @@ spack:
     - neurodamus-neocortex+ngv+metabolism+caliper%intel
     - neurodamus-thalamus+coreneuron+caliper%intel
     - neurodamus-thalamus+coreneuron+caliper%intel^neuron+knl
-    - neuron%intel+coreneuron build_type=Debug
+    - neuron%intel+coreneuron build_type=FastDebug
     - nmodl
     - parquet-converters
     - py-basalt@0.2.9


### PR DESCRIPTION
As you can see here for example https://bbpgitlab.epfl.ch/hpc/sim/blueconfigs/-/jobs/535349 we install the neurodamus packages with `^neuron+coreneuron build_type=FastDebug` after Olli's latest changes and `NEURON` gets rebuild every time