### PR TITLE
neuron: pass -xHost in very specific circumstances

### DIFF
--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -259,10 +259,15 @@ class Neuron(CMakePackage):
         # improves ccache performance in CI builds.
         if self.spec.satisfies("@8.2:"):
             args.append("-DNRN_AVOID_ABSOLUTE_PATHS=ON")
-        if ("%intel" in self.spec or "%oneapi" in self.spec) and self.spec.variants[
-            "build_type"
-        ].value == "Release":
-            # Compile for the host architecture. This is mainly just a test.
+        if (
+            ("%intel" in self.spec or "%oneapi" in self.spec)
+            and self.spec.satisfies("+coreneuron~nmodl")
+            and self.spec.variants["build_type"].value == "Release"
+        ):
+            # Compile for the host architecture when using MOD2C. This seems to be
+            # needed to undo a performance regression for this configuration that
+            # came with CoreNEURON being merged into NEURON. It can go away when
+            # mod2c goes away "soon"
             compilation_flags.append("-xHost")
         else:
             # Pass Spack's target architecture flags in explicitly so that they're

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -259,11 +259,17 @@ class Neuron(CMakePackage):
         # improves ccache performance in CI builds.
         if self.spec.satisfies("@8.2:"):
             args.append("-DNRN_AVOID_ABSOLUTE_PATHS=ON")
-        # Pass Spack's target architecture flags in explicitly so that they're
-        # saved to the nrnivmodl Makefile.
-        compilation_flags.append(
-            self.spec.architecture.target.optimization_flags(self.spec.compiler)
-        )
+        if ("%intel" in self.spec or "%oneapi" in self.spec) and self.spec.variants[
+            "build_type"
+        ].value == "Release":
+            # Compile for the host architecture. This is mainly just a test.
+            compilation_flags.append("-xHost")
+        else:
+            # Pass Spack's target architecture flags in explicitly so that they're
+            # saved to the nrnivmodl Makefile.
+            compilation_flags.append(
+                self.spec.architecture.target.optimization_flags(self.spec.compiler)
+            )
         if "%intel" in self.spec:
             # icpc: command line warning #10121: overriding '-march=skylake' with '-march=skylake'
             compilation_flags.append("-diag-disable=10121")


### PR DESCRIPTION
- See https://bbpgitlab.epfl.ch/hpc/cellular/coreneuron-perf-tests/-/merge_requests/21 for background.
- This is/was done in the `coreneuron` recipe: https://github.com/BlueBrain/spack/blob/c673bbc4a4648710c96d53beaee503b5f25c50a2/bluebrain/repo-bluebrain/packages/coreneuron/package.py#L130
- Should go away "soon" when MOD2C does; NMODL does not seem to need this