### PR TITLE
neuron: add 9.0.a9 including SoA data

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -32,10 +32,10 @@ spack:
           ^petsc+complex: '{name}-complex/{version}'
   specs:
     - neuron+tests+coreneuron
-    - neuron+tests+nmodl+sympy+coreneuron
+    - neuron+tests+coreneuron+sympy
     - neuron%nvhpc+caliper+coreneuron+gpu+tests+openmp
-    - neuron%nvhpc+caliper+coreneuron+gpu+tests~openmp+nmodl
-    - neuron%nvhpc+caliper+coreneuron+gpu+tests+openmp+nmodl+sympy
+    - neuron%nvhpc+caliper+coreneuron+gpu+tests~openmp
+    - neuron%nvhpc+caliper+coreneuron+gpu+tests+openmp+sympy
     - nest@2.20.1
     - neurodamus-hippocampus+coreneuron+caliper
     - neurodamus-mousify+coreneuron+caliper

--- a/bluebrain/repo-bluebrain/packages/libsonata-report/package.py
+++ b/bluebrain/repo-bluebrain/packages/libsonata-report/package.py
@@ -18,6 +18,7 @@ class LibsonataReport(CMakePackage):
     git = "https://github.com/BlueBrain/libsonatareport.git"
 
     version("develop", branch="master", submodules=False, get_full_repo=True)
+    version("1.2.1", tag="1.2.1", submodules=False)
     version("1.2", tag="1.2", submodules=False)
     version("1.1.1", tag="1.1.1", submodules=False)
     version("1.1", tag="1.1", submodules=False)

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -32,6 +32,7 @@ class Neuron(CMakePackage):
     patch("patch-v800-cmake-nvhpc.patch", when="@8.0.0%nvhpc^cmake@3.20:")
 
     version("develop", branch="master")
+    version("9.0.a9", commit="baf3b14")
     version("9.0.a8", commit="67a672a")
     version("9.0.a5", commit="522c866")
     version("9.0.a4", commit="de2c927")
@@ -111,10 +112,10 @@ class Neuron(CMakePackage):
     )
     # There are three different eras relevant for these variants:
     # * neuron@:9 -- coreneuron was a separate package, so nmodl is irrelevant to this recipe
-    # * neuron@9:9.0.a6 -- coreneuron exists inside neuron, nmodl is active if +coreneuron+nmodl
-    # * neuron@develop -- coreneuron exists inside neuron,
-    #                     mod2c is dead so nmodl active if +coreneuron
-    nmodl_enabled_specs = [nmodl_variant_exists + "+nmodl", "@develop +coreneuron"]
+    # * neuron@9:9.0.a8 -- coreneuron exists inside neuron, nmodl is active if +coreneuron+nmodl
+    # * neuron@9.0.a9   -- coreneuron exists inside neuron, mod2c is dead so nmodl active if
+    #                      +coreneuron
+    nmodl_enabled_specs = [nmodl_variant_exists + "+nmodl", "@9.0.a9: +coreneuron"]
     for nmodl_spec in nmodl_enabled_specs:
         # The lack of version constraint is a lie
         # most neuron/coreneuron versions are only compatible with one


### PR DESCRIPTION
Deploy https://github.com/neuronsimulator/nrn/pull/2027 into the `unstable` modules on BB5.