### PR TITLE
py-dask-mpi: remove jupyter-server-proxy (#36680)

### DIFF
--- a/var/spack/repos/builtin/packages/py-dask-mpi/package.py
+++ b/var/spack/repos/builtin/packages/py-dask-mpi/package.py
@@ -23,6 +23,9 @@ class PyDaskMpi(PythonPackage):
     depends_on("py-dask@2.2:", when="@:2.21.0", type=("build", "run"))
     depends_on("py-dask@2.19:", when="@2022.4.0:", type=("build", "run"))
     depends_on("py-distributed@2.19:", when="@2022.4.0:", type=("build", "run"))
-    depends_on("py-jupyter-server-proxy", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-mpi4py@3.0.3:", when="@2022.4.0:", type=("build", "run"))
+
+    # jupyter-server-proxy is not a needed dependency; https://github.com/dask/dask-mpi/pull/102
+    # this significantly reduces the dependency tree of py-dask-mpi
+    patch("remove-dependency-jupyter-proxy.patch", when="@:2022.4.0")

--- a/var/spack/repos/builtin/packages/py-dask-mpi/remove-dependency-jupyter-proxy.patch
+++ b/var/spack/repos/builtin/packages/py-dask-mpi/remove-dependency-jupyter-proxy.patch
@@ -1,0 +1,9 @@
+diff --git a/environment.yml b/environment.yml
+index 5747157..a552b81 100644
+--- a/environment.yml
++++ b/environment.yml
+@@ -3,4 +3,3 @@ dependencies:
+   - dask>=2.19
+   - distributed>=2.19
+   - mpi4py>=3.0.3
+-  - jupyter-server-proxy


### PR DESCRIPTION
* py-dask-mpi: remove jupyter-server-proxy

This dependency isn't a 'hard' one; it optionally simplifies getting access to the web consoles. See: https://github.com/dask/dask-mpi/pull/102