### PR TITLE
sim-model, py-neurodamus: Update py-neurodamus to new version

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -12,6 +12,7 @@ class PyNeurodamus(PythonPackage):
     git = "ssh://git@bbpgitlab.epfl.ch/hpc/sim/neurodamus-py.git"
 
     version("develop", branch="main")
+    version("2.15.3", tag="2.15.3")
     version("2.15.2", tag="2.15.2")
     version("2.15.1", tag="2.15.1")
     version("2.15.0", tag="2.15.0")

--- a/bluebrain/repo-bluebrain/packages/sim-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/sim-model/package.py
@@ -247,7 +247,7 @@ class SimModel(Package):
         if "+caliper" in self.spec:
             env.set("NEURODAMUS_CALI_ENABLED", "true")  # Needed for slurm.taskprolog
             env.set("CALI_MPIREPORT_FILENAME", "/dev/null")  # Prevents 'stdout' output
-            env.set("CALI_CHANNEL_FLUSH_ON_EXIT", "true")
+            env.set("CALI_CHANNEL_FLUSH_ON_EXIT", "false")
             env.set(
                 "CALI_MPIREPORT_LOCAL_CONFIG",
                 "SELECT sum(sum#time.duration), \


### PR DESCRIPTION
- py-neurodamus 2.15.3 includes fix that always executes `MPI_Finalize` in the end of the execution
- Disable flush on exit for caliper since this is already happening in `MPI_Finalize` stage