### PR TITLE
libsonata: add variant `tests` to build the tests.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/libsonata/package.py
+++ b/bluebrain/repo-bluebrain/packages/libsonata/package.py
@@ -27,6 +27,7 @@ class Libsonata(CMakePackage):
     version('0.1.10', tag='v0.1.10')
 
     variant('mpi', default=True, description="Enable MPI backend")
+    variant('tests', default=False, description="Enable building tests")
 
     depends_on('cmake@3.3:', type='build')
     depends_on('py-setuptools-scm', type='build', when='@0.1:')
@@ -34,7 +35,7 @@ class Libsonata(CMakePackage):
     depends_on('highfive+mpi', when='+mpi')
     depends_on('highfive~mpi', when='~mpi')
     depends_on('mpi', when='+mpi')
-    depends_on('catch2', when='@0.1.3:')
+    depends_on('catch2@2', when='@0.1.3:')
     # Version restriction guessed from old deployment
     #
     # No `when` clause, as clingo will penalize new versions with the
@@ -44,7 +45,7 @@ class Libsonata(CMakePackage):
     def cmake_args(self):
         result = [
             '-DEXTLIB_FROM_SUBMODULES=OFF',
-            '-DSONATA_TESTS=OFF',
+            self.define_from_variant('SONATA_TESTS', 'tests'),
         ]
         if not self.spec.satisfies('@develop'):
             result.append('-DSONATA_CXX_WARNINGS:BOOL=OFF')


### PR DESCRIPTION
This is useful when developing `libsonata` fully through spack, e.g.

    spack develop --no-clone -p ${PWD} libsonata@develop
    spack add libsonata@develop +tests
    spack install --util=install -j $(nproc)

    spack cd --build-dir libsonata
    spack build-env libsonata -- bash

Which will open a bash shell configured such that `make` works. In order to also have the test built, this commit add the variant `tests`. Additionally this pins the Catch to any `v2` (since `libsonata` and Catch3 aren't compatible).

The name `tests` seems to be slightly more popular than `test` both upstream spack and BBP spack.