### PR TITLE
deploy: remove TDS sync.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,27 +127,6 @@ forward_tests:
     reports:
       junit: spack_tests/*/*.xml
 
-# Incrementally sync deployment builds over to TDS
-#
-# This enables us to work on TDS while the production system is undergoing
-# maintenance.
-#
-# No explicit dependency to avoid sync errors impacting the regular
-# deployment. The sync job uses an internal resource group to avoid
-# overlapping execution.
-sync_to_tds:
-  needs: [atomic_build]
-  variables:
-    DEPLOYMENT_BASE: $DEPLOYMENT_BASE
-  # Really only want to run this when builds are active: exclude running
-  # on PRs, just merges and schedules.
-  rules:
-    - if: $CI_EXTERNAL_PULL_REQUEST_IID
-      when: never
-    - when: always
-  trigger:
-    project: hpc/spack-sync
-
 # Trigger basic container builds
 update_spacktainerizer:
   needs: []


### PR DESCRIPTION
TDS is dead, don't even attempt to sync any longer.
