### PR TITLE
nmodl: add new version compatible with neuron@9.0.a9

### DIFF
--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -15,6 +15,7 @@ class Nmodl(CMakePackage):
 
     version("develop", branch="master", submodules=True)
     version("llvm", branch="llvm", submodules=True)
+    version("0.7.a1", commit="2ce4a2b91dfcfe6356b6a5003c4e99b8711564ee")
     version("0.6.0", tag="0.6")
     version("0.5.0", tag="0.5")
     version("0.4.0", tag="0.4")


### PR DESCRIPTION
Should have been included in https://github.com/BlueBrain/spack/pull/2051.
See also: HPCTM-1768.