### PR TITLE
py-archive-advisor: bump version

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-archive-advisor/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-archive-advisor/package.py
@@ -13,6 +13,7 @@ class PyArchiveAdvisor(PythonPackage):
     git = "ssh://git@bbpgitlab.epfl.ch/hpc/archive-advisor.git"
 
     version("develop", branch="main")
+    version("0.0.3", tag="0.0.3")
     version("0.0.2", tag="0.0.2")
     version("0.0.1", tag="0.0.1")
 


### PR DESCRIPTION
This MR bumps the version of `py-archive-advisor` to the `0.0.3` tag, current latest.