### PR TITLE
morpho-kit, py-morpho-kit: release 0.3.5

### DIFF
--- a/bluebrain/repo-bluebrain/packages/morpho-kit/package.py
+++ b/bluebrain/repo-bluebrain/packages/morpho-kit/package.py
@@ -15,7 +15,7 @@ class MorphoKit(CMakePackage):
     submodules = True
 
     version("develop", branch="main")
-    version("0.3.5", commit="aee8232e8acb7add30e210b11fe2528fa658fb9f")
+    version("0.3.5", tag="v0.3.5")
     version("0.3.4", tag="v0.3.4")
     version("0.3.3", tag="0.3.3")
     version("0.3.2", tag="v0.3.2")

--- a/bluebrain/repo-bluebrain/packages/morpho-kit/package.py
+++ b/bluebrain/repo-bluebrain/packages/morpho-kit/package.py
@@ -15,6 +15,7 @@ class MorphoKit(CMakePackage):
     submodules = True
 
     version("develop", branch="main")
+    version("0.3.5", commit="aee8232e8acb7add30e210b11fe2528fa658fb9f")
     version("0.3.4", tag="v0.3.4")
     version("0.3.3", tag="0.3.3")
     version("0.3.2", tag="v0.3.2")
@@ -23,7 +24,8 @@ class MorphoKit(CMakePackage):
     version("0.2.0", tag="v0.2.0")
 
     depends_on("cmake@3.2:", type="build")
-    depends_on("morphio@2.3.9:")
+    depends_on("morphio@2.3.9:", when="@0.3.4")
+    depends_on("morphio@3.3.5:", when="@0.3.5:")
     depends_on("cli11", when="@0.3.3:")  # for utilities
     depends_on("libsonata", when="@0.3.3:")  # for utilities
     depends_on("highfive@2.4.0:", when="@0.3.3:")  # for utilities

--- a/bluebrain/repo-bluebrain/packages/py-morpho-kit/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-morpho-kit/package.py
@@ -15,7 +15,7 @@ class PyMorphoKit(PythonPackage):
     submodules = True
 
     version("develop", branch="main")
-    version("0.3.5", commit="aee8232e8acb7add30e210b11fe2528fa658fb9f")
+    version("0.3.5", tag="v0.3.5")
     version("0.3.4", tag="v0.3.4")
     version("0.3.3", tag="0.3.3")
     version("0.3.2", tag="v0.3.2")

--- a/bluebrain/repo-bluebrain/packages/py-morpho-kit/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-morpho-kit/package.py
@@ -15,6 +15,7 @@ class PyMorphoKit(PythonPackage):
     submodules = True
 
     version("develop", branch="main")
+    version("0.3.5", commit="aee8232e8acb7add30e210b11fe2528fa658fb9f")
     version("0.3.4", tag="v0.3.4")
     version("0.3.3", tag="0.3.3")
     version("0.3.2", tag="v0.3.2")
@@ -23,7 +24,8 @@ class PyMorphoKit(PythonPackage):
     depends_on("py-setuptools", type="build")
     depends_on("py-setuptools-scm", type="build")
 
-    depends_on("morphio@2.3.9:", type=("build", "link"))
+    depends_on("morphio@2.3.9:", type=("build", "link"), when="@0.3.4")
+    depends_on("morphio@3.3.5:", type=("build", "link"), when="@0.3.5:")
 
     depends_on("cmake@3.2:", type="build")
     depends_on("py-numpy", type="run")


### PR DESCRIPTION
This release uses the `morphio.Collection` API (which was essentially copied from there).