### PR TITLE
deploy: add py-archive-advisor package for deployment

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -12,6 +12,7 @@ spack:
           - neurodamus-thalamus
           - neurodamus-mousify
           - parquet-converters
+          - py-archive-advisor
           - py-basalt
           - py-mvdtool
           - py-neurodamus
@@ -47,6 +48,7 @@ spack:
     - neuron+coreneuron build_type=FastDebug
     - nmodl
     - parquet-converters
+    - py-archive-advisor
     - py-neurodamus
     - py-pytouchreader
     - reportinglib


### PR DESCRIPTION
deploy: add `archive-advisor` to deploy list to make it more readily available to users.