### PR TITLE
deploy: inject some OpenMP into MKL

### DIFF
--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -243,7 +243,8 @@ github_information:
     -     sed -e "/:':/{s/'//g}" "spack_config/packages.yaml.tmp" > "spack_config/packages.yaml"
     # The Intel® Oneapi™ MKL module requires an OpenMP library in LD_LIBRARY_PATH,
     # manually add it in:
-    -     MKL_MODULE=$(module show intel-oneapi-mkl|&sed -ne 's/:$//g;2p')
+    -     MKL_MODULE=$(spack module tcl find intel-oneapi-mkl|&sed -ne 's/:$//g;2p')
+    -     echo "Modifying MKL module in ${MKL_MODULE}"
     -     echo "# This avoids a missing symbol 'omp_get_num_procs' when calling anything that needs MKL" >> "${MKL_MODULE}"
     -     echo "append-path      LD_LIBRARY_PATH $(module show intel-oneapi-compilers|&grep LD_LIBRARY_PATH|grep -oe '/gpfs[^:]*linux/compiler/lib/intel64_lin')" >> "${MKL_MODULE}"
     - fi

--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -243,7 +243,7 @@ github_information:
     -     sed -e "/:':/{s/'//g}" "spack_config/packages.yaml.tmp" > "spack_config/packages.yaml"
     # The Intel® Oneapi™ MKL module requires an OpenMP library in LD_LIBRARY_PATH,
     # manually add it in:
-    -     MKL_MODULE=$(unset MODULEPATH; module use ${DEPLOYMENT_ROOT}/stage_${CI_JOB_STAGE}/modules_tcl${DEPLOYMENT_SUFFIX}/*; module show intel-oneapi-mkl|&sed -ne '2{s/:$//g;p}')
+    -     MKL_MODULE=$(unset MODULEPATH; module use ${DEPLOYMENT_ROOT}/stage_${CI_JOB_STAGE}/modules_tcl${DEPLOYMENT_SUFFIX}/linux*; module show intel-oneapi-mkl|&sed -ne '2{s/:$//g;p}')
     -     echo "Modifying MKL module in ${MKL_MODULE}"
     -     echo "# This avoids a missing symbol 'omp_get_num_procs' when calling anything that needs MKL" >> "${MKL_MODULE}"
     -     echo "append-path      LD_LIBRARY_PATH $(module show intel-oneapi-compilers|&grep LD_LIBRARY_PATH|grep -oe '/gpfs[^:]*linux/compiler/lib/intel64_lin')" >> "${MKL_MODULE}"

--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -241,6 +241,8 @@ github_information:
     # move afterwards
     -     spack export --scope=user --module tcl --explicit --unbuildable cuda intel-oneapi-mkl likwid llvm openscenegraph optix --exclude 'neuron|hdf5|nvhpc' ${shas} > "spack_config/packages.yaml.tmp"
     -     sed -e "/:':/{s/'//g}" "spack_config/packages.yaml.tmp" > "spack_config/packages.yaml"
+    # Make new modules visible to the module system
+    -     . ${SPACK_ROOT}/share/spack/setup-env.sh
     # The Intel® Oneapi™ MKL module requires an OpenMP library in LD_LIBRARY_PATH,
     # manually add it in:
     -     MKL_MODULE=$(spack module tcl find --full-path intel-oneapi-mkl)

--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -241,6 +241,12 @@ github_information:
     # move afterwards
     -     spack export --scope=user --module tcl --explicit --unbuildable cuda intel-oneapi-mkl likwid llvm openscenegraph optix --exclude 'neuron|hdf5|nvhpc' ${shas} > "spack_config/packages.yaml.tmp"
     -     sed -e "/:':/{s/'//g}" "spack_config/packages.yaml.tmp" > "spack_config/packages.yaml"
+    - elif [[ "${CI_JOB_STAGE}" == "externals" ]]; then
+    # The Intel® Oneapi™ MKL module requires an OpenMP library in LD_LIBRARY_PATH,
+    # manually add it in:
+    -     MKL_MODULE=$(module show intel-oneapi-mkl|&sed -ne 's/:$//g;2p')
+    -     echo "# This avoids a missing symbol 'omp_get_num_procs' when calling anything that needs MKL" >> "${MKL_MODULE}"
+    -     echo "append-path      LD_LIBRARY_PATH $(module show intel-oneapi-compilers|&grep LD_LIBRARY_PATH|grep -oe '/gpfs[^:]*linux/compiler/lib/intel64_lin')" >> "${MKL_MODULE}"
     - fi
     # Fail if software fails to build!
     - if grep -q -m1 -l -R '<failure' "spack_tests"; then exit 1; fi

--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -241,7 +241,6 @@ github_information:
     # move afterwards
     -     spack export --scope=user --module tcl --explicit --unbuildable cuda intel-oneapi-mkl likwid llvm openscenegraph optix --exclude 'neuron|hdf5|nvhpc' ${shas} > "spack_config/packages.yaml.tmp"
     -     sed -e "/:':/{s/'//g}" "spack_config/packages.yaml.tmp" > "spack_config/packages.yaml"
-    - elif [[ "${CI_JOB_STAGE}" == "externals" ]]; then
     # The Intel® Oneapi™ MKL module requires an OpenMP library in LD_LIBRARY_PATH,
     # manually add it in:
     -     MKL_MODULE=$(module show intel-oneapi-mkl|&sed -ne 's/:$//g;2p')

--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -241,11 +241,9 @@ github_information:
     # move afterwards
     -     spack export --scope=user --module tcl --explicit --unbuildable cuda intel-oneapi-mkl likwid llvm openscenegraph optix --exclude 'neuron|hdf5|nvhpc' ${shas} > "spack_config/packages.yaml.tmp"
     -     sed -e "/:':/{s/'//g}" "spack_config/packages.yaml.tmp" > "spack_config/packages.yaml"
-    # Make new modules visible to the module system
-    -     . ${SPACK_ROOT}/share/spack/setup-env.sh
     # The Intel® Oneapi™ MKL module requires an OpenMP library in LD_LIBRARY_PATH,
     # manually add it in:
-    -     MKL_MODULE=$(spack module tcl find --full-path intel-oneapi-mkl)
+    -     MKL_MODULE=$(unset MODULEPATH; module use ${DEPLOYMENT_ROOT}/stage_${CI_JOB_STAGE}/modules_tcl${DEPLOYMENT_SUFFIX}/*; module show intel-oneapi-mkl|&sed -ne '2{s/:$//g;p}')
     -     echo "Modifying MKL module in ${MKL_MODULE}"
     -     echo "# This avoids a missing symbol 'omp_get_num_procs' when calling anything that needs MKL" >> "${MKL_MODULE}"
     -     echo "append-path      LD_LIBRARY_PATH $(module show intel-oneapi-compilers|&grep LD_LIBRARY_PATH|grep -oe '/gpfs[^:]*linux/compiler/lib/intel64_lin')" >> "${MKL_MODULE}"

--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -243,7 +243,7 @@ github_information:
     -     sed -e "/:':/{s/'//g}" "spack_config/packages.yaml.tmp" > "spack_config/packages.yaml"
     # The Intel® Oneapi™ MKL module requires an OpenMP library in LD_LIBRARY_PATH,
     # manually add it in:
-    -     MKL_MODULE=$(spack module tcl find intel-oneapi-mkl)
+    -     MKL_MODULE=$(spack module tcl find --full-path intel-oneapi-mkl)
     -     echo "Modifying MKL module in ${MKL_MODULE}"
     -     echo "# This avoids a missing symbol 'omp_get_num_procs' when calling anything that needs MKL" >> "${MKL_MODULE}"
     -     echo "append-path      LD_LIBRARY_PATH $(module show intel-oneapi-compilers|&grep LD_LIBRARY_PATH|grep -oe '/gpfs[^:]*linux/compiler/lib/intel64_lin')" >> "${MKL_MODULE}"

--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -243,7 +243,7 @@ github_information:
     -     sed -e "/:':/{s/'//g}" "spack_config/packages.yaml.tmp" > "spack_config/packages.yaml"
     # The Intel® Oneapi™ MKL module requires an OpenMP library in LD_LIBRARY_PATH,
     # manually add it in:
-    -     MKL_MODULE=$(spack module tcl find intel-oneapi-mkl|&sed -ne 's/:$//g;2p')
+    -     MKL_MODULE=$(spack module tcl find intel-oneapi-mkl)
     -     echo "Modifying MKL module in ${MKL_MODULE}"
     -     echo "# This avoids a missing symbol 'omp_get_num_procs' when calling anything that needs MKL" >> "${MKL_MODULE}"
     -     echo "append-path      LD_LIBRARY_PATH $(module show intel-oneapi-compilers|&grep LD_LIBRARY_PATH|grep -oe '/gpfs[^:]*linux/compiler/lib/intel64_lin')" >> "${MKL_MODULE}"


### PR DESCRIPTION
Should fix BSD-326, and make `py-numpy` usable again.
