### PR TITLE
py-neurodamus: use new gitlab git remote

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -9,7 +9,7 @@ class PyNeurodamus(PythonPackage):
     """The BBP simulation control suite, Python API"""
 
     homepage = "https://github.com/BlueBrain/neurodamus"
-    git = "git@bbpgitlab.epfl.ch:hpc/sim/neurodamus.git"
+    git = "https://github.com/BlueBrain/neurodamus.git"
 
     version("develop", branch="main")
     version("2.15.3", tag="2.15.3")

--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -8,8 +8,8 @@ from spack.package import *
 class PyNeurodamus(PythonPackage):
     """The BBP simulation control suite, Python API"""
 
-    homepage = "https://bbpteam.epfl.ch/project/spaces/display/BGLIB/Neurodamus"
-    git = "ssh://git@bbpgitlab.epfl.ch/hpc/sim/neurodamus-py.git"
+    homepage = "https://github.com/BlueBrain/neurodamus"
+    git = "git@bbpgitlab.epfl.ch:hpc/sim/neurodamus.git"
 
     version("develop", branch="main")
     version("2.15.3", tag="2.15.3")


### PR DESCRIPTION
- Wasn't sure whether CI has the needed permissions to access the github repo so for now I used it's mirror on gitlab
- This is needed to unblock https://github.com/BlueBrain/neurodamus/pull/9 which tries to fix running the `blueconfigs` CI with the proper `neurodamus` branch