### PR TITLE
py-bcsb: create package and deploy.

### DIFF
--- a/bluebrain/deployment/environments/applications_viz.yaml
+++ b/bluebrain/deployment/environments/applications_viz.yaml
@@ -5,6 +5,7 @@ spack:
       tcl:
         include:
           - brayns
+          - py-bcsb
           - py-brayns
           - py-brayns-circuit-studio-backend
           - brion
@@ -14,6 +15,7 @@ spack:
     - brayns
     - brayns@3.2.0
     - brayns@3.1.2
+    - py-bcsb
     - py-brayns
     - py-brayns@3.2.0
     - py-brayns@3.1.2

--- a/bluebrain/repo-bluebrain/packages/py-bcsb/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-bcsb/package.py
@@ -13,7 +13,7 @@ class PyBcsb(PythonPackage):
     git = "ssh://git@bbpgitlab.epfl.ch/viz/brayns/braynscircuitstudiobackend.git"
 
     version("develop", branch="develop")
-    version("1.1.0", branch="adrien_tests")
+    version("2.0.0", tag="v2.0.0")
 
     depends_on("python@3.10:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))

--- a/bluebrain/repo-bluebrain/packages/py-bcsb/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-bcsb/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2018 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyBcsb(PythonPackage):
+    """Backend service for Brayns Circuit Studio."""
+
+    homepage = "https://bbpgitlab.epfl.ch/viz/brayns/braynscircuitstudiobackend"
+    git = "ssh://git@bbpgitlab.epfl.ch/viz/brayns/braynscircuitstudiobackend.git"
+
+    version("develop", branch="develop")
+    version("1.1.0", branch="adrien_tests")
+
+    depends_on("python@3.10:", type=("build", "run"))
+    depends_on("py-setuptools", type=("build", "run"))
+
+    depends_on("py-websockets@10.3:", type=("run"))
+    depends_on("py-libsonata@0.1.23:", type=("run"))
+    depends_on("py-psutil@5.9.5:", type=("run"))
+    depends_on("py-bluepy@2.5.1", type=("run"))


### PR DESCRIPTION
Refactored implementation of py-brayns-circuit-studio-backend.

We will remove the previous package once it is not needed anymore for AWS and VSM.