### PR TITLE
neuron: enable some unsafe math optimisations with GCC

### DIFF
--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -297,15 +297,17 @@ class Neuron(CMakePackage):
             compilation_flags.append(
                 self.spec.architecture.target.optimization_flags(self.spec.compiler)
             )
-            # In case we're using GCC compiler we enable `-ffast-math` to allow vectorization
+            # In case we're using GCC compiler we enable certain optimization options to allow vectorization
             # of mechanism kernels in case `libmvec` is available in the system.
             # Due to the fact that the generated code by NMODL includes `#pragma omp simd` clauses
-            # we also need to enable `+openmp` to make sure that the code gets vectorized
+            # we also need to enable `+openmp` or add `-fopenmp-simd` to make sure that the code gets vectorized
             if "%gcc" in self.spec and self.spec.variants["build_type"].value in [
                 "Release",
                 "RelWithDebInfo",
             ]:
-                compilation_flags.append("-ffast-math")
+                compilation_flags.append("-ffinite-math-only -fno-math-errno -funsafe-math-optimizations")
+                if "+openmp" not in self.spec:
+                    compilation_flags.append("-fopenmp-simd")
         if "%intel" in self.spec:
             # icpc: command line warning #10121: overriding '-march=skylake' with '-march=skylake'
             compilation_flags.append("-diag-disable=10121")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -307,9 +307,12 @@ class Neuron(CMakePackage):
                 "Release",
                 "RelWithDebInfo",
             ]:
-                compilation_flags.append(
-                    "-ffinite-math-only -fno-math-errno -funsafe-math-optimizations -fno-associative-math"
-                )
+                compilation_flags += [
+                    "-ffinite-math-only",
+                    "-fno-math-errno",
+                    "-funsafe-math-optimizations",
+                    "-fno-associative-math",
+                ]
                 if "+openmp" not in self.spec:
                     compilation_flags.append("-fopenmp-simd")
         if "%intel" in self.spec:

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -297,6 +297,12 @@ class Neuron(CMakePackage):
             compilation_flags.append(
                 self.spec.architecture.target.optimization_flags(self.spec.compiler)
             )
+            # In case we're using GCC compiler we enable `-ffast-math` to allow vectorization
+            # of mechanism kernels in case `libmvec` is available in the system.
+            # Due to the fact that the generated code by NMODL includes `#pragma omp simd` clauses
+            # we also need to enable `+openmp` to make sure that the code gets vectorized
+            if "%gcc" in self.spec and self.spec.variants["build_type"].value in ["Release", "RelWithDebInfo"]:
+                compilation_flags.append("-ffast-math")
         if "%intel" in self.spec:
             # icpc: command line warning #10121: overriding '-march=skylake' with '-march=skylake'
             compilation_flags.append("-diag-disable=10121")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -308,7 +308,7 @@ class Neuron(CMakePackage):
                 "RelWithDebInfo",
             ]:
                 compilation_flags.append(
-                    "-ffinite-math-only -fno-math-errno -funsafe-math-optimizations"
+                    "-ffinite-math-only -fno-math-errno -funsafe-math-optimizations -fno-associative-math"
                 )
                 if "+openmp" not in self.spec:
                     compilation_flags.append("-fopenmp-simd")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -305,7 +305,9 @@ class Neuron(CMakePackage):
                 "Release",
                 "RelWithDebInfo",
             ]:
-                compilation_flags.append("-ffinite-math-only -fno-math-errno -funsafe-math-optimizations")
+                compilation_flags.append(
+                    "-ffinite-math-only -fno-math-errno -funsafe-math-optimizations"
+                )
                 if "+openmp" not in self.spec:
                     compilation_flags.append("-fopenmp-simd")
         if "%intel" in self.spec:

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -301,7 +301,10 @@ class Neuron(CMakePackage):
             # of mechanism kernels in case `libmvec` is available in the system.
             # Due to the fact that the generated code by NMODL includes `#pragma omp simd` clauses
             # we also need to enable `+openmp` to make sure that the code gets vectorized
-            if "%gcc" in self.spec and self.spec.variants["build_type"].value in ["Release", "RelWithDebInfo"]:
+            if "%gcc" in self.spec and self.spec.variants["build_type"].value in [
+                "Release",
+                "RelWithDebInfo",
+            ]:
                 compilation_flags.append("-ffast-math")
         if "%intel" in self.spec:
             # icpc: command line warning #10121: overriding '-march=skylake' with '-march=skylake'

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -297,10 +297,12 @@ class Neuron(CMakePackage):
             compilation_flags.append(
                 self.spec.architecture.target.optimization_flags(self.spec.compiler)
             )
-            # In case we're using GCC compiler we enable certain optimization options to allow vectorization
-            # of mechanism kernels in case `libmvec` is available in the system.
-            # Due to the fact that the generated code by NMODL includes `#pragma omp simd` clauses
-            # we also need to enable `+openmp` or add `-fopenmp-simd` to make sure that the code gets vectorized
+            # In case we're using GCC compiler we enable certain optimization options
+            # to allow vectorization of mechanism kernels in case `libmvec` is available
+            # in the system.
+            # Due to the fact that the generated code by NMODL includes `#pragma omp simd`
+            # clauses we also need to enable `+openmp` or add `-fopenmp-simd` to make sure
+            # that the code gets vectorized
             if "%gcc" in self.spec and self.spec.variants["build_type"].value in [
                 "Release",
                 "RelWithDebInfo",


### PR DESCRIPTION
- Pass `-fopenmp-simd` when the `openmp` variant is **not** set, so vectorisation via `#pragma omp simd` is still possible.
- With GCC and `RelWithDebInfo` and `Release` build types, pass a limited subset of `-ffast-math` so that GCC 12+ can vectorise mechanism code generated by NMODL
  - This excludes some types of value-changing floating point optimisation, such as assuming associativity, that the Intel compilers allow by default...
  - Some parts of the NEURON codebase explicitly use compensated summation algorithms that are broken by assuming floating point calculations are associative...