### PR TITLE
hdf5: highfive: py-h5py: backport upstream

### DIFF
--- a/bluebrain/repo-bluebrain/packages/hdf5/package.py
+++ b/bluebrain/repo-bluebrain/packages/hdf5/package.py
@@ -8,7 +8,7 @@ class Hdf5(BuiltinHdf5):
     variant(
         "page_buffer_patch",
         default=False,
-        when="@1.12.1",
+        when="@1.12.1,1.14.0",
         description="Enable the page buffer in parallel HDF5.",
     )
 
@@ -19,4 +19,10 @@ class Hdf5(BuiltinHdf5):
         "page-buffer-check-on-file-open_v1.12.1.patch",
         when="@1.12.1+page_buffer_patch+mpi",
         sha256="379c30fab7abb88e95d6e65c318baaeb3f7443290ad3fab4cfc5bcaa9a3f0a25",
+    )
+
+    patch(
+        "page-buffer-check-on-file-open_v1.14.0.patch",
+        when="@1.14.0+page_buffer_patch+mpi",
+        sha256="77fb681371736c156e348b4733e6cb505ed91e3968182a3c08f2eff052b90e34"
     )

--- a/bluebrain/repo-bluebrain/packages/hdf5/package.py
+++ b/bluebrain/repo-bluebrain/packages/hdf5/package.py
@@ -24,5 +24,5 @@ class Hdf5(BuiltinHdf5):
     patch(
         "page-buffer-check-on-file-open_v1.14.0.patch",
         when="@1.14.0+page_buffer_patch+mpi",
-        sha256="77fb681371736c156e348b4733e6cb505ed91e3968182a3c08f2eff052b90e34"
+        sha256="77fb681371736c156e348b4733e6cb505ed91e3968182a3c08f2eff052b90e34",
     )

--- a/bluebrain/repo-bluebrain/packages/hdf5/page-buffer-check-on-file-open_v1.14.0.patch
+++ b/bluebrain/repo-bluebrain/packages/hdf5/page-buffer-check-on-file-open_v1.14.0.patch
@@ -1,0 +1,18 @@
+diff --git i/src/H5Fint.c w/src/H5Fint.c
+index 7ad35fc552..9af22da567 100644
+--- i/src/H5Fint.c
++++ w/src/H5Fint.c
+@@ -1921,8 +1921,11 @@ H5F_open(const char *name, unsigned flags, hid_t fcpl_id, hid_t fapl_id)
+             HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL,
+                         "collective metadata writes are not supported with page buffering")
+ 
+-        /* Temporary: fail file create when page buffering feature is enabled for parallel */
+-        HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL, "page buffering is disabled for parallel")
++        /* The pagebuffer isn't compatible with MPI-IO. */
++        if (H5Pget_driver(fapl_id) == H5FD_MPIO)
++            HGOTO_ERROR(H5E_FILE, H5E_CANTOPENFILE, NULL,
++                        "MPIO is not supported with page buffering")
++
+ #endif /* H5_HAVE_PARALLEL */
+         /* Query for other page buffer cache properties */
+         if (H5P_get(a_plist, H5F_ACS_PAGE_BUFFER_MIN_META_PERC_NAME, &page_buf_min_meta_perc) < 0)

--- a/bluebrain/repo-patches/packages/highfive/package.py
+++ b/bluebrain/repo-patches/packages/highfive/package.py
@@ -60,7 +60,7 @@ class Highfive(CMakePackage):
 
     # Using the page buffer with pHDF5 requires HDF5 to be patched. This
     # patch is currently only available for one version.
-    depends_on("hdf5@1.12.1 +page_buffer_patch+mpi", when="+mpi+page_buffer_patch")
+    depends_on("hdf5@1.12.1,1.14.0 +page_buffer_patch+mpi", when="+mpi+page_buffer_patch")
 
     depends_on("eigen", when="+eigen")
     depends_on("xtensor", when="+xtensor")

--- a/var/spack/repos/builtin/packages/hdf5/hdf5_1_14_0_config_find_mpi.patch
+++ b/var/spack/repos/builtin/packages/hdf5/hdf5_1_14_0_config_find_mpi.patch
@@ -1,0 +1,13 @@
+diff --git a/config/cmake/hdf5-config.cmake.in b/config/cmake/hdf5-config.cmake.in
+index 35cee4f..b336377 100644
+--- a/config/cmake/hdf5-config.cmake.in
++++ b/config/cmake/hdf5-config.cmake.in
+@@ -63,6 +63,8 @@ if (${HDF5_PACKAGE_NAME}_ENABLE_PARALLEL)
+     set (${HDF5_PACKAGE_NAME}_MPI_Fortran_INCLUDE_PATH "@MPI_Fortran_INCLUDE_DIRS@")
+     set (${HDF5_PACKAGE_NAME}_MPI_Fortran_LIBRARIES    "@MPI_Fortran_LIBRARIES@")
+   endif ()
++
++    find_package(MPI QUIET REQUIRED)
+ endif ()
+ 
+ if (${HDF5_PACKAGE_NAME}_BUILD_JAVA)

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -1,9 +1,10 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 import shutil
 
 import llnl.util.tty as tty
@@ -22,33 +23,31 @@ class Hdf5(CMakePackage):
     list_url = "https://support.hdfgroup.org/ftp/HDF5/releases"
     list_depth = 3
     git = "https://github.com/HDFGroup/hdf5.git"
-    maintainers = [
-        "lrknox",
-        "brtnfld",
-        "byrnHDF",
-        "ChristopherHogan",
-        "epourmal",
-        "gheber",
-        "hyoklee",
-        "lkurz",
-        "soumagne",
-    ]
+    maintainers("lrknox", "brtnfld", "byrnHDF", "gheber", "hyoklee", "lkurz")
 
-    tags = ["e4s"]
+    tags = ["e4s", "windows"]
+    executables = ["^h5cc$", "^h5pcc$"]
 
     test_requires_compiler = True
 
     # The 'develop' version is renamed so that we could uninstall (or patch) it
     # without affecting other develop version.
-    version("develop-1.13", branch="develop")
+    version("develop-1.15", branch="develop")
+    version("develop-1.14", branch="hdf5_1_14")
     version("develop-1.12", branch="hdf5_1_12")
     version("develop-1.10", branch="hdf5_1_10")
     version("develop-1.8", branch="hdf5_1_8")
 
     # Odd versions are considered experimental releases
+    version("1.13.3", sha256="83c7c06671f975cee6944b0b217f95005faa55f79ea5532cf4ac268989866af4")
     version("1.13.2", sha256="01643fa5b37dba7be7c4db6bbf3c5d07adf5c1fa17dbfaaa632a279b1b2f06da")
 
     # Even versions are maintenance versions
+    version(
+        "1.14.0",
+        sha256="a571cc83efda62e1a51a0a912dd916d01895801c5025af91669484a1575a6ef4",
+        preferred=True,
+    )
     version(
         "1.12.2",
         sha256="2a89af03d56ce7502dcae18232c241281ad1773561ec00c0f0e8ee2463910f14",
@@ -179,6 +178,7 @@ class Hdf5(CMakePackage):
 
     variant("hl", default=False, description="Enable the high-level library")
     variant("cxx", default=False, description="Enable C++ support")
+    variant("map", when="@1.14:", default=False, description="Enable MAP API support")
     variant("fortran", default=False, description="Enable Fortran support")
     variant("java", when="@1.10:", default=False, description="Enable Java support")
     variant("threadsafe", default=False, description="Enable thread-safe capabilities")
@@ -190,11 +190,12 @@ class Hdf5(CMakePackage):
         "api",
         default="default",
         description="Choose api compatibility for earlier version",
-        values=("default", "v114", "v112", "v110", "v18", "v16"),
+        values=("default", "v116", "v114", "v112", "v110", "v18", "v16"),
         multi=False,
     )
 
     depends_on("cmake@3.12:", type="build")
+    depends_on("cmake@3.18:", type="build", when="@1.13:")
 
     depends_on("mpi", when="+mpi")
     depends_on("java", type=("build", "run"), when="+java")
@@ -202,12 +203,32 @@ class Hdf5(CMakePackage):
     depends_on("zlib@1.1.2:")
 
     # The compiler wrappers (h5cc, h5fc, etc.) run 'pkg-config'.
-    depends_on("pkgconfig", type="run")
+    # Skip this on Windows since pkgconfig is autotools
+    for plat in ["cray", "darwin", "linux"]:
+        depends_on("pkgconfig", when=f"platform={plat}", type="run")
 
+    conflicts("+mpi", "^mpich@4.0:4.0.3")
+    conflicts("api=v116", when="@1.6:1.14", msg="v116 is not compatible with this release")
+    conflicts(
+        "api=v116",
+        when="@develop-1.8:develop-1.14",
+        msg="v116 is not compatible with this release",
+    )
     conflicts("api=v114", when="@1.6:1.12", msg="v114 is not compatible with this release")
+    conflicts(
+        "api=v114",
+        when="@develop-1.8:develop-1.12",
+        msg="v114 is not compatible with this release",
+    )
     conflicts("api=v112", when="@1.6:1.10", msg="v112 is not compatible with this release")
+    conflicts(
+        "api=v112",
+        when="@develop-1.8:develop-1.10",
+        msg="v112 is not compatible with this release",
+    )
     conflicts("api=v110", when="@1.6:1.8", msg="v110 is not compatible with this release")
-    conflicts("api=v18", when="@1.6.0:1.6", msg="v18 is not compatible with this release")
+    conflicts("api=v110", when="@develop-1.8", msg="v110 is not compatible with this release")
+    conflicts("api=v18", when="@1.6", msg="v18 is not compatible with this release")
 
     # The Java wrappers cannot be built without shared libs.
     conflicts("+java", when="~shared")
@@ -284,6 +305,13 @@ class Hdf5(CMakePackage):
     # See https://github.com/HDFGroup/hdf5/issues/1157
     patch("fortran-kinds-2.patch", when="@1.10.8,1.12.1")
 
+    # Patch needed for HDF5 1.14.0 where dependency on MPI::MPI_C was declared
+    # PUBLIC.  Dependent packages using the default hdf5 package but not
+    # expecting to use MPI then failed to configure because they did not call
+    # find_package(MPI).  This patch does that for them.  Later HDF5 versions
+    # will include the patch code changes.
+    patch("hdf5_1_14_0_config_find_mpi.patch", when="@1.14.0")
+
     # The argument 'buf_size' of the C function 'h5fget_file_image_c' is
     # declared as intent(in) though it is modified by the invocation. As a
     # result, aggressive compilers such as Fujitsu's may do a wrong
@@ -315,9 +343,19 @@ class Hdf5(CMakePackage):
 
     # The parallel compiler wrappers (i.e. h5pcc, h5pfc, etc.) reference MPI
     # compiler wrappers and do not need to be changed.
-    filter_compiler_wrappers(
-        "h5cc", "h5hlcc", "h5fc", "h5hlfc", "h5c++", "h5hlc++", relative_root="bin"
-    )
+    # These do not exist on Windows.
+    # Enable only for supported target platforms.
+    for spack_spec_target_platform in ["linux", "darwin", "cray"]:
+        filter_compiler_wrappers(
+            "h5cc",
+            "h5hlcc",
+            "h5fc",
+            "h5hlfc",
+            "h5c++",
+            "h5hlc++",
+            relative_root="bin",
+            when=f"platform={spack_spec_target_platform}",
+        )
 
     def url_for_version(self, version):
         url = (
@@ -339,6 +377,8 @@ class Hdf5(CMakePackage):
                 # More recent versions set CMAKE_POSITION_INDEPENDENT_CODE to
                 # True and build with PIC flags.
                 cmake_flags.append(self.compiler.cc_pic_flag)
+            if spec.satisfies("@1.8.21 %oneapi@2023.0.0"):
+                cmake_flags.append("-Wno-error=int-conversion")
         elif name == "cxxflags":
             if spec.satisfies("@:1.8.12+cxx~shared"):
                 cmake_flags.append(self.compiler.cxx_pic_flag)
@@ -406,11 +446,7 @@ class Hdf5(CMakePackage):
                 "libhdf5_java",
                 "libhdf5",
             ],
-            ("cxx", "hl"): [
-                "libhdf5_hl_cpp",
-                "libhdf5_hl",
-                "libhdf5",
-            ],
+            ("cxx", "hl"): ["libhdf5_hl_cpp", "libhdf5_hl", "libhdf5"],
             ("fortran", "hl"): [
                 "libhdf5_hl_fortran",
                 "libhdf5_hl_f90cstub",
@@ -419,29 +455,11 @@ class Hdf5(CMakePackage):
                 "libhdf5_f90cstub",
                 "libhdf5",
             ],
-            ("hl",): [
-                "libhdf5_hl",
-                "libhdf5",
-            ],
-            ("cxx", "fortran"): [
-                "libhdf5_fortran",
-                "libhdf5_f90cstub",
-                "libhdf5_cpp",
-                "libhdf5",
-            ],
-            ("cxx",): [
-                "libhdf5_cpp",
-                "libhdf5",
-            ],
-            ("fortran",): [
-                "libhdf5_fortran",
-                "libhdf5_f90cstub",
-                "libhdf5",
-            ],
-            ("java",): [
-                "libhdf5_java",
-                "libhdf5",
-            ],
+            ("hl",): ["libhdf5_hl", "libhdf5"],
+            ("cxx", "fortran"): ["libhdf5_fortran", "libhdf5_f90cstub", "libhdf5_cpp", "libhdf5"],
+            ("cxx",): ["libhdf5_cpp", "libhdf5"],
+            ("fortran",): ["libhdf5_fortran", "libhdf5_f90cstub", "libhdf5"],
+            ("java",): ["libhdf5_java", "libhdf5"],
         }
 
         # Turn the query into the appropriate key
@@ -449,6 +467,79 @@ class Hdf5(CMakePackage):
         libraries = query2libraries[key]
 
         return find_libraries(libraries, root=self.prefix, shared=shared, recursive=True)
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("-showconfig", output=str, error=str)
+        match = re.search(r"HDF5 Version: (\d+\.\d+\.\d+)(\D*\S*)", output)
+        return match.group(1) if match else None
+
+    @classmethod
+    def determine_variants(cls, exes, version):
+        def is_enabled(text):
+            if text in set(["t", "true", "enabled", "yes", "1"]):
+                return True
+            return False
+
+        results = []
+        for exe in exes:
+            variants = []
+            output = Executable(exe)("-showconfig", output=str, error=os.devnull)
+            match = re.search(r"High-level library: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+hl")
+            else:
+                variants.append("~hl")
+
+            match = re.search(r"Parallel HDF5: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+mpi")
+            else:
+                variants.append("~mpi")
+
+            match = re.search(r"C\+\+: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+cxx")
+            else:
+                variants.append("~cxx")
+
+            match = re.search(r"Fortran: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+fortran")
+            else:
+                variants.append("~fortran")
+
+            match = re.search(r"Java: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+java")
+            else:
+                variants.append("~java")
+
+            match = re.search(r"Threadsafety: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+threadsafe")
+            else:
+                variants.append("~threadsafe")
+
+            match = re.search(r"Build HDF5 Tools: (\S+)", output)
+            if match and is_enabled(match.group(1)):
+                variants.append("+tools")
+            else:
+                variants.append("~tools")
+
+            match = re.search(r"I/O filters \(external\): \S*(szip\(encoder\))\S*", output)
+            if match:
+                variants.append("+szip")
+            else:
+                variants.append("~szip")
+
+            match = re.search(r"Default API mapping: (\S+)", output)
+            if match and match.group(1) in set(["v114", "v112", "v110", "v18", "v16"]):
+                variants.append("api={0}".format(match.group(1)))
+
+            results.append(" ".join(variants))
+
+        return results
 
     @when("@:1.8.21,1.10.0:1.10.5+szip")
     def setup_build_environment(self, env):
@@ -480,6 +571,7 @@ class Hdf5(CMakePackage):
                 # are enabled but the tests are disabled.
                 spec.satisfies("@1.8.22+shared+tools"),
             ),
+            self.define_from_variant("HDF5_ENABLE_MAP_API", "map"),
             self.define("HDF5_ENABLE_Z_LIB_SUPPORT", True),
             self.define_from_variant("HDF5_ENABLE_SZIP_SUPPORT", "szip"),
             self.define_from_variant("HDF5_ENABLE_SZIP_ENCODING", "szip"),
@@ -498,14 +590,19 @@ class Hdf5(CMakePackage):
         if api != "default":
             args.append(self.define("DEFAULT_API_VERSION", api))
 
-        if "+mpi" in spec:
-            args.append(self.define("CMAKE_C_COMPILER", spec["mpi"].mpicc))
+        # MSMPI does not provide compiler wrappers
+        # and pointing these variables at the MSVC compilers
+        # breaks CMake's mpi detection for MSMPI.
+        if "+mpi" in spec and "msmpi" not in spec:
+            args.extend(
+                [
+                    "-DMPI_CXX_COMPILER:PATH=%s" % spec["mpi"].mpicxx,
+                    "-DMPI_C_COMPILER:PATH=%s" % spec["mpi"].mpicc,
+                ]
+            )
 
-            if "+cxx" in self.spec:
-                args.append(self.define("CMAKE_CXX_COMPILER", spec["mpi"].mpicxx))
-
-            if "+fortran" in self.spec:
-                args.append(self.define("CMAKE_Fortran_COMPILER", spec["mpi"].mpifc))
+            if "+fortran" in spec:
+                args.extend(["-DMPI_Fortran_COMPILER:PATH=%s" % spec["mpi"].mpifc])
 
         # work-around for https://github.com/HDFGroup/hdf5/issues/1320
         if spec.satisfies("@1.10.8,1.13.0"):
@@ -567,7 +664,7 @@ class Hdf5(CMakePackage):
             r"(Requires(?:\.private)?:.*)(hdf5[^\s,]*)(?:-[^\s,]*)(.*)",
             r"\1\2\3",
             *pc_files,
-            backup=False
+            backup=False,
         )
 
         # Create non-versioned symlinks to the versioned pkg-config files:

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -13,9 +13,10 @@ class PyH5py(PythonPackage):
     homepage = "https://www.h5py.org/"
     pypi = "h5py/h5py-3.3.0.tar.gz"
     git = "https://github.com/h5py/h5py.git"
-    maintainers = ["bryanherman", "takluyver"]
+    maintainers("bryanherman", "takluyver")
 
     version("master", branch="master")
+    version("3.8.0", sha256="6fead82f0c4000cf38d53f9c030780d81bfa0220218aee13b90b7701c937d95f")
     version("3.7.0", sha256="3fcf37884383c5da64846ab510190720027dca0768def34dd8dcb659dbe5cbf3")
     version("3.6.0", sha256="8752d2814a92aba4e2b2a5922d2782d0029102d99caaf3c201a566bc0b40db29")
     version("3.5.0", sha256="77c7be4001ac7d3ed80477de5b6942501d782de1bbe4886597bdfec2a7ab821f")
@@ -37,39 +38,46 @@ class PyH5py(PythonPackage):
     variant("mpi", default=True, description="Build with MPI support")
 
     # Python versions
+    depends_on("python@:3.9", type=("build", "run"), when="@:2.8")
     depends_on("python@3.6:", type=("build", "run"), when="@3:3.1")
     depends_on("python@3.7:", type=("build", "run"), when="@3.2:")
 
     # Build dependencies
-    depends_on("py-cython@0.23:", type="build", when="@:2")
-    depends_on("py-cython@0.29:", type=("build"), when="@3: ^python@:3.7")
-    depends_on("py-cython@0.29.14:", type=("build"), when="@3: ^python@3.8.0:3.8")
-    depends_on("py-cython@0.29.15:", type=("build"), when="@3: ^python@3.9.0:")
+    depends_on("py-cython@0.23:0", type="build", when="@:2")
+    depends_on("py-cython@0.29:0", type=("build"), when="@3:")
+    depends_on("py-cython@0.29.14:0", type=("build"), when="@3:3.7 ^python@3.8.0:3.8")
+    depends_on("py-cython@0.29.15:0", type=("build"), when="@3:3.7 ^python@3.9.0:")
     depends_on("py-pkgconfig", type="build")
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@61:", type="build", when="@3.8.0:")
     depends_on("py-wheel", type="build", when="@3:")
 
     # Build and runtime dependencies
-    depends_on("py-cached-property@1.5:", type=("build", "run"), when="^python@:3.7")
+    depends_on("py-cached-property@1.5:", type=("build", "run"), when="@:3.6 ^python@:3.7")
     depends_on("py-numpy@1.7:", type=("build", "run"), when="@:2")
-    depends_on("py-numpy@1.12:", type=("build", "run"), when="@3: ^python@3.6.0:3.6")
-    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@3: ^python@3.7.0:3.7")
-    depends_on("py-numpy@1.17.5:", type=("build", "run"), when="@3: ^python@3.8.0:3.8")
-    depends_on("py-numpy@1.19.3:", type=("build", "run"), when="@3: ^python@3.9.0:")
+    depends_on("py-numpy@1.14.5:", type=("build", "run"), when="@3:")
+    depends_on("py-numpy@1.17.5:", type=("build", "run"), when="@3:3.5 ^python@3.8.0:3.8")
+    depends_on("py-numpy@1.19.3:", type=("build", "run"), when="@3:3.5 ^python@3.9.0:")
     depends_on("py-six", type=("build", "run"), when="@:2")
 
     # Link dependencies (py-h5py v2 cannot build against HDF5 1.12 regardless
     # of API setting)
     depends_on("hdf5@1.8.4:1.11 +hl", when="@:2")
-    depends_on("hdf5@1.8.4: +hl", when="@3:")
+    depends_on("hdf5@1.8.4:1.12 +hl", when="@3:3.7")
+    depends_on("hdf5@1.8.4:1.14 +hl", when="@3.8:")
 
     # MPI dependencies
     depends_on("hdf5+mpi", when="+mpi")
     depends_on("mpi", when="+mpi")
     depends_on("py-mpi4py", when="@:2 +mpi", type=("build", "run"))
-    depends_on("py-mpi4py@3:", when="@3:3.2+mpi^python@3:3.7", type=("build", "run"))
-    depends_on("py-mpi4py@3.0.2:", when="@3.3.0:+mpi^python@3:3.7", type=("build", "run"))
-    depends_on("py-mpi4py@3.0.3:", when="@3:+mpi^python@3.8.0:", type=("build", "run"))
+    depends_on("py-mpi4py@3.0.2:", when="@3: +mpi", type=("build", "run"))
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%oneapi@2023.0.0:"):
+                flags.append("-Wno-error=incompatible-function-pointer-types")
+                flags.append("-Wno-error=incompatible-pointer-types-discards-qualifiers")
+        return (flags, None, None)
 
     def setup_build_environment(self, env):
         env.set("HDF5_DIR", self.spec["hdf5"].prefix)


### PR DESCRIPTION
Backports the updated recipes for HDF5 and H5Py. Also adds the patch for the pagebuffer fix for `hdf5@1.14.0`.