### PR TITLE
py-dask: bump

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-archngv/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-archngv/package.py
@@ -47,7 +47,7 @@ class PyArchngv(PythonPackage):
     # needed for trimesh marchingcubes
     depends_on("py-scikit-image", type=("build", "run"))
 
-    depends_on("py-dask+distributed+bag@2.0:", type=("build", "run"))
+    depends_on("py-dask+distributed@2.0:", type=("build", "run"))
     depends_on("py-distributed@2.0:", type=("build", "run"))
     depends_on("py-dask-mpi@2.0:", type=("build", "run"))
 

--- a/bluebrain/repo-bluebrain/packages/py-minis-validation/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-minis-validation/package.py
@@ -23,7 +23,7 @@ class PyMinisValidation(PythonPackage):
     depends_on("py-h5py@3.0:3.999", type=("build", "run"))
     depends_on("py-click@7.0:7.999", type=("build", "run"))
     depends_on("py-pyyaml@5.1:5.999", type=("build", "run"))
-    depends_on("py-dask+distributed+bag", type=("build", "run"))
+    depends_on("py-dask+distributed", type=("build", "run"))
     depends_on("py-dask-mpi", type=("build", "run"))
     depends_on("py-distributed", type=("build", "run"))
     depends_on("neuron+python@7.8:", type=("build", "run"))

--- a/bluebrain/repo-bluebrain/packages/py-morph-tool/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-morph-tool/package.py
@@ -26,7 +26,7 @@ class PyMorphTool(PythonPackage):
     depends_on("py-xmltodict@0.12:", type=("build", "run"))
 
     depends_on("py-plotly@4.1:", type=("build", "run"))
-    depends_on("py-dask+bag@2.19:", type=("build", "run"))
+    depends_on("py-dask@2.19:", type=("build", "run"))
     depends_on("neuron+python@7.8:", type=("build", "run"))
     depends_on("py-bluepyopt@1.9.37:", type=("build", "run"))
 

--- a/bluebrain/repo-bluebrain/packages/py-morphology-repair-workflow/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-morphology-repair-workflow/package.py
@@ -21,7 +21,7 @@ class PyMorphologyRepairWorkflow(PythonPackage):
     depends_on("py-setuptools", type=("build", "run"))
 
     depends_on("py-click@7.0:", type="run")
-    depends_on("py-dask+bag", type="run")
+    depends_on("py-dask", type="run")
     depends_on("py-more-itertools@8.4.0:", type="run")
     depends_on("py-numpy@1.19.1:", type="run")
     depends_on("py-pandas@1.1.0:", type="run")

--- a/var/spack/repos/builtin/packages/py-dask/package.py
+++ b/var/spack/repos/builtin/packages/py-dask/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -12,175 +12,108 @@ class PyDask(PythonPackage):
     homepage = "https://github.com/dask/dask/"
     pypi = "dask/dask-1.1.0.tar.gz"
 
-    maintainers = ["skosukhin"]
+    maintainers("skosukhin")
 
-    version("2021.9.1", sha256="e11f2bf2cac809e5408fc107dcf727af3bc3472160f206cb4b828211396ad65c")
+    version("2023.4.1", sha256="9dc72ebb509f58f3fe518c12dd5a488c67123fdd66ccb0b968b34fd11e512153")
+    version("2022.10.2", sha256="42cb43f601709575fa46ce09e74bea83fdd464187024f56954e09d9b428ceaab")
     version("2021.6.2", sha256="8588fcd1a42224b7cfcd2ebc8ad616734abb6b1a4517efd52d89c7dd66eb91f8")
     version("2021.4.1", sha256="195e4eeb154222ea7a1c368119b5f321ee4ec9d78531471fe0145a527f744aa8")
     version("2020.12.0", sha256="43e745afd4b464e6c0113131e430a16dce6ac42460b06e24d799093d098f7ab0")
-    version("2.16.0", sha256="2af5b0dcd48ce679ce0321cf91de623f4fe376262789b951fefa3c334002f350")
-    version("1.2.2", sha256="5e7876bae2a01b355d1969b73aeafa23310febd8c353163910b73e93dc7e492c")
-    version("1.1.2", sha256="93b355b9a9c9a3ddbb39fab99d5759aad5cfd346f4520b87788970e80cf97256")
-    version("1.1.0", sha256="e76088e8931b326c05a92d2658e07b94a6852b42c13a7560505a8b2354871454")
-    version("0.17.4", sha256="c111475a3d1f8cba41c8094e1fb1831c65015390dcef0308042a11a9606a2f6d")
-    version("0.8.1", sha256="43deb1934cd033668e5e60b735f45c9c3ee2813f87bd51c243f975e55267fa43")
 
     variant("array", default=True, description="Install requirements for dask.array")
-    variant("bag", default=True, description="Install requirements for dask.bag")
+    variant(
+        "bag", default=True, when="@:2021.3.0", description="Install requirements for dask.bag"
+    )
     variant("dataframe", default=True, description="Install requirements for dask.dataframe")
     variant("distributed", default=True, description="Install requirements for dask.distributed")
     variant("diagnostics", default=False, description="Install requirements for dask.diagnostics")
     variant(
         "delayed",
         default=True,
+        when="@:2021.3.0",
         description="Install requirements for dask.delayed (dask.imperative)",
     )
-    variant("yaml", default=True, description="Ensure support for YAML configuration files")
 
-    conflicts("~bag", when="@2021.3.1:")
-    conflicts("+distributed", when="@:0.4.0,0.7.6:0.8.1")
-    conflicts("+diagnostics", when="@:0.5.0")
-    conflicts("~delayed", when="@2021.3.1:")
-    conflicts("+yaml", when="@:0.17.5")
-    conflicts("~yaml", when="@2.17.1:")
-
-    depends_on("python@2.7:2.8,3.5:", type=("build", "run"))
-    depends_on("python@3.5:", type=("build", "run"), when="@2.0.0:")
-    depends_on("python@3.6:", type=("build", "run"), when="@2.7.0:")
-    depends_on("python@3.7:", type=("build", "run"), when="@2021.3.1:")
+    depends_on("python@3.8:", type=("build", "run"), when="@2022.10.2:")
 
     depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")
+    depends_on("py-versioneer@0.28+toml", type="build", when="@2023.4.1:")
 
     # Common requirements
-    depends_on("py-pyyaml", type=("build", "run"), when="@2.17.1:")
+    depends_on("py-packaging@20:", type="build", when="@2022.10.2:")
+    depends_on("py-pyyaml", type=("build", "run"))
+    depends_on("py-pyyaml@5.3.1:", type=("build", "run"), when="@2022.10.2:")
     depends_on("py-cloudpickle@1.1.1:", type=("build", "run"), when="@2021.3.1:")
+    depends_on("py-cloudpickle@1.5.0:", type=("build", "run"), when="@2023.4.1:")
     depends_on("py-fsspec@0.6.0:", type=("build", "run"), when="@2021.3.1:")
+    depends_on("py-fsspec@2021.09.0:", type=("build", "run"), when="@2023.4.1:")
     depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@2021.3.1:")
+    depends_on("py-toolz@0.10.0:", type=("build", "run"), when="@2023.4.1:")
     depends_on("py-partd@0.3.10:", type=("build", "run"), when="@2021.3.1:")
+    depends_on("py-partd@1.2.0:", type=("build", "run"), when="@2023.4.0:")
+    depends_on("py-click@7.0:", type=("build", "run"), when="@2022.10.2:")
+    depends_on("py-click@8.0:", type=("build", "run"), when="@2023.4.1:")
+    depends_on("py-importlib-metadata@4.13.0:", type=("build", "run"), when="@2023.4.0:")
 
     # Requirements for dask.array
-    depends_on("py-numpy", type=("build", "run"), when="@:0.17.1 +array")
-    depends_on("py-numpy@1.10.4:", type=("build", "run"), when="@0.17.2: +array")
-    depends_on("py-numpy@1.11.0:", type=("build", "run"), when="@0.17.3: +array")
-    depends_on("py-numpy@1.13.0:", type=("build", "run"), when="@1.2.1: +array")
     depends_on("py-numpy@1.15.1:", type=("build", "run"), when="@2020.12.0: +array")
     depends_on("py-numpy@1.16.0:", type=("build", "run"), when="@2021.3.1: +array")
-
-    depends_on("py-toolz", type=("build", "run"), when="@:0.6.1 +array")
-    depends_on("py-toolz@0.7.2:", type=("build", "run"), when="@0.7.0: +array")
-    depends_on("py-toolz@0.7.3:", type=("build", "run"), when="@0.14.1: +array")
+    depends_on("py-numpy@1.18.0:", type=("build", "run"), when="@2022.10.2: +array")
+    depends_on("py-numpy@1.21.0:", type=("build", "run"), when="@2023.4.0: +array")
     # The dependency on py-toolz is non-optional starting version 2021.3.1
-    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@2.13.0:2021.3.0 +array")
+    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@:2021.3.0 +array")
 
     # Requirements for dask.bag
-    depends_on("py-dill", type=("build", "run"), when="@:0.7.5 +bag")
-    depends_on("py-cloudpickle", type=("build", "run"), when="@0.7.6: +bag")
     depends_on("py-cloudpickle@0.2.1:", type=("build", "run"), when="@0.8.2: +bag")
     # The dependency on py-cloudpickle is non-optional starting version 2021.3.1
     depends_on("py-cloudpickle@0.2.2:", type=("build", "run"), when="@2.13.0:2021.3.0 +bag")
-
-    depends_on("py-fsspec@0.3.3:", type=("build", "run"), when="@2.2.0: +bag")
-    depends_on("py-fsspec@0.5.1:", type=("build", "run"), when="@2.5.0: +bag")
     # The dependency on py-fsspec is non-optional starting version 2021.3.1
-    depends_on("py-fsspec@0.6.0:", type=("build", "run"), when="@2.8.0:2021.3.0 +bag")
-
-    depends_on("py-toolz", type=("build", "run"), when="@:0.6.1 +bag")
-    depends_on("py-toolz@0.7.2:", type=("build", "run"), when="@0.7.0: +bag")
-    depends_on("py-toolz@0.7.3:", type=("build", "run"), when="@0.14.1: +bag")
+    depends_on("py-fsspec@0.6.0:", type=("build", "run"), when="@:2021.3.0 +bag")
     # The dependency on py-toolz is non-optional starting version 2021.3.1
-    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@2.13.0:2021.3.0 +bag")
-
-    depends_on("py-partd@0.3.2:", type=("build", "run"), when="@0.6.0: +bag")
-    depends_on("py-partd@0.3.3:", type=("build", "run"), when="@0.9.0: +bag")
-    depends_on("py-partd@0.3.5:", type=("build", "run"), when="@0.10.2: +bag")
-    depends_on("py-partd@0.3.6:", type=("build", "run"), when="@0.12.0: +bag")
-    depends_on("py-partd@0.3.7:", type=("build", "run"), when="@0.13.0: +bag")
-    depends_on("py-partd@0.3.8:", type=("build", "run"), when="@0.15.0: +bag")
+    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@:2021.3.0 +bag")
     # The dependency on py-partd is non-optional starting version 2021.3.1
-    depends_on("py-partd@0.3.10:", type=("build", "run"), when="@2.0.0:2021.3.0 +bag")
+    depends_on("py-partd@0.3.10:", type=("build", "run"), when="@:2021.3.0 +bag")
 
     # Requirements for dask.dataframe
-    depends_on("py-numpy", type=("build", "run"), when="@:0.17.1 +dataframe")
-    depends_on("py-numpy@1.10.4:", type=("build", "run"), when="@0.17.2: +dataframe")
-    depends_on("py-numpy@1.11.0:", type=("build", "run"), when="@0.17.3: +dataframe")
-    depends_on("py-numpy@1.13.0:", type=("build", "run"), when="@1.2.1: +dataframe")
     depends_on("py-numpy@1.15.1:", type=("build", "run"), when="@2020.12.0: +dataframe")
     depends_on("py-numpy@1.16.0:", type=("build", "run"), when="@2021.3.1: +dataframe")
-
-    depends_on("py-pandas@0.16.0:", type=("build", "run"), when="+dataframe")
-    depends_on("py-pandas@0.18.0:", type=("build", "run"), when="@0.9.0: +dataframe")
-    depends_on("py-pandas@0.19.0:", type=("build", "run"), when="@0.14.0: +dataframe")
-    depends_on("py-pandas@0.21.0:", type=("build", "run"), when="@1.2.1: +dataframe")
-    depends_on("py-pandas@0.23.0:", type=("build", "run"), when="@2.11.0: +dataframe")
+    depends_on("py-numpy@1.18.0:", type=("build", "run"), when="@2022.10.2: +dataframe")
+    depends_on("py-numpy@1.21.0:", type=("build", "run"), when="@2023.4.0: +dataframe")
     depends_on("py-pandas@0.25.0:", type=("build", "run"), when="@2020.12.0: +dataframe")
-
-    depends_on("py-toolz", type=("build", "run"), when="@:0.6.1 +dataframe")
-    depends_on("py-toolz@0.7.2:", type=("build", "run"), when="@0.7.0: +dataframe")
-    depends_on("py-toolz@0.7.3:", type=("build", "run"), when="@0.14.1: +dataframe")
+    depends_on("py-pandas@1.0:", type=("build", "run"), when="@2022.10.2: +dataframe")
+    depends_on("py-pandas@1.3:", type=("build", "run"), when="@2023.4.0: +dataframe")
     # The dependency on py-toolz is non-optional starting version 2021.3.1
-    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@2.13.0:2021.3.0 +dataframe")
-
-    depends_on("py-partd@0.3.2:", type=("build", "run"), when="@0.6.0: +dataframe")
-    depends_on("py-partd@0.3.3:", type=("build", "run"), when="@0.9.0: +dataframe")
-    depends_on("py-partd@0.3.5:", type=("build", "run"), when="@0.10.2: +dataframe")
-    depends_on("py-partd@0.3.7:", type=("build", "run"), when="@0.13.0: +dataframe")
-    depends_on("py-partd@0.3.8:", type=("build", "run"), when="@0.15.0: +dataframe")
-    depends_on("py-partd@0.3.10:", type=("build", "run"), when="@2.0.0: +dataframe")
+    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@:2021.3.0 +dataframe")
     # The dependency on py-partd is non-optional starting version 2021.3.1
-    depends_on("py-partd@0.3.10:", type=("build", "run"), when="@2.0.0:2021.3.0 +dataframe")
-
-    depends_on("py-cloudpickle@0.2.1:", type=("build", "run"), when="@0.8.2:2.6.0 +dataframe")
-
-    depends_on("py-fsspec@0.3.3:", type=("build", "run"), when="@2.2.0: +dataframe")
-    depends_on("py-fsspec@0.5.1:", type=("build", "run"), when="@2.5.0: +dataframe")
+    depends_on("py-partd@0.3.10:", type=("build", "run"), when="@:2021.3.0 +dataframe")
     # The dependency on py-fsspec is non-optional starting version 2021.3.1
-    depends_on("py-fsspec@0.6.0:", type=("build", "run"), when="@2.8.0:2021.3.0 +dataframe")
+    depends_on("py-fsspec@0.6.0:", type=("build", "run"), when="@:2021.3.0 +dataframe")
 
     # Requirements for dask.distributed
-    depends_on("py-dill", type=("build", "run"), when="@:0.7.5 +distributed")
-    depends_on("py-pyzmq", type=("build", "run"), when="@:0.7.5 +distributed")
-    depends_on("py-distributed@:2021.8.0", type=("build", "run"), when="@0.8.2: +distributed")
-    depends_on("py-distributed@1.9:2021.8.0", type=("build", "run"), when="@0.9.0: +distributed")
-    depends_on("py-distributed@1.10:2021.8.0", type=("build", "run"), when="@0.10.0: +distributed")
-    depends_on("py-distributed@1.14:2021.8.0", type=("build", "run"), when="@0.12.0: +distributed")
-    depends_on("py-distributed@1.15:2021.8.0", type=("build", "run"), when="@0.13.0: +distributed")
-    depends_on("py-distributed@1.16:2021.8.0", type=("build", "run"), when="@0.14.1: +distributed")
-    depends_on("py-distributed@1.20:2021.8.0", type=("build", "run"), when="@0.16.0: +distributed")
-    depends_on("py-distributed@1.21:2021.8.0", type=("build", "run"), when="@0.17.0: +distributed")
-    depends_on("py-distributed@1.22:2021.8.0", type=("build", "run"), when="@0.18.0: +distributed")
-    depends_on("py-distributed@2.0:2021.8.0", type=("build", "run"), when="@2.0.0: +distributed")
     depends_on(
-        "py-distributed@2020.12.0:2021.8.0", type=("build", "run"), when="@2020.12.0: +distributed"
+        "py-distributed@2020.12.0:2021.8.0", type=("build", "run"), when="@:2021.6.1 +distributed"
     )
     depends_on("py-distributed@2021.6.2", type=("build", "run"), when="@2021.6.2 +distributed")
+    depends_on("py-distributed@2022.10.2", type=("build", "run"), when="@2022.10.2 +distributed")
+    depends_on("py-distributed@2023.4.1", type=("build", "run"), when="@2023.4.1 +distributed")
 
     # Requirements for dask.diagnostics
-    depends_on("py-bokeh@1.0.0:", type=("build", "run"), when="@2.0.0: +diagnostics")
-    depends_on("py-bokeh@1.0.0:1,2.0.1:", type=("build", "run"), when="@2.26.0: +diagnostics")
+    depends_on("py-bokeh@1.0.0:1,2.0.1:", type=("build", "run"), when="+diagnostics")
+    depends_on("py-bokeh@2.4.2:2", type=("build", "run"), when="@2022.10.2:2023.3 +diagnostics")
+    depends_on("py-bokeh@2.4.2:", type=("build", "run"), when="@2023.4.0: +diagnostics")
+    depends_on("py-jinja2", type=("build", "run"), when="@2022.10.2: +diagnostics")
+    depends_on("py-jinja2@2.10.3", type=("build", "run"), when="@2023.4.0: +diagnostics")
 
     # Requirements for dask.delayed
-    depends_on("py-cloudpickle@0.2.1:", type=("build", "run"), when="@2.7.0: +delayed")
     # The dependency on py-cloudpickle is non-optional starting version 2021.3.1
-    depends_on("py-cloudpickle@0.2.2:", type=("build", "run"), when="@2.13.0:2021.3.0 +delayed")
-
-    depends_on("py-toolz@0.7.2:", type=("build", "run"), when="@0.8.1: +delayed")
-    depends_on("py-toolz@0.7.3:", type=("build", "run"), when="@0.14.1: +delayed")
+    depends_on("py-cloudpickle@0.2.2:", type=("build", "run"), when="@:2021.3.0 +delayed")
     # The dependency on py-toolz is non-optional starting version 2021.3.1
-    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@2.13.0:2021.3.0 +delayed")
-
-    # Support for YAML configuration files
-    # The dependency on py-pyyaml is non-optional starting version 2.17.1
-    depends_on("py-pyyaml", type=("build", "run"), when="@0.18.0:2.17.0 +yaml")
+    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@:2021.3.0 +delayed")
 
     @property
     def import_modules(self):
-        modules = ["dask"]
-
-        if self.spec.satisfies("@0.9.0:"):
-            modules.append("dask.bytes")
-
-        if self.spec.satisfies("@:0.20.2"):
-            modules.append("dask.store")
+        modules = ["dask", "dask.bytes"]
 
         if "+array" in self.spec:
             modules.append("dask.array")
@@ -188,15 +121,8 @@ class PyDask(PythonPackage):
         if "+bag" in self.spec:
             modules.append("dask.bag")
 
-        if self.spec.satisfies("@:0.7.5 +distributed"):
-            modules.append("dask.distributed")
-
         if "+dataframe" in self.spec:
-            modules.append("dask.dataframe")
-            if self.spec.satisfies("@0.8.2:"):
-                modules.append("dask.dataframe.tseries")
-            if self.spec.satisfies("@0.12.0:"):
-                modules.append("dask.dataframe.io")
+            modules.extend(["dask.dataframe", "dask.dataframe.tseries", "dask.dataframe.io"])
 
         if "+diagnostics" in self.spec:
             modules.append("dask.diagnostics")

--- a/var/spack/repos/builtin/packages/py-distributed/package.py
+++ b/var/spack/repos/builtin/packages/py-distributed/package.py
@@ -57,6 +57,7 @@ class PyDistributed(PythonPackage):
     depends_on("py-psutil@5.7.0:", type=("build", "run"), when="@2023.4.1:")
     depends_on("py-sortedcontainers@:1,2.0.2:", type=("build", "run"))
     depends_on("py-sortedcontainers@2.0.5:", type=("build", "run"), when="@2023.4.1:")
+    depends_on("py-tblib@1.6:", type=("build", "run"))
     depends_on("py-toolz@0.8.2:", type=("build", "run"))
     # Note that the setup.py is wrong for py-toolz, when="@2022.10.2".
     # See https://github.com/dask/distributed/pull/7309

--- a/var/spack/repos/builtin/packages/py-distributed/package.py
+++ b/var/spack/repos/builtin/packages/py-distributed/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -30,41 +30,47 @@ class PyDistributed(PythonPackage):
         "distributed.diagnostics",
     ]
 
+    version("2023.4.1", sha256="0140376338efdcf8db1d03f7c1fdbb5eab2a337b03e955d927c116824ee94ac5")
+    version("2022.10.2", sha256="53f0a5bf6efab9a5ab3345cd913f6d3f3d4ea444ee2edbea331c7fef96fd67d0")
     version("2022.2.1", sha256="fb62a75af8ef33bbe1aa80a68c01a33a93c1cd5a332dd017ab44955bf7ecf65b")
     version("2021.6.2", sha256="d7d112a86ab049dcefa3b21fd1baea4212a2c03d22c24bd55ad38d21a7f5d148")
     version("2021.4.1", sha256="4c1b189ec5aeaf770c473f730f4a3660dc655601abd22899e8a0662303662168")
     version("2020.12.0", sha256="2a0b6acc921cd4e0143a7c4383cdcbed7defbc4bd9dc3aab0c7f1c45f14f80e1")
-    version("2.10.0", sha256="2f8cca741a20f776929cbad3545f2df64cf60207fb21f774ef24aad6f6589e8b")
-    version("1.28.1", sha256="3bd83f8b7eb5938af5f2be91ccff8984630713f36f8f66097e531a63f141c48a")
 
-    depends_on("python@2.7:2.8,3.5:", when="@:1", type=("build", "run"))
-    depends_on("python@3.6:", when="@2:", type=("build", "run"))
-    depends_on("python@3.7:", when="@2021.4.1:", type=("build", "run"))
     depends_on("python@3.8:", when="@2022.2.1:", type=("build", "run"))
-    depends_on("py-setuptools", type=("build", "run"))
+    depends_on("py-setuptools", type="build")
+    depends_on("py-setuptools@62.6:", type="build", when="@2023.4.1:")
+    depends_on("py-versioneer@0.28+toml", type="build", when="@2023.4.1:")
 
+    # In Spack py-dask+distributed depends on py-distributed, not the other way around.
+    # Hence, no need for depends_on("py-dask", ...)
     depends_on("py-click@6.6:", type=("build", "run"))
-    depends_on("py-cloudpickle@0.2.2:", type=("build", "run"), when="@:2.16.0")
-    depends_on("py-cloudpickle@1.3.0:", type=("build", "run"), when="@2.17.0:2.20.0")
-    depends_on("py-cloudpickle@1.5.0:", type=("build", "run"), when="@2.21.0:")
+    depends_on("py-click@8.0:", type=("build", "run"), when="@2023.4.1:")
+    depends_on("py-cloudpickle@1.5.0:", type=("build", "run"))
     depends_on("py-jinja2", type=("build", "run"), when="@2022.2.1:")
-    depends_on("py-contextvars", type=("build", "run"), when="@2020: ^python@:3.6")
-    depends_on("py-msgpack", type=("build", "run"), when="@:2.10.0")
-    depends_on("py-msgpack@0.6.0:", type=("build", "run"), when="@2.11.0:")
+    depends_on("py-jinja2@2.10.3", type=("build", "run"), when="@2023.4.1:")
+    depends_on("py-locket@1:", type=("build", "run"), when="@2022.2.1:")
+    depends_on("py-msgpack@0.6.0:", type=("build", "run"))
+    depends_on("py-msgpack@1.0.0:", type=("build", "run"), when="@2023.4.1:")
     depends_on("py-packaging@20.0:", type=("build", "run"), when="@2022.2.1:")
     depends_on("py-psutil@5.0:", type=("build", "run"))
-    depends_on("py-six", type=("build", "run"), when="@:1")
+    depends_on("py-psutil@5.7.0:", type=("build", "run"), when="@2023.4.1:")
     depends_on("py-sortedcontainers@:1,2.0.2:", type=("build", "run"))
-    depends_on("py-tblib", type=("build", "run"), when="@:2.10.0")
-    depends_on("py-tblib@1.6.0:", type=("build", "run"), when="@2.11.0:")
-    depends_on("py-toolz@0.7.4:", type=("build", "run"), when="@:2.12.0")
-    depends_on("py-toolz@0.8.2:", type=("build", "run"), when="@2.13.0:")
+    depends_on("py-sortedcontainers@2.0.5:", type=("build", "run"), when="@2023.4.1:")
+    depends_on("py-toolz@0.8.2:", type=("build", "run"))
+    # Note that the setup.py is wrong for py-toolz, when="@2022.10.2".
+    # See https://github.com/dask/distributed/pull/7309
+    depends_on("py-toolz@0.10.0:", type=("build", "run"), when="@2022.10.2:")
     depends_on("py-tornado@5:", type=("build", "run"), when="^python@:3.7")
     depends_on("py-tornado@6.0.3:", type=("build", "run"), when="^python@3.8:")
+    depends_on("py-tornado@6.0.3:6.1", type=("build", "run"), when="@2022.10.2:")
     depends_on("py-zict@0.1.3:", type=("build", "run"))
+    depends_on("py-zict@2.2.0:", type=("build", "run"), when="@2023.4.1:")
     depends_on("py-pyyaml", type=("build", "run"))
-    depends_on("py-futures", when="@:1 ^python@2.7:2.8", type=("build", "run"))
-    depends_on("py-singledispatch", when="@:1 ^python@2.7:2.8", type=("build", "run"))
+    depends_on("py-pyyaml@5.3.1:", type=("build", "run"), when="@2023.4.1:")
+    depends_on("py-urllib3", type=("build", "run"), when="@2022.10.2:")
+    depends_on("py-urllib3@1.24.3:", type=("build", "run"), when="@2023.4.1:")
 
     def patch(self):
-        filter_file("^dask .*", "", "requirements.txt")
+        if self.spec.satisfies("@:2023.3"):
+            filter_file("^dask .*", "", "requirements.txt")

--- a/var/spack/repos/builtin/packages/py-fsspec/package.py
+++ b/var/spack/repos/builtin/packages/py-fsspec/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -12,6 +12,8 @@ class PyFsspec(PythonPackage):
     homepage = "https://github.com/intake/filesystem_spec"
     pypi = "fsspec/fsspec-0.4.4.tar.gz"
 
+    version("2023.1.0", sha256="fbae7f20ff801eb5f7d0bedf81f25c787c0dfac5e982d98fa3884a9cde2b5411")
+    version("2022.11.0", sha256="259d5fd5c8e756ff2ea72f42e7613c32667dc2049a4ac3d84364a7ca034acb8b")
     version("2021.7.0", sha256="792ebd3b54de0b30f1ce73f0ba0a8bcc864724f2d9f248cb8d0ece47db0cbde8")
     version("2021.4.0", sha256="8b1a69884855d1a8c038574292e8b861894c3373282d9a469697a2b41d5289a6")
     version("0.9.0", sha256="3f7a62547e425b0b336a6ac2c2e6c6ac824648725bc8391af84bb510a63d1a56")
@@ -19,12 +21,8 @@ class PyFsspec(PythonPackage):
     version("0.7.3", sha256="1b540552c93b47e83c568e87507d6e02993e6d1b30bc7285f2336c81c5014103")
     version("0.4.4", sha256="97697a46e8bf8be34461c2520d6fc4bfca0ed749b22bb2b7c21939fd450a7d63")
 
-    variant("http", default=False, description="HTTPFileSystem support (Requires version 0.8.1+)")
+    variant("http", default=False, description="HTTPFileSystem support", when="@0.8.1:")
 
-    conflicts("+http", when="@:0.8.0", msg="Only available in 0.8.1+")
-
-    depends_on("python@3.5:", type=("build", "run"))
-    depends_on("python@3.6:", type=("build", "run"), when="@0.6.3:")
     depends_on("py-setuptools", type="build")
     depends_on("py-requests", type=("build", "run"), when="+http")
     depends_on("py-aiohttp", type=("build", "run"), when="+http")

--- a/var/spack/repos/builtin/packages/py-locket/package.py
+++ b/var/spack/repos/builtin/packages/py-locket/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -12,6 +12,7 @@ class PyLocket(PythonPackage):
     homepage = "https://github.com/mwilliamson/locket.py"
     pypi = "locket/locket-0.2.0.tar.gz"
 
+    version("1.0.0", sha256="5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632")
     version("0.2.0", sha256="1fee63c1153db602b50154684f5725564e63a0f6d09366a1cb13dffcec179fb4")
 
     # pip silently replaces distutils with setuptools

--- a/var/spack/repos/builtin/packages/py-partd/package.py
+++ b/var/spack/repos/builtin/packages/py-partd/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -12,11 +12,13 @@ class PyPartd(PythonPackage):
     homepage = "https://github.com/dask/partd/"
     pypi = "partd/partd-0.3.8.tar.gz"
 
+    version("1.4.0", sha256="aa0ff35dbbcc807ae374db56332f4c1b39b46f67bf2975f5151e0b4186aed0d5")
     version("1.1.0", sha256="6e258bf0810701407ad1410d63d1a15cfd7b773fd9efe555dac6bb82cc8832b0")
     version("0.3.10", sha256="33722a228ebcd1fa6f44b1631bdd4cff056376f89eb826d7d880b35b637bcfba")
     version("0.3.8", sha256="67291f1c4827cde3e0148b3be5d69af64b6d6169feb9ba88f0a6cfe77089400f")
 
     depends_on("python@3.5:", type=("build", "run"), when="@1.1.0:")
+    depends_on("python@3.7:", type=("build", "run"), when="@1.4.0:")
     depends_on("py-setuptools", type="build")
     depends_on("py-locket", type=("build", "run"))
     depends_on("py-toolz", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-versioneer/package.py
+++ b/var/spack/repos/builtin/packages/py-versioneer/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -14,11 +14,20 @@ class PyVersioneer(PythonPackage):
     pypi = "versioneer/versioneer-0.26.tar.gz"
     git = "https://github.com/python-versioneer/python-versioneer.git"
 
-    maintainers = ["scemama"]
+    maintainers("scemama")
 
+    version("0.28", sha256="7175ca8e7bb4dd0e3c9779dd2745e5b4a6036304af3f5e50bd896f10196586d6")
+    version("0.27", sha256="452e0130658e9d3f0ba3e8a70cf34ef23c0ff6cbf743555b3e73a6c11d0161a3")
     version("0.26", sha256="84fc729aa296d1d26645a8f62f178019885ff6f9a1073b29a4a228270ac5257b")
     version("0.18", sha256="ead1f78168150011189521b479d3a0dd2f55c94f5b07747b484fd693c3fbf335")
+
+    variant("toml", default=True, description="Install TOML support", when="@0.26:")
 
     depends_on("python@3.7:", when="@0.23:", type=("build", "run"))
     depends_on("python@3.6:", when="@0.19:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    depends_on("py-tomli", when="@0.28: ^python@:3.10", type="build")
+    depends_on("py-tomli", when="@0.27", type="build")
+
+    depends_on("py-tomli", when="@0.28: +toml ^python@:3.10", type=("build", "run"))
+    depends_on("py-tomli", when="@:0.27 +toml", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-zict/package.py
+++ b/var/spack/repos/builtin/packages/py-zict/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -12,7 +12,10 @@ class PyZict(PythonPackage):
     homepage = "https://zict.readthedocs.io/en/latest/"
     pypi = "zict/zict-1.0.0.tar.gz"
 
+    version("3.0.0", sha256="e321e263b6a97aafc0790c3cfb3c04656b7066e6738c37fffcca95d803c9fba5")
     version("1.0.0", sha256="e34dd25ea97def518fb4c77f2c27078f3a7d6c965b0a3ac8fe5bdb0a8011a310")
 
+    depends_on("python@3.8:", when="@3.0.0:", type=("build", "run"))
+
     depends_on("py-setuptools", type="build")
-    depends_on("py-heapdict", type=("build", "run"))
+    depends_on("py-heapdict", type=("build", "run"), when="@:2.2.0")


### PR DESCRIPTION
The connectome manipulator needs a newer dask, thus update it and necessary dependencies from upstream. Patch to add `py-tblib` to `py-distributed` already merged to upstream, too.