### PR TITLE
deploy: steps, petsc, petsc-py, and omega-h

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -29,11 +29,7 @@ spack:
           +common: '{name}/{version}-commonmods'
           +plasticity: '{name}-plasticity/{version}'
           +ngv+metabolism: '{name}-multiscale/{version}'
-  packages:
-    steps:
-      variants: +petsc
-    trilinos:
-      version: [13.0.1]
+          ^petsc+complex: '{name}-complex/{version}'
   specs:
     - neuron+tests+coreneuron
     - neuron+tests+nmodl+sympy+coreneuron
@@ -57,6 +53,8 @@ spack:
     - spatial-index
     - spykfunc
     - steps
+    - steps@5
+    - steps@5 ^petsc+complex
     - synapsetool
     - touchdetector
     - unit-test-translator

--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -11,7 +11,7 @@ spack:
           - highfive+mpi
           - neuron+mpi
           - omega-h
-          - petsc+int64+mpi
+          - petsc
           - py-cgal-pybind
           - py-dask-mpi
           - py-flake8
@@ -30,19 +30,22 @@ spack:
           - python-dev
         projections:
           all: '{name}/{version}'
-          'omega-h+gmsh': '{name}/{version}-gmsh'
+          petsc+complex+int64+mpi: '{name}-complex/{version}'
+          ^petsc+complex: '{name}-complex/{version}'
+  packages:
+    petsc:
+      variants: ~hypre
   specs:
     - boost+atomic+chrono+date_time+filesystem+json+locale+log+math+program_options+python+random+regex+serialization+shared+signals+stacktrace+system+test+timer+type_erasure
     - caliper+cuda cuda_arch=70
     - gmsh+metis+mpi+openmp+shared
     - hdf5+mpi
     - highfive+mpi
-    - hypre+int64+mpi
     - metis+int64
     - neuron+mpi
     - omega-h+gmsh
-    - petsc~int64+mpi
     - petsc+int64+mpi
+    - petsc+complex+int64+mpi
     - py-cgal-pybind
     - py-dask-mpi
     - py-flake8

--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -20,6 +20,7 @@ spack:
           - py-mpi4py
           - py-notebook
           - py-numpy
+          - py-petsc4py
           - py-pip
           - py-poisson-recon-pybind
           - py-pytest
@@ -54,6 +55,8 @@ spack:
     - py-mpi4py
     - py-notebook
     - py-numpy
+    - py-petsc4py
+    - py-petsc4py ^petsc+complex+int64+mpi
     - py-pip
     - py-poisson-recon-pybind
     - py-rtree

--- a/bluebrain/repo-patches/packages/steps/package.py
+++ b/bluebrain/repo-patches/packages/steps/package.py
@@ -17,7 +17,8 @@ class Steps(CMakePackage):
     submodules = True
 
     version("develop", branch="master")
-    version("4.0.0", tag="4.0.0")
+    version("5.0.0a", commit="804e7ef")
+    version("4.0.0", tag="4.0.0", preferred=True)
     version("3.6.0", tag="3.6.0")
     version("3.5.0b", commit="b2be5fe")
 

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -268,24 +268,17 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     # Also PETSc prefer to build it without internal superlu, likely due to
     # conflict in headers see
     # https://bitbucket.org/petsc/petsc/src/90564b43f6b05485163c147b464b5d6d28cde3ef/config/BuildSystem/config/packages/hypre.py
-    depends_on("hypre@:2.13+mpi~internal-superlu~int64", when="@:3.8+hypre+mpi~complex~int64")
-    depends_on("hypre@:2.13+mpi~internal-superlu+int64", when="@:3.8+hypre+mpi~complex+int64")
-    depends_on(
-        "hypre@2.14:2.18.2+mpi~internal-superlu~int64", when="@3.9:3.13+hypre+mpi~complex~int64"
-    )
-    depends_on(
-        "hypre@2.14:2.18.2+mpi~internal-superlu+int64", when="@3.9:3.13+hypre+mpi~complex+int64"
-    )
-    depends_on(
-        "hypre@2.14:2.22.0+mpi~internal-superlu~int64", when="@3.14:3.15+hypre+mpi~complex~int64"
-    )
-    depends_on(
-        "hypre@2.14:2.22.0+mpi~internal-superlu+int64", when="@3.14:3.15+hypre+mpi~complex+int64"
-    )
-    depends_on("hypre@2.14:+mpi~internal-superlu~int64", when="@3.16:+hypre+mpi~complex~int64")
-    depends_on("hypre@2.14:+mpi~internal-superlu+int64", when="@3.16:+hypre+mpi~complex+int64")
-    depends_on("hypre@develop+mpi~internal-superlu+int64", when="@main+hypre+mpi~complex+int64")
-    depends_on("hypre@develop+mpi~internal-superlu~int64", when="@main+hypre+mpi~complex~int64")
+    depends_on("hypre@:2.13~internal-superlu", when="@:3.8+hypre")
+    depends_on("hypre@2.14:2.18.2~internal-superlu", when="@3.9:3.13+hypre")
+    depends_on("hypre@2.14:2.22.0~internal-superlu", when="@3.14:3.15+hypre")
+    depends_on("hypre@2.14:~internal-superlu", when="@3.16:+hypre")
+    depends_on("hypre@develop~internal-superlu", when="@main+hypre")
+    depends_on("hypre+complex", when="+hypre+complex")
+    depends_on("hypre~complex", when="+hypre~complex")
+    depends_on("hypre+int64", when="+hypre+int64")
+    depends_on("hypre~int64", when="-hypre~int64")
+    depends_on("hypre+mpi", when="+hypre+mpi")
+
     depends_on("superlu-dist@:4.3~int64", when="@3.4.4:3.6.4+superlu-dist+mpi~int64")
     depends_on("superlu-dist@:4.3+int64", when="@3.4.4:3.6.4+superlu-dist+mpi+int64")
     depends_on("superlu-dist@5.0.0:5.1.3~int64", when="@3.7.0:3.7+superlu-dist+mpi~int64")


### PR DESCRIPTION
* remove dead config related to trilinos
* remove useless steps spec +petsc since it is now the default
* omega-h: remove module suffix "-gmsh"
* petsc:
	- turn off variant `hypre` which is enabled by default
	- provide 2 modules, with and without "complex" variant
* steps: provide modules versions
	- tag 4.0.0
	- virtual version 5.0.0a that point to a recent revision of master