### PR TITLE
deploy: spdlog: prefer +fmt_external

### DIFF
--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -133,6 +133,8 @@ packages:
     externals:
     - spec: slurm@21.08.3
       prefix: /usr
+  spdlog:
+    variants: +fmt_external
   steps:
     variants: +lapack+petsc+mpi
   superlu-dist:


### PR DESCRIPTION
(at least) `nmodl@nvhpc`, which depends on `fmt` and `spdlog`, has compilation problems without this.