### PR TITLE
deploy: remove cuda@12, use gcc@11.3.0 for cuda/nvhpc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ setup_environment:
     # Global default, as long as we have a 9.x.x, environment-modules picks
     # the wrong one as default :(
     DEFAULT_GCC_VERSION: "12.2.0"
-    # Needed for NVIDIA compilers, which lag behind reasonably modern times
+    # Used by the Intel compilers
     LEGACY_GCC_VERSION: "11.3.0"
     # Used for cloning Spack
     DEPLOYMENT_BRANCH: "$DEPLOYMENT_DEFAULT_BRANCH"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,9 +24,8 @@ setup_environment:
     # Global default, as long as we have a 9.x.x, environment-modules picks
     # the wrong one as default :(
     DEFAULT_GCC_VERSION: "12.2.0"
-    # Needed for Intel compilers, which may re-use some libraries from a
-    # legacy GCC
-    LEGACY_GCC_VERSION: "9.4.0"
+    # Needed for NVIDIA compilers, which lag behind reasonably modern times
+    LEGACY_GCC_VERSION: "11.3.0"
     # Used for cloning Spack
     DEPLOYMENT_BRANCH: "$DEPLOYMENT_DEFAULT_BRANCH"
     # Proprietary sources

--- a/bluebrain/deployment/bin/configure-compilers
+++ b/bluebrain/deployment/bin/configure-compilers
@@ -110,28 +110,6 @@ while read -r line; do
                 done
             done
         fi
-    elif [[ ${line} = *"nvhpc"* ]]; then
-        # Configure NVHPC compilers to use an up to date version of the C++
-        # standard library from the deployed version of GCC.
-        NVHPC_DIR=$(dirname $(which makelocalrc))
-        NVHPC_TMPDIR=$(mktemp -d -p .)
-        # Try and avoid autoloaded dependencies of other compilers (looking
-        # at you, LLVM) polluting the localrc of the NVIDIA compilers
-        (
-            module purge
-            ${cmd}
-            makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${LEGACY_GCC_DIR}/bin/gcc -gpp ${LEGACY_GCC_DIR}/bin/g++ -g77 ${LEGACY_GCC_DIR}/bin/gfortran -x
-        )
-        # olupton 2021-10-15: is this still needed? Not sure.
-        echo "set PREOPTIONS=-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1;" >> "${NVHPC_TMPDIR}/localrc"
-        log "NVIDIA localrc template"
-        cat "${NVHPC_TMPDIR}/localrc"
-        if [[ "${NVHPC_DIR}" != "${DEPLOYMENT_ROOT}"* ]]; then
-            log "...installation does not match install prefix, skipping modification of files"
-        else
-            cp -v "${NVHPC_TMPDIR}/localrc" "${NVHPC_DIR}/localrc"
-        fi
-        rm -rf "${NVHPC_TMPDIR}"
     fi
     cmd=${cmd/load/unload}
     echo "${cmd}"

--- a/bluebrain/deployment/bin/configure-compilers
+++ b/bluebrain/deployment/bin/configure-compilers
@@ -25,14 +25,14 @@ DEFAULT_GCC_DIR=$(spack -E location --install-dir ${DEFAULT_GCC_HASH:-gcc@${DEFA
 # Use the Spack configuration to grab the matching module for GCC;
 # requires GCC to be compiler found beforehand.
 GCC_MODULES="$(spack -E config get compilers|sed -n "
-    /^\s*spec: gcc@${DEFAULT_GCC_VERSION}/,/^\s*modules:/ {
+    /^\s*spec: gcc@${LEGACY_GCC_VERSION}/,/^\s*modules:/ {
         /^\s*modules:/ {
             s/^\s*modules: \[\(.*\)\]\$/\1/;
             p;
         }
     }")"
-log "...using gcc ${LEGACY_GCC_VERSION} from ${LEGACY_GCC_DIR} for Intel (legacy)"
-log "...using gcc ${DEFAULT_GCC_VERSION} from ${DEFAULT_GCC_DIR} for modern Intel and NVHPC with module(s) ${GCC_MODULES}"
+log "...using gcc ${LEGACY_GCC_VERSION} from ${LEGACY_GCC_DIR} for Intel (legacy) and NVHPC with module(s) ${GCC_MODULES}"
+log "...using gcc ${DEFAULT_GCC_VERSION} from ${DEFAULT_GCC_DIR} for modern Intel"
 
 while read -r line; do
     sha="${line%% *}"    # Remove everything after and including the first space

--- a/bluebrain/deployment/bin/configure-compilers
+++ b/bluebrain/deployment/bin/configure-compilers
@@ -120,7 +120,7 @@ while read -r line; do
         (
             module purge
             ${cmd}
-            makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${DEFAULT_GCC_DIR}/bin/gcc -gpp ${DEFAULT_GCC_DIR}/bin/g++ -g77 ${DEFAULT_GCC_DIR}/bin/gfortran -x
+            makelocalrc ${NVHPC_DIR} -d "${NVHPC_TMPDIR}" -gcc ${LEGACY_GCC_DIR}/bin/gcc -gpp ${LEGACY_GCC_DIR}/bin/g++ -g77 ${LEGACY_GCC_DIR}/bin/gfortran -x
         )
         # olupton 2021-10-15: is this still needed? Not sure.
         echo "set PREOPTIONS=-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1;" >> "${NVHPC_TMPDIR}/localrc"

--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -38,9 +38,10 @@ spack:
   specs:
     - neuron+tests+coreneuron
     - neuron+tests+nmodl+sympy+coreneuron
-    - neuron%nvhpc+caliper+coreneuron+gpu+tests+openmp
-    - neuron%nvhpc+caliper+coreneuron+gpu+tests~openmp+nmodl
-    - neuron%nvhpc+caliper+coreneuron+gpu+tests+openmp+nmodl+sympy
+    # Try +rx3d after https://github.com/neuronsimulator/nrn/pull/2235?
+    - neuron%nvhpc+caliper+coreneuron+gpu~rx3d+tests+openmp
+    - neuron%nvhpc+caliper+coreneuron+gpu~rx3d+tests~openmp+nmodl
+    - neuron%nvhpc+caliper+coreneuron+gpu~rx3d+tests+openmp+nmodl+sympy
     - nest@2.20.1
     - neurodamus-core~common~~coreneuron
     - neurodamus-core+common~~coreneuron

--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -38,8 +38,9 @@ spack:
   specs:
     - neuron+tests+coreneuron
     - neuron+tests+nmodl+sympy+coreneuron
-    # - neuron%nvhpc+tests+gpu+openmp+coreneuron
-    # - neuron%nvhpc+tests+gpu+openmp+nmodl+sympy+coreneuron
+    - neuron%nvhpc+caliper+coreneuron+gpu+tests+openmp
+    - neuron%nvhpc+caliper+coreneuron+gpu+tests~openmp+nmodl
+    - neuron%nvhpc+caliper+coreneuron+gpu+tests+openmp+nmodl+sympy
     - nest@2.20.1
     - neurodamus-core~common~~coreneuron
     - neurodamus-core+common~~coreneuron

--- a/bluebrain/deployment/environments/compilers.yaml
+++ b/bluebrain/deployment/environments/compilers.yaml
@@ -17,7 +17,6 @@ spack:
     intel-parallel-studio:
       variants: +advisor+daal+gdb+inspector+ipp~mkl~mpi+rpath+shared~tbb+vtune
   specs:
-    - gcc@9.4.0
     - gcc@11.3.0
     - gcc@12.2.0
     - intel-oneapi-compilers@2022.2.1

--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -89,7 +89,8 @@ spack:
     # - cuda@11.6.1
     # NVHPC 22.11 ships CUDA 11.8.0 (version.json)
     - cuda@11.8.0%gcc@11.3.0
-    - cuda@12.0.0
+    # CUDA 12 requires a CUDA driver that is not yet available on BB5
+    # - cuda@12.0.0
     - cudnn@8.0.3.33-11.0
     - darshan-runtime
     - darshan-util

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -22,8 +22,7 @@ packages:
       - one_of: ["%intel", "%nvhpc"]
   cuda:
     # Should match what is provided by NVHPC, too
-    version: [11.8.0]
-    require: "%gcc@11.3.0"
+    require: "@11.8.0%gcc@11.3.0"
   curl:
     version: [7.29.0]
     externals:

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -14,15 +14,17 @@ packages:
   boost:
     variants: +filesystem+pic+test
   caliper:
-    require: "%gcc"
+    # Allow GCC != 12 for things that depend on CUDA
+    require: "%gcc target=skylake"
   coreneuron:
     # Keep this aligned with NEURON, otherwise the Spack solver may decide that
     # rolling back to NEURON 8.2.2 with external CoreNEURON is a net win
     require:
       - one_of: ["%intel", "%nvhpc"]
   cuda:
-    # Should match what is provided by NVHPC, too
-    require: "@11.8.0%gcc@11.3.0"
+    # Pin 11.8.0 to avoid 12.0.0, which is too new for BB5
+    # Pin GCC 11 because CUDA 11.8.0 is incompatible with GCC 12
+    require: "@11.8.0%gcc@11.3.0 target=skylake"
   curl:
     version: [7.29.0]
     externals:
@@ -58,8 +60,8 @@ packages:
     - spec: libtool@2.4.2
       prefix: /usr
   llvm:
-    # Non-GCC12 allowed for CUDA reasons
-    require: "%gcc"
+    # Allow GCC != 12 for things that depend on CUDA
+    require: "%gcc target=skylake"
   m4:
     version: [1.4.16]
     externals:
@@ -96,7 +98,8 @@ packages:
     require:
       - one_of: ["%gcc", "%intel", "%nvhpc"]
   nvhpc:
-    require: "%gcc@11.3.0"
+    # Consistently use GCC 11.3.0 for CUDA/NVIDIA
+    require: "%gcc@11.3.0 target=skylake"
   omega-h:
     variants: ~kokkos~trilinos
   opencv:

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -23,7 +23,7 @@ packages:
   cuda:
     # Should match what is provided by NVHPC, too
     version: [11.8.0]
-    require: "%gcc"
+    require: "%gcc@11.3.0"
   curl:
     version: [7.29.0]
     externals:

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -152,7 +152,7 @@ packages:
   timemory:
     variants: +mpi~cuda+cupti+caliper~gperftools~python@3.0.0a
   all:
-    require: "%gcc@12.2.0 target=skylake"
+    require: "%gcc target=skylake"
     providers:
       mpi:: [hpe-mpi]
       scalapack:: [intel-oneapi-mkl]

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -13,6 +13,8 @@ packages:
     variants: +gas+gold+ld+plugins~libiberty
   boost:
     variants: +filesystem+pic+test
+  caliper:
+    require: "%gcc"
   coreneuron:
     # Keep this aligned with NEURON, otherwise the Spack solver may decide that
     # rolling back to NEURON 8.2.2 with external CoreNEURON is a net win
@@ -20,7 +22,7 @@ packages:
       - one_of: ["%intel", "%nvhpc"]
   cuda:
     # Should match what is provided by NVHPC, too
-    # version: [11.6.1]
+    version: [11.8.0]
     require: "%gcc"
   curl:
     version: [7.29.0]
@@ -56,6 +58,9 @@ packages:
     externals:
     - spec: libtool@2.4.2
       prefix: /usr
+  llvm:
+    # Non-GCC12 allowed for CUDA reasons
+    require: "%gcc"
   m4:
     version: [1.4.16]
     externals:
@@ -152,7 +157,7 @@ packages:
   timemory:
     variants: +mpi~cuda+cupti+caliper~gperftools~python@3.0.0a
   all:
-    require: "%gcc target=skylake"
+    require: "%gcc@12.2.0 target=skylake"
     providers:
       mpi:: [hpe-mpi]
       scalapack:: [intel-oneapi-mkl]

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -96,6 +96,8 @@ packages:
   nmodl:
     require:
       - one_of: ["%gcc", "%intel", "%nvhpc"]
+  nvhpc:
+    require: "%gcc@11.3.0"
   omega-h:
     variants: ~kokkos~trilinos
   opencv:


### PR DESCRIPTION
- Roll back from CUDA 12
- Try and consistently configure the NVIDIA toolchain to use GCC 11.3.0