### PR TITLE
steps: friends don't let friends use `piptools`

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -53,8 +53,8 @@ spack:
     - spatial-index
     - spykfunc
     - steps
-    - steps@5
-    - steps@5 ^petsc+complex
+  # - steps@5
+  # - steps@5 ^petsc+complex
     - synapsetool
     - touchdetector
     - unit-test-translator

--- a/bluebrain/repo-patches/packages/steps/package.py
+++ b/bluebrain/repo-patches/packages/steps/package.py
@@ -78,7 +78,6 @@ class Steps(CMakePackage):
     depends_on("py-mpi4py", when="+distmesh", type=("build", "test", "run"))
     depends_on("py-nose", when="@3:4", type=("build", "test"))
     depends_on("py-numpy", type=("build", "test", "run"))
-    depends_on("py-pip-tools", type="build", when="@5:")
     depends_on("py-scipy", type=("build", "test", "run"))
     depends_on("python", type=("build", "test", "run"))
     depends_on("omega-h+gmsh+mpi", when="~bundle+distmesh")


### PR DESCRIPTION
A temporary hack to avoid `steps@5` from destroying the deployment.

See also CNS-OIST/HBP_STEPS#1080.