### PR TITLE
deploy: get rid of modules based on petsc+complex

### DIFF
--- a/bluebrain/deployment/environments/applications_hpc.yaml
+++ b/bluebrain/deployment/environments/applications_hpc.yaml
@@ -29,7 +29,6 @@ spack:
           +common: '{name}/{version}-commonmods'
           +plasticity: '{name}-plasticity/{version}'
           +ngv+metabolism: '{name}-multiscale/{version}'
-          ^petsc+complex: '{name}-complex/{version}'
   specs:
     - neuron+tests+coreneuron
     - neuron+tests+coreneuron+sympy
@@ -54,7 +53,6 @@ spack:
     - spykfunc
     - steps
     - steps@5
-    - steps@5 ^petsc+complex
     - synapsetool
     - touchdetector
     - unit-test-translator

--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -33,8 +33,6 @@ spack:
           - python-dev
         projections:
           all: '{name}/{version}'
-          petsc+int64+mpi+complex: '{name}-complex/{version}'
-          ^petsc+complex: '{name}-complex/{version}'
   packages:
     petsc:
       variants: ~hypre
@@ -48,9 +46,7 @@ spack:
     - neuron+mpi
     - omega-h+gmsh
     - petsc+int64+mpi
-    - petsc+int64+mpi+complex
     - slepc~arpack ^petsc+int64+mpi
-    - slepc~arpack ^petsc+int64+mpi+complex
     - py-cgal-pybind
     - py-dask-mpi
     - py-flake8
@@ -60,9 +56,7 @@ spack:
     - py-notebook
     - py-numpy
     - py-petsc4py ^petsc+int64+mpi
-    - py-petsc4py ^petsc+int64+mpi+complex
     - py-slepc4py ^slepc~arpack ^petsc+int64+mpi
-    - py-slepc4py ^slepc~arpack ^petsc+int64+mpi+complex
     - py-pip
     - py-poisson-recon-pybind
     - py-rtree


### PR DESCRIPTION
Since the solver in repository molsys/bloodflow does not need scalar to be complexes anymore, these variants can be removed from deployment.