### PR TITLE
deploy: allow {[core]neuron,nmodl}%oneapi

### DIFF
--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -238,6 +238,9 @@ class Neuron(CMakePackage):
             if "%intel" in self.spec:
                 # This one definitely seems wise
                 compilation_flags += ["-fp-model", "consistent"]
+            elif "%oneapi" in self.spec:
+                # The documentation doesn't mention consistent for these intel compilers
+                compilation_flags.append("-fp-model=precise")
             # Remove default flags (RelWithDebInfo etc.)
             args.append("-DCMAKE_BUILD_TYPE=Custom")
 

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -17,7 +17,7 @@ packages:
     # Keep this aligned with NEURON, otherwise the Spack solver may decide that
     # rolling back to NEURON 8.2.2 with external CoreNEURON is a net win
     require:
-      - one_of: ["%intel", "%nvhpc"]
+      - one_of: ["%intel", "%nvhpc", "%oneapi"]
   cuda:
     # Pin GCC 11 because CUDA 11.8.0 is incompatible with GCC 12
     # CUDA 12.0.0 should be compatible with GCC 12
@@ -70,7 +70,6 @@ packages:
   model-neocortex:
     variants: ~gpu
     require: "%intel"
-      # - one_of: ["%intel", "%nvhpc"]
   mxnet:
     version: [1.8.0]  # Don't build @1.master because nobody likes moving targets
   neurodamus-hippocampus:
@@ -90,10 +89,10 @@ packages:
     require: "%intel"
   neuron:
     require:
-      - one_of: ["%intel", "%nvhpc"]
+      - one_of: ["%intel", "%nvhpc", "%oneapi"]
   nmodl:
     require:
-      - one_of: ["%gcc", "%intel", "%nvhpc"]
+      - one_of: ["%gcc", "%intel", "%nvhpc", "%oneapi"]
   omega-h:
     variants: ~kokkos~trilinos
   opencv:


### PR DESCRIPTION
Also teach neuron what `build_type=FastDebug` means with `%oneapi`.

Reduced version of https://github.com/BlueBrain/spack/pull/1891 that should be sufficient to allow https://github.com/neuronsimulator/nrn/pull/2259 to be merged.

Changing which Intel compiler we deploy NEURON/neurodamus with, and banning `%intel`, will be done later.