### PR TITLE
py-neurodamus: Add version 2.16.0

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -12,6 +12,7 @@ class PyNeurodamus(PythonPackage):
     git = "https://github.com/BlueBrain/neurodamus.git"
 
     version("develop", branch="main")
+    version("2.16.0", tag="2.16.0")
     version("2.15.3", tag="2.15.3")
     version("2.15.2", tag="2.15.2")
     version("2.15.1", tag="2.15.1")


### PR DESCRIPTION
Add `py-neurodamus` 2.16.0 for the following features:
 * [BBPBGLIB-1036] Pure SONATA reader for gap junctions
 * [BBPBGLIB-984] Option to keep Cell axon during init
 * [BBPBGLIB-1035] Drop Synapsetool. Migrate all synapses loading to libsonata (no syn2 support)

https://github.com/BlueBrain/neurodamus/blob/2.16.0/CHANGES.rst
