### PR TITLE
deploy: Updated hpe-mpi module to set LD_LIBRARY_PATH

### DIFF
--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -47,6 +47,10 @@ spack:
           - ilmbase
           - openblas
           - openexr
+        hpe-mpi:
+          environment:
+            set:
+              LD_LIBRARY_PATH: '{prefix}/lib'
   packages:
     all:
       providers:


### PR DESCRIPTION
Having this in the environment helps with various runtime tools (profilers, debuggers, ...)