### PR TITLE
deploy: only generate module for openjdk@17, don't propagate down

### DIFF
--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -135,7 +135,6 @@ spack:
     # #providers
     - openblas
     - openjdk@17  # HELP-17046
-    - openjdk@11  # Should be preferred by Spark for now
     - poppler
     - python
     - qhull

--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -237,7 +237,7 @@ github_information:
     #
     # As we're using the underlying config, create a temporary file and
     # move afterwards
-    -     spack export --scope=user --module tcl --explicit --unbuildable cuda intel-oneapi-mkl likwid llvm openscenegraph optix --exclude 'neuron|hdf5|nvhpc' ${shas} > "spack_config/packages.yaml.tmp"
+    -     spack export --scope=user --module tcl --explicit --unbuildable cuda intel-oneapi-mkl likwid llvm openscenegraph optix --exclude 'neuron|hdf5|nvhpc|openjdk' ${shas} > "spack_config/packages.yaml.tmp"
     -     sed -e "/:':/{s/'//g}" "spack_config/packages.yaml.tmp" > "spack_config/packages.yaml"
     - fi
     # Fail if software fails to build!


### PR DESCRIPTION
Excluding openjdk from being an external in packages.yaml should solve
some problems with incompatibilities around Spark, and mixing and
matching modules.
