### PR TITLE
neuron: revert NRN_ENABLE_MPI_DYNAMIC=ON change

### DIFF
--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -221,7 +221,8 @@ class Neuron(CMakePackage):
             args.append("-DNRN_SANITIZERS=" + ",".join(self.spec.variants["sanitizers"].value))
         if "+mpi" in self.spec:
             args.append("-DNRN_ENABLE_MPI=ON")
-            args.append("-DNRN_ENABLE_MPI_DYNAMIC=ON")
+            if "~coreneuron" in self.spec:
+                args.append("-DNRN_ENABLE_MPI_DYNAMIC=ON")
         else:
             args.append("-DNRN_ENABLE_MPI=OFF")
         if "+python" in self.spec:


### PR DESCRIPTION
Revert #1952 pending required fixes.

TODO:
- [x] Confirm that this branch is sufficient to un-break NEURON and BlueConfigs CI, pending in https://bbpgitlab.epfl.ch/hpc/cellular/nrn/-/pipelines/116101 ✅ 