### PR TITLE
deploy: Ospray should really be `%gcc`

### DIFF
--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -114,8 +114,6 @@ packages:
     externals:
     - spec: opengl@4.5
       prefix: /usr
-  ospray:
-    require: "%intel"
   perl:
     version: [5.16.3]
     externals:


### PR DESCRIPTION
In the context of BSD-350, we found out that Brayns' unit tests crash
_unless_ we change Ospray from Intel over to GCC.
