### PR TITLE
py-toolz: upstream has a newer version

### DIFF
--- a/bluebrain/repo-patches/packages/py-toolz/package.py
+++ b/bluebrain/repo-patches/packages/py-toolz/package.py
@@ -1,8 +1,0 @@
-from spack.package import *
-from spack.pkg.builtin.py_toolz import PyToolz as BuiltinPyToolz
-
-
-class PyToolz(BuiltinPyToolz):
-    __doc__ = BuiltinPyToolz.__doc__
-
-    version("0.11.1", sha256="c7a47921f07822fe534fb1c01c9931ab335a4390c782bd28c6bcc7c2f71f3fbf")

--- a/var/spack/repos/builtin/packages/py-toolz/package.py
+++ b/var/spack/repos/builtin/packages/py-toolz/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -12,6 +12,8 @@ class PyToolz(PythonPackage):
     homepage = "https://github.com/pytoolz/toolz/"
     pypi = "toolz/toolz-0.9.0.tar.gz"
 
+    version("0.12.0", sha256="88c570861c440ee3f2f6037c4654613228ff40c93a6c25e0eba70d17282c6194")
     version("0.9.0", sha256="929f0a7ea7f61c178bd951bdae93920515d3fbdbafc8e6caf82d752b9b3b31c9")
 
     depends_on("py-setuptools", type="build")
+    depends_on("python@3.5:", type=("build", "run"), when="@0.11.0:")


### PR DESCRIPTION
The only one using it is py-morphology-repair-workflow, and that depends on `py-toolz@0.11.1:`