### PR TITLE
deploy: re-add a once-iffy neuron spec

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -34,6 +34,7 @@ spack:
     - asciitoh5@1.0
     - neuron%intel+tests+coreneuron
     - neuron%intel+tests+nmodl+sympy+coreneuron
+    - neuron%nvhpc+coreneuron+tests+gpu
     - neuron%nvhpc+tests+gpu+openmp+coreneuron
     - neuron%nvhpc+tests+gpu+openmp+nmodl+sympy+coreneuron
     - nest@2.20.1


### PR DESCRIPTION
This reverts commit 21710b53f9247d58c66f96135dc947dc05772d33 from #1846.