### PR TITLE
py-archive-advisor: bump version to 0.0.4

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-archive-advisor/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-archive-advisor/package.py
@@ -13,6 +13,7 @@ class PyArchiveAdvisor(PythonPackage):
     git = "ssh://git@bbpgitlab.epfl.ch/hpc/archive-advisor.git"
 
     version("develop", branch="main")
+    version("0.0.4", tag="0.0.4")
     version("0.0.3", tag="0.0.3")
     version("0.0.2", tag="0.0.2")
     version("0.0.1", tag="0.0.1")


### PR DESCRIPTION
Simple PR to bump `py-archive-advisor` to version 0.0.4. 

It mainly fixes a bug in how a `PermissionError` exception gets handled.