### PR TITLE
intel-oneapi-compilers: runtime dep on binutils

### DIFF
--- a/bluebrain/deployment/bin/configure-compilers
+++ b/bluebrain/deployment/bin/configure-compilers
@@ -70,9 +70,12 @@ while read -r line; do
     echo "${cmd}"
     ${cmd}
     set -o nounset
-    if [[ ${spec} != *"intel-parallel-studio"* ]]; then
-        spack compiler find --scope=user
-    fi
+    output=$(spack compiler find --scope=user)
+    echo "${output}"
+    # Grab a list of compiler specs, e.g. gcc@11.3.0. Note that for compiler packages like
+    # intel-oneapi-compilers@a.b.c this can be multiple specs (intel@d.e.f, oneapi@g.h.i,
+    # dpcpp@j.k.l) with versions that are not all the same.
+    compiler_specs=$(echo "${output}" | grep -o '[a-z]\+@[0-9\.]\+')
 
     if [[ ${spec} = *"intel"* ]]; then
         # update intel modules to use newer gcc in .cfg files
@@ -110,11 +113,6 @@ while read -r line; do
 
     cmd=${cmd/unload/show/}
     full_module_path="$(${cmd}|&sed -ne '2{s/:$// p}')"
-    spec=${spec%%[+ ]*}             # truncate variants
-    spec=${spec/llvm/clang}         # LLVM identifies as clang
-    spec=${spec/20.0.4/19.1.3.304}  # Intel identifies as an older version
-    # Intel oneapi™ is split into two, gains another version tidbit
-    spec=${spec/intel-oneapi-compilers@2021.4.0/\\(intel\\|oneapi\\)@2021.4.0}
     # Remove empty module definitions, as they may appear anywhere
     # under the compiler key. Further, purge some garbage where clang's
     # spec spans multiple lines with a quote in front.
@@ -125,8 +123,11 @@ while read -r line; do
         /modules: \[\]/ d;
         /^\s*Target:.\s*$/ d;
         /^\s*$/ d;
-        s#spec: .clang#spec: clang#
-        s#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' ${HOME}/.spack/compilers.yaml
+        s#spec: .clang#spec: clang#' ${HOME}/.spack/compilers.yaml
+    for spec in ${compiler_specs}; do
+        sed -i -e 's#\( *\)spec: '"${spec}"'#&\n\1modules: ['"${full_module_path}"']#' \
+          ${HOME}/.spack/compilers.yaml
+    done
 done
 
 sed  -i 's#.*f\(77\|c\): null#      f\1: /usr/bin/gfortran#' ${HOME}/.spack/compilers.yaml

--- a/bluebrain/repo-patches/packages/intel-oneapi-compilers/package.py
+++ b/bluebrain/repo-patches/packages/intel-oneapi-compilers/package.py
@@ -1,0 +1,10 @@
+from spack.package import *
+from spack.pkg.builtin.intel_oneapi_compilers import (
+    IntelOneapiCompilers as BuiltinIntelOneapiCompilers,
+)
+
+
+class IntelOneapiCompilers(BuiltinIntelOneapiCompilers):
+    __doc__ = BuiltinIntelOneapiCompilers.__doc__
+    # Otherwise module load intel-oneapi-compilers leaves us with a prehistoric binutils
+    depends_on("binutils", type="run")


### PR DESCRIPTION
Intel analogue of NVHPC fix in #1955. Avoids a prehistoric binutils when building with %oneapi. Should fix e.g. https://bbpgitlab.epfl.ch/hpc/nmodl/-/jobs/688876.

Update compiler configuration logic to get the list of compiler specs provided by a particular package from Spack, instead of using ad-hoc logic. This fixes a bug whereby the Intel entries in `compilers.yaml` did not contain the list of `modules` to be loaded, which meant that the `binutils` fix above was not picked up.

TODO:
- [x] Check that with this PR `module load intel-oneapi-compilers` followed by `which ld` shows a binary from the deployment's modern `binutils`

```console
[olupton@bbpv2 ~]$ module purge
[olupton@bbpv2 ~]$ module load /gpfs/bbp.cscs.ch/ssd/apps/bsd/pulls/1994/stage_compilers/modules_tcl/linux-rhel7-haswell/intel-oneapi-compilers/2022.2.1
[olupton@bbpv2 ~]$ which ld
/gpfs/bbp.cscs.ch/ssd/apps/bsd/2023-02-23/stage_compilers/install_gcc-4.8.5-haswell/binutils-2.37-l5h4u2/bin/ld
```