### PR TITLE
py-currentscape: move to builtin

### DIFF
--- a/var/spack/repos/builtin/packages/py-currentscape/package.py
+++ b/var/spack/repos/builtin/packages/py-currentscape/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -14,12 +14,8 @@ class PyCurrentscape(PythonPackage):
 
     version("develop", branch="master")
     version("0.0.10", tag="currentscape-v0.0.10")
-    version("0.0.9", tag="currentscape-v0.0.9")
-    version("0.0.6", tag="currentscape-v0.0.6")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-numpy", type="run")
-    depends_on("py-matplotlib", type="run")
-    depends_on("py-scipy", type="run")
-    depends_on("py-bluepyopt", type="run")
-    depends_on("py-palettable", type="run")
+    depends_on("py-numpy", type=("build", "run"))
+    depends_on("py-matplotlib", type=("build", "run"))
+    depends_on("py-palettable", type=("build", "run"))


### PR DESCRIPTION
* Dependency cleanup (no more reference to dependencies which are not publicly available)
* Dependency type cleanup
* Remove older versions
