### PR TITLE
steps: add 4.1.0 and cleanup

### DIFF
--- a/bluebrain/repo-patches/packages/steps/package.py
+++ b/bluebrain/repo-patches/packages/steps/package.py
@@ -32,6 +32,7 @@ class Steps(CMakePackage):
         default=False if sys.platform == "darwin" else True,
         description="Generate non-portable arch-specific code",
     )
+    variant("blender", default=False, description="Build stepsblender package")
     variant("lapack", default=False, description="Use new BDSystem/Lapack code for E-Field solver")
     variant("distmesh", default=True, description="Add solvers based on distributed mesh")
     variant("petsc", default=True, description="Use PETSc library for parallel E-Field solver")

--- a/bluebrain/repo-patches/packages/steps/package.py
+++ b/bluebrain/repo-patches/packages/steps/package.py
@@ -16,9 +16,11 @@ class Steps(CMakePackage):
 
     maintainers("tristan0x")
 
-    version("develop", branch="master", submodules=True)
-    version("5.0.0a", commit="b4bdd64", submodules=True)
-    version("4.1.0", submodules=True, preferred=True)
+    submodules = True
+
+    version("develop", branch="master")
+    version("5.0.0a", commit="b4bdd64")
+    version("4.1.0", tag="4.1.0", preferred=True)
 
     variant(
         "codechecks",

--- a/bluebrain/repo-patches/packages/steps/package.py
+++ b/bluebrain/repo-patches/packages/steps/package.py
@@ -77,7 +77,9 @@ class Steps(CMakePackage):
     depends_on("py-cython")
     depends_on("py-gcovr", when="+coverage", type="build")
     depends_on("py-h5py", type=("build", "test", "run"))
+    depends_on("py-pip", type="build", when="@5:")
     depends_on("py-matplotlib", type=("build", "test"))
+    depends_on("py-build", type="build", when="@5:")
     depends_on("py-mpi4py", when="+distmesh", type=("build", "test", "run"))
     depends_on("py-numpy", type=("build", "test", "run"))
     depends_on("py-scipy", type=("build", "test", "run"))
@@ -100,7 +102,6 @@ class Steps(CMakePackage):
         )
         args = [
             self.define("STEPS_INSTALL_PYTHON_DEPS", False),
-            self.define("STEPS_USE_STEPSBLENDER", False),
             self.define_from_variant("BUILD_STOCHASTIC_TESTS", "stochtests"),
             self.define_from_variant("BUILD_TESTING", "codechecks"),
             self.define_from_variant("ENABLE_CODECOVERAGE", "coverage"),
@@ -109,6 +110,7 @@ class Steps(CMakePackage):
             self.define_from_variant("STEPS_USE_CALIPER_PROFILING", "caliper"),
             self.define_from_variant("STEPS_USE_DIST_MESH", "distmesh"),
             self.define_from_variant("STEPS_USE_LIKWID_PROFILING", "likwid"),
+            self.define_from_variant("STEPS_USE_STEPSBLENDER", "blender"),
             self.define_from_variant("STEPS_USE_VESICLE_SOLVER", "vesicle"),
             self.define_from_variant("TARGET_NATIVE_ARCH", "native"),
             self.define_from_variant("USE_BDSYSTEM_LAPACK", "lapack"),

--- a/bluebrain/repo-patches/packages/steps/package.py
+++ b/bluebrain/repo-patches/packages/steps/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -14,18 +14,16 @@ class Steps(CMakePackage):
     homepage = "https://groups.oist.jp/cnu/software"
     git = "ssh://git@bbpgitlab.epfl.ch/hpc/HBP_STEPS.git"
 
-    submodules = True
+    maintainers("tristan0x")
 
-    version("develop", branch="master")
-    version("5.0.0a", commit="d75d46f")
-    version("4.0.0", tag="4.0.0", preferred=True)
-    version("3.6.0", tag="3.6.0")
-    version("3.5.0b", commit="b2be5fe")
+    version("develop", branch="master", submodules=True)
+    version("5.0.0a", commit="b4bdd64", submodules=True)
+    version("4.1.0", submodules=True, preferred=True)
 
     variant(
         "codechecks",
         default=False,
-        description="Perform additional code checks like " "code formatting or static analysis",
+        description="Perform additional code checks like code formatting or static analysis",
     )
     variant(
         "native",
@@ -55,40 +53,35 @@ class Steps(CMakePackage):
 
     # Build with `ninja` instead of `make`
     generator = "Ninja"
-    depends_on("ninja", type="build")
 
+    conflicts("+distmesh~mpi", msg="steps+distmesh requires +mpi")
     depends_on("benchmark", type=("build", "test"))
-    depends_on("boost", when="@:3")
-    depends_on("boost", when="@4:", type="build")
     depends_on("blas")
+    depends_on("boost", type="build")
+    depends_on("caliper", when="+caliper")
+    depends_on("easyloggingpp", when="~bundle")
+    depends_on("gmsh", when="+distmesh")
     depends_on("gsl", when="+vesicle")
     depends_on("lapack", when="+lapack")
     depends_on("lcov", when="+coverage", type="build")
-    depends_on("metis+int64", when="@3.6.1:")
-    depends_on("eigen", when="@3.6.1:")
+    depends_on("likwid", when="+likwid")
+    depends_on("metis+int64")
     depends_on("mpi", when="+mpi")
+    depends_on("ninja", type="build")
+    depends_on("omega-h+gmsh+mpi", when="~bundle+distmesh")
     depends_on("petsc~debug+int64+mpi", when="+petsc+mpi")
     depends_on("petsc~debug+int64~mpi", when="+petsc~mpi")
     depends_on("pkgconfig", type="build")
-    depends_on("py-build", type="build", when="@5:")
-    depends_on("py-pip", type="build", when="@5:")
     depends_on("py-cython")
-    depends_on("py-h5py", type=("build", "test", "run"))
     depends_on("py-gcovr", when="+coverage", type="build")
+    depends_on("py-h5py", type=("build", "test", "run"))
     depends_on("py-matplotlib", type=("build", "test"))
     depends_on("py-mpi4py", when="+distmesh", type=("build", "test", "run"))
-    depends_on("py-nose", when="@3:4", type=("build", "test"))
     depends_on("py-numpy", type=("build", "test", "run"))
     depends_on("py-scipy", type=("build", "test", "run"))
     depends_on("python", type=("build", "test", "run"))
-    depends_on("omega-h+gmsh+mpi", when="~bundle+distmesh")
-    depends_on("gmsh", when="+distmesh")
-    depends_on("easyloggingpp", when="~bundle")
     depends_on("random123", when="~bundle")
     depends_on("sundials@:2.99.99+int64", when="~bundle")
-    depends_on("caliper", when="+caliper")
-    depends_on("likwid", when="+likwid")
-    conflicts("+distmesh~mpi", msg="steps+distmesh requires +mpi")
 
     patch("for_aarch64.patch", when="target=aarch64:")
 
@@ -106,8 +99,6 @@ class Steps(CMakePackage):
         args = [
             self.define("STEPS_INSTALL_PYTHON_DEPS", False),
             self.define("STEPS_USE_STEPSBLENDER", False),
-            self.define("USE_MPI", "True" if "+mpi" in self.spec else "False"),
-            self.define("USE_PETSC", "True" if "+petsc" in self.spec else "False"),
             self.define_from_variant("BUILD_STOCHASTIC_TESTS", "stochtests"),
             self.define_from_variant("BUILD_TESTING", "codechecks"),
             self.define_from_variant("ENABLE_CODECOVERAGE", "coverage"),
@@ -116,9 +107,11 @@ class Steps(CMakePackage):
             self.define_from_variant("STEPS_USE_CALIPER_PROFILING", "caliper"),
             self.define_from_variant("STEPS_USE_DIST_MESH", "distmesh"),
             self.define_from_variant("STEPS_USE_LIKWID_PROFILING", "likwid"),
-            self.define_from_variant("STEPS_USE_VESICLE_MODEL", "vesicle"),
+            self.define_from_variant("STEPS_USE_VESICLE_SOLVER", "vesicle"),
             self.define_from_variant("TARGET_NATIVE_ARCH", "native"),
             self.define_from_variant("USE_BDSYSTEM_LAPACK", "lapack"),
+            self.define_from_variant("USE_MPI", "mpi"),
+            self.define_from_variant("USE_PETSC", "petsc"),
             "-DBLAS_LIBRARIES=" + self.spec["blas"].libs.joined(";"),
             f"-DPYTHON_EXECUTABLE={python_interpreter}",
         ]

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -235,7 +235,7 @@ class BundleFetchStrategy(FetchStrategy):
 
     def mirror_id(self):
         """BundlePackages don't have a mirror id."""
-        return ''
+        return ""
 
 
 class FetchStrategyComposite(pattern.Composite):

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -801,6 +801,8 @@ class GitFetchStrategy(VCSFetchStrategy):
 
     def mirror_id(self):
         repo_ref = self.commit or self.tag or self.branch
+        if repo_ref is None:
+            raise ValueError("GitFetchStrategy requires at least a commit, a tag, or a branch.")
         if self.submodules:
             repo_ref += "_submodules"
         if repo_ref:


### PR DESCRIPTION
* add new version 4.1.0
* remove unused versions and cleanup dependencies accordingly
* rename CMake option `STEPS_USE_VESICLE_MODEL` to `STEPS_USE_VESICLE_SOLVER`
* use spack function `define_from_variant` for `USE_MPI` and `USE_PETSC` since both master and 4.1.0 now allow boolean values