### PR TITLE
deploy: configure pipelines by using git versions.

### DIFF
--- a/bluebrain/spack-scripting/scripting/cmd/configure_pipeline.py
+++ b/bluebrain/spack-scripting/scripting/cmd/configure_pipeline.py
@@ -1,8 +1,6 @@
-import os
 import re
 
 from llnl.util import tty
-from llnl.util.filesystem import filter_file
 
 import spack.config
 import spack.environment as ev
@@ -63,11 +61,7 @@ def get_commit(package_name, ref, ref_type):
             )
         commit, ref_check = remote_refs[0].split()
         assert remote_ref == ref_check
-        tty.info(
-            "{}: resolved {} {} to {}".format(
-                package_name, ref_type, ref, commit
-            )
-        )
+        tty.info("{}: resolved {} {} to {}".format(package_name, ref_type, ref, commit))
         return commit
 
 


### PR DESCRIPTION
Rather than overriding which commit `@develop` points to, we should use
the git sha in the required versions. Spack did not like the git version
to be a `require:` property, so set it as a package preference instead.
