### PR TITLE
mpich, sim-model: import dso_suffix

### DIFF
--- a/bluebrain/repo-bluebrain/packages/sim-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/sim-model/package.py
@@ -7,6 +7,7 @@ import os
 import shutil
 from contextlib import contextmanager
 
+from spack.build_environment import dso_suffix
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 
+from spack.build_environment import dso_suffix
 from spack.package import *
 
 


### PR DESCRIPTION
The one in `mpich` is causing the containerization of neurodamus-neocortex to fail.