### PR TITLE
neuron: deploy new version with NVHPC fixes

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -38,10 +38,9 @@ spack:
   specs:
     - neuron+tests+coreneuron
     - neuron+tests+nmodl+sympy+coreneuron
-    # Try +rx3d after https://github.com/neuronsimulator/nrn/pull/2235?
-    - neuron%nvhpc+caliper+coreneuron+gpu~rx3d+tests+openmp
-    # - neuron%nvhpc+caliper+coreneuron+gpu~rx3d+tests~openmp+nmodl
-    - neuron%nvhpc+caliper+coreneuron+gpu~rx3d+tests+openmp+nmodl+sympy
+    - neuron%nvhpc+caliper+coreneuron+gpu+tests+openmp
+    - neuron%nvhpc+caliper+coreneuron+gpu+tests~openmp+nmodl
+    - neuron%nvhpc+caliper+coreneuron+gpu+tests+openmp+nmodl+sympy
     - nest@2.20.1
     - neurodamus-core~common~~coreneuron
     - neurodamus-core+common~~coreneuron

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,7 +31,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
-    version("9.0.a5", commit="bea7eb8")
+    version("9.0.a5", commit="bccc357")
     version("9.0.a4", commit="de2c927")
     version("9.0.a3", commit="afce1ef")
     version("9.0.a2", commit="89f7dab")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,6 +31,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
+    version("9.0.a5", commit="bea7eb8")
     version("9.0.a4", commit="de2c927")
     version("9.0.a3", commit="afce1ef")
     version("9.0.a2", commit="89f7dab")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -31,7 +31,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
-    version("9.0.a5", commit="bccc357")
+    version("9.0.a5", commit="522c866")
     version("9.0.a4", commit="de2c927")
     version("9.0.a3", commit="afce1ef")
     version("9.0.a2", commit="89f7dab")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -137,8 +137,8 @@ class Neuron(CMakePackage):
     # (as PYTHONPATH) during build time
     depends_on("py-sympy@1.3:", type=("build", "run"))
     # Next two needed in versions containing neuronsimulator/nrn#2235.
-    depends_on("py-pip", type=("build"), when="@develop")
-    depends_on("py-packaging", type=("run"), when="@develop")
+    depends_on("py-pip", type=("build"), when="@9.0.a5:")
+    depends_on("py-packaging", type=("run"), when="@9.0.a5:")
 
     # dependency on coreneuron via submodule
     depends_on("coreneuron+legacy-unit~caliper", when="@:8.99+coreneuron+legacy-unit~caliper")


### PR DESCRIPTION
The main changes in NEURON this is bringing in are:
- https://github.com/neuronsimulator/nrn/pull/2235 (to fix `neuron%nvhpc+rx3d` with the new deployment(?))
  - Implies updating the version ranges introduced in https://github.com/BlueBrain/spack/pull/1845
- https://github.com/neuronsimulator/nrn/pull/2252 (to avoid https://github.com/BlueBrain/CoreNeuron/issues/888 on BB5 with NVHPC 23.1)
- https://github.com/neuronsimulator/nrn/pull/2250 (to avoid a Random123-related compilation failure that only shows up after PRs to Spack are merged, hopefully...)
  - In principle allows the reversion of https://github.com/BlueBrain/spack/pull/1875 in this PR.
  - https://bbpgitlab.epfl.ch/hpc/spack/-/pipelines/104359
  - https://forums.developer.nvidia.com/t/nvc-23-1-compilation-issues-with-internal-linkage-variables/244680