### PR TITLE
spatial-index: bump to version 2.0.0

### DIFF
--- a/bluebrain/repo-bluebrain/packages/spatial-index/package.py
+++ b/bluebrain/repo-bluebrain/packages/spatial-index/package.py
@@ -15,6 +15,7 @@ class SpatialIndex(PythonPackage):
     submodules = True
 
     version("develop", branch="main")
+    version("2.0.0", tag="2.0.0")
     version("1.2.1", tag="1.2.1")
     version("1.2.0", tag="1.2.0")
     version("1.1.0", tag="1.1.0")


### PR DESCRIPTION
This MR bumps the spatial-index (https://bbpgitlab.epfl.ch/hpc/spatial-index) recipe to include the newly released version 2.0.0.