### PR TITLE
deploy: disable a problematic spec

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -40,7 +40,7 @@ spack:
     - neuron+tests+nmodl+sympy+coreneuron
     # Try +rx3d after https://github.com/neuronsimulator/nrn/pull/2235?
     - neuron%nvhpc+caliper+coreneuron+gpu~rx3d+tests+openmp
-    - neuron%nvhpc+caliper+coreneuron+gpu~rx3d+tests~openmp+nmodl
+    # - neuron%nvhpc+caliper+coreneuron+gpu~rx3d+tests~openmp+nmodl
     - neuron%nvhpc+caliper+coreneuron+gpu~rx3d+tests+openmp+nmodl+sympy
     - nest@2.20.1
     - neurodamus-core~common~~coreneuron


### PR DESCRIPTION
- Introduced in https://github.com/BlueBrain/spack/pull/1859, but CI passed there.
- Causing the `develop` branch CI to fail: https://bbpgitlab.epfl.ch/hpc/spack/-/jobs/588333
- 2023 deployment analogue of https://github.com/BlueBrain/spack/pull/1846...
- See also: https://forums.developer.nvidia.com/t/nvc-23-1-compilation-issues-with-internal-linkage-variables/244680
- See also: https://github.com/BlueBrain/spack/pull/1847