### PR TITLE
libsonata: add variant `cxxstd` with default 14.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/libsonata/package.py
+++ b/bluebrain/repo-bluebrain/packages/libsonata/package.py
@@ -28,6 +28,7 @@ class Libsonata(CMakePackage):
 
     variant('mpi', default=True, description="Enable MPI backend")
     variant('tests', default=False, description="Enable building tests")
+    variant('cxxstd', default="14", when="@0.1.17:", description="The C++ standard to use")
 
     depends_on('cmake@3.3:', type='build')
     depends_on('py-setuptools-scm', type='build', when='@0.1:')
@@ -47,6 +48,10 @@ class Libsonata(CMakePackage):
             '-DEXTLIB_FROM_SUBMODULES=OFF',
             self.define_from_variant('SONATA_TESTS', 'tests'),
         ]
+
+        if self.spec.satisfies('@0.1.17:'):
+            result.append(self.define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'))
+
         if not self.spec.satisfies('@develop'):
             result.append('-DSONATA_CXX_WARNINGS:BOOL=OFF')
         if self.spec.satisfies('+mpi'):


### PR DESCRIPTION
In order to set the C++ standard according to which the libsonata code is compiled this commit adds a variant `cxxstd` with default `14`. When 
 https://github.com/BlueBrain/libsonata/pull/247 

gets merged, we can invoke `cmake` with `-DCMAKE_CXX_STANDARD=...`  to configure the C++ standard.

The following should be discussed:
* The name of `cxxstd` seems to be in line with other Spack recipes, but should also be the same across BBP projects.
* Should the new variant only be available as of `0.1.17` or also for older variants (where `14` is the only possible choice)?