### PR TITLE
py-morphio: remove dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-morphio/package.py
+++ b/var/spack/repos/builtin/packages/py-morphio/package.py
@@ -30,5 +30,3 @@ class PyMorphio(PythonPackage):
         depends_on("py-h5py@3", type=("build", "run"))
     else:
         depends_on("hdf5", type=("build", "run"))
-    depends_on("highfive", type=("build", "run"))
-    depends_on("py-pybind11", type=("build", "run"))


### PR DESCRIPTION
pybind11 and highfive are added through submodules or already included in the pip package. Adding them explicitly breaks the build for some reason.