### PR TITLE
deploy: darshan-runtime - set DARSHAN_LOGHINTS in the generated module

### DIFF
--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -54,6 +54,11 @@ spack:
           environment:
             prepend_path:
               LD_LIBRARY_PATH: '{prefix}/lib'
+        # until darshan-hpc/darshan/issues/920 is fixed
+        darshan-runtime:
+          environment:
+            set:
+              DARSHAN_LOGHINTS: 'romio_no_indep_rw=false'
         linaro-forge:
           environment:
             set:


### PR DESCRIPTION
Until darshan-hpc/darshan/issues/920 is well understood and fixed upstream, set MPI I/O hint `romio_no_indep_rw=false` to avoid the bug.