### PR TITLE
hpe-mpi: Fix SINGULARITY_CONTAINLIBS env variable

### DIFF
--- a/bluebrain/repo-patches/packages/hpe-mpi/package.py
+++ b/bluebrain/repo-patches/packages/hpe-mpi/package.py
@@ -18,11 +18,7 @@ class HpeMpi(Package):
 
     homepage = "http://www.no-name.com"
     url = "http://www.no-name.com/hpempi-1.0.tar.gz"
-    version(
-        "2.26",
-        sha256="2f27ad2e92ef0004b9a4dfb3b76837d1b657c43ff89f4deef99be58a322a80b7",
-        url="file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.21.tar.xz",
-    ) 
+
     version(
         "2.21",
         sha256="2f27ad2e92ef0004b9a4dfb3b76837d1b657c43ff89f4deef99be58a322a80b7",

--- a/bluebrain/repo-patches/packages/hpe-mpi/package.py
+++ b/bluebrain/repo-patches/packages/hpe-mpi/package.py
@@ -18,7 +18,11 @@ class HpeMpi(Package):
 
     homepage = "http://www.no-name.com"
     url = "http://www.no-name.com/hpempi-1.0.tar.gz"
-
+    version(
+        "2.26",
+        sha256="2f27ad2e92ef0004b9a4dfb3b76837d1b657c43ff89f4deef99be58a322a80b7",
+        url="file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.21.tar.xz",
+    ) 
     version(
         "2.21",
         sha256="2f27ad2e92ef0004b9a4dfb3b76837d1b657c43ff89f4deef99be58a322a80b7",
@@ -104,9 +108,10 @@ class HpeMpi(Package):
         #             LD_PRELOAD env variable of the container to make sure that
         #             the executable that might have hardcoded RPATH use this
         #             HPE-MPI implementation
-        libdir = self.prefix.lib
-        for lib in libdir:
-            env.append_path("SINGULARITY_CONTAINLIBS", lib, separator=",")
+        lib_directory = self.prefix.lib
+        for lib in os.listdir(lib_directory):
+            if os.path.isfile(os.path.join(lib_directory, lib)):
+                env.append_path("SINGULARITY_CONTAINLIBS", os.path.join(lib_directory, lib), separator=",")
         env.prepend_path(
             "SINGULARITYENV_LD_PRELOAD", "/.singularity.d/libs/libmpi.so", separator=","
         )

--- a/bluebrain/repo-patches/packages/hpe-mpi/package.py
+++ b/bluebrain/repo-patches/packages/hpe-mpi/package.py
@@ -107,7 +107,9 @@ class HpeMpi(Package):
         lib_directory = self.prefix.lib
         for lib in os.listdir(lib_directory):
             if os.path.isfile(os.path.join(lib_directory, lib)):
-                env.append_path("SINGULARITY_CONTAINLIBS", os.path.join(lib_directory, lib), separator=",")
+                env.append_path(
+                    "SINGULARITY_CONTAINLIBS", os.path.join(lib_directory, lib), separator=","
+                )
         env.prepend_path(
             "SINGULARITYENV_LD_PRELOAD", "/.singularity.d/libs/libmpi.so", separator=","
         )


### PR DESCRIPTION
- In the previous version there was an issue with the way `SINGULARITY_CONTAINLIBS` was set breaking `singularityce` module
- This fixes the issue:

```
/gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_modules/linux-rhel7-skylake/hpe-mpi/2.26:

module-whatis    HPE-SGI MPI package
prepend-path     PATH /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/bin
prepend-path     MANPATH /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/man
prepend-path     CMAKE_PREFIX_PATH /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/.
setenv           ROMIO_TUNEGATHER 0
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi_panfs.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi_st.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libpmi2mpt.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libsma.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi_mt.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi_lustre.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi_f08_intel.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi++abi1002.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi_f08.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi_bpheap.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libxmpi.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi++.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi.so
append-path      --delim , SINGULARITY_CONTAINLIBS /gpfs/bbp.cscs.ch/data/scratch/proj16/magkanar/spack_packages/software/install_gcc-12.2.0-skylake/hpe-mpi-2.26-zwxxno/lib/libmpi_im.so
prepend-path     --delim , SINGULARITYENV_LD_PRELOAD /.singularity.d/libs/libmpi.so
append-path      --delim , SINGULARITY_CONTAINLIBS /lib64/libpmi2.so
```