### PR TITLE
nvhpc: runtime dependency on binutils

### DIFF
--- a/bluebrain/repo-patches/packages/nvhpc/package.py
+++ b/bluebrain/repo-patches/packages/nvhpc/package.py
@@ -1,0 +1,8 @@
+from spack.package import *
+from spack.pkg.builtin.nvhpc import Nvhpc as BuiltinNvhpc
+
+
+class Nvhpc(BuiltinNvhpc):
+    __doc__ = BuiltinNvhpc.__doc__
+    # Otherwise module load nvhpc leaves us with a prehistoric binutils
+    depends_on("binutils", type="run")


### PR DESCRIPTION
After https://github.com/BlueBrain/spack/pull/1929, some compilation with `%nvhpc` fails due to a too-old `ld` (example: [here](https://bbpgitlab.epfl.ch/hpc/nmodl/-/jobs/648738)).

```console
$ unset MODULEPATH
$ . /gpfs/bbp.cscs.ch/ssd/apps/bsd/pulls/1955/config/modules.sh
$ module load unstable
$ which ld
/usr/bin/ld
$ module load nvhpc
$ which ld
/gpfs/bbp.cscs.ch/ssd/apps/bsd/2023-02-23/stage_externals/install_gcc-12.2.0-skylake/binutils-2.37-e57ece/bin/ld
```

TODO:
- [x] Check that https://bbpgitlab.epfl.ch/hpc/nmodl/-/pipelines/115246 passes ✅ 