### PR TITLE
nmodl, neuron: explicitly set BUILD_TESTING=ON

### DIFF
--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -65,6 +65,10 @@ class Nmodl(CMakePackage):
             "-DNMODL_3RDPARTY_USE_JSON=OFF",
             "-DNMODL_3RDPARTY_USE_PYBIND11=OFF",
             "-DNMODL_3RDPARTY_USE_SPDLOG=OFF",
+            # This recipe is used in CI pipelines that run the tests directly from
+            # the build directory and not via Spack's --test=X option. Setting this
+            # aims to override the implicit CMake argument that Spack injects.
+            self.define("BUILD_TESTING", True),
             self.define("PYTHON_EXECUTABLE", python.command),
             self.define_from_variant("NMODL_ENABLE_PYTHON_BINDINGS", "python"),
             self.define_from_variant("NMODL_ENABLE_LEGACY_UNITS", "legacy-unit"),

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -54,8 +54,6 @@ class Nmodl(CMakePackage):
     depends_on("spdlog")
 
     def cmake_args(self):
-        spec = self.spec
-
         # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from
         # the Spack dependency graph.
         options = [

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -191,6 +191,12 @@ class Neuron(CMakePackage):
                 "+tests",
             ]
         ]
+        if self.spec.satisfies("+tests"):
+            # The +tests variant is used in CI pipelines that run the tests
+            # directly from the build directory, not via Spack's --test=X
+            # option. This overrides the implicit CMake argument that Spack
+            # injects.
+            args.append(self.define("BUILD_TESTING", True))
         if self.spec.satisfies("@9.0.a3:+tests"):
             # The +tests variant is primarily used for CI pipelines, which do
             # not run on exclusive resources and do not give reliable results


### PR DESCRIPTION
Since the new deployment went live, Spack has been implicitly disabling CTest because we do not pass `--test`.
We don't want to let Spack drive testing, because:
- we currently have infrastructure for reporting test results that assumes otherwise
- we do not currently build on nodes that are necessarily able to execute the tests (e.g. `neuron +coreneuron+gpu`)