### PR TITLE
py-archive-advisor, py-find-duplicate-files: added for the first time

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-archive-advisor/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-archive-advisor/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyArchiveAdvisor(PythonPackage):
+    """A tool to parse folders to log files that have to be deleted or checked before archival."""
+
+    homepage = "https://bbpteam.epfl.ch/documentation/projects/archive-advisor"
+    git = "ssh://git@bbpgitlab.epfl.ch/hpc/archive-advisor.git"
+
+    version("develop", branch="main")
+    version("0.0.2", tag="0.0.2")
+    version("0.0.1", tag="0.0.1")
+
+    depends_on("py-setuptools", type=("build", "run"))
+    depends_on("py-click", type=("build", "run"))
+    depends_on("py-pyyaml", type=("build", "run"))
+    depends_on("py-rich", type=("build", "run"))
+    depends_on("py-gitpython", type=("build", "run"))
+    depends_on("py-find-duplicate-files", type=("build", "run"))

--- a/bluebrain/repo-patches/packages/py-find-duplicate-files/package.py
+++ b/bluebrain/repo-patches/packages/py-find-duplicate-files/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class PyFindDuplicateFiles(PythonPackage):
+    """A tool to find duplicate stuff."""
+
+    pypi = "find-duplicate-files/find-duplicate-files-2.1.0.tar.gz"
+
+    version("2.1.0", "11a4c742720e49883901a5be4447225d4a67a9e1e67f9446127f90ffda96a339")
+
+    depends_on("py-setuptools", type="build")
+    depends_on("py-mock", type="build")


### PR DESCRIPTION
This MR includes recipes for both the Archive Advisor tool (https://bbpgitlab.epfl.ch/hpc/archive-advisor) as `py-archive-advisor`. 
It also includes one of its optional dependencies, the Python library `find-duplicate-files`: https://pypi.org/project/find-duplicate-files/ as `py-find-duplicate-files`.