### PR TITLE
spatial-index: needs Boost with `+serialization`.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/spatial-index/package.py
+++ b/bluebrain/repo-bluebrain/packages/spatial-index/package.py
@@ -29,7 +29,7 @@ class SpatialIndex(PythonPackage):
 
     depends_on("py-setuptools")
     depends_on("cmake@3.2:", type="build")
-    depends_on("boost@1.79.0: +filesystem")
+    depends_on("boost@1.79.0: +filesystem+serialization")
     depends_on("py-docopt", type=("build", "run"))
     # `py-libsonata@0.1.15` contains a regression that throws
     # on empty selections. Therefore, SpatialIndex can't use


### PR DESCRIPTION
The new deployment seems to require mentioning `+serialization` for Boost.