### PR TITLE
py-bluepysnap: add v2.0.2, keep the old version in some packages

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-archngv/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-archngv/package.py
@@ -21,7 +21,7 @@ class PyArchngv(PythonPackage):
     depends_on("py-scipy@1.5.0:", type=("build", "run"))
     depends_on("py-h5py@3.1.0:", type=("build", "run"))
     depends_on("py-libsonata@0.1.21:", type=("build", "run"))
-    depends_on("py-bluepysnap@1.0.5:", type=("build", "run"))
+    depends_on("py-bluepysnap@1.0.5:1", type=("build", "run"))
     depends_on("py-cached-property@1.5:", type=("build", "run"))
     depends_on("py-voxcell@3.0.0:", type=("build", "run"))
     depends_on("py-vascpy@0.1.0:", type=("build", "run"))

--- a/bluebrain/repo-bluebrain/packages/py-bluecellulab/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-bluecellulab/package.py
@@ -19,7 +19,7 @@ class PyBluecellulab(PythonPackage):
     depends_on("neuron+python@8", type=("build", "run"))
     depends_on("py-numpy@1.8:", type=("build", "run"))
     depends_on("py-matplotlib@3.0.0:", type=("build", "run"))
-    depends_on("py-bluepysnap@1.0.7", type=("build", "run"))
+    depends_on("py-bluepysnap@1.0.7:1", type=("build", "run"))
     depends_on("py-pandas@1.0.0:", type=("build", "run"))
     depends_on("py-pydantic", type=("build", "run"))
     depends_on("py-typing-extensions@4.8.0", type="run")

--- a/bluebrain/repo-bluebrain/packages/py-bluepysnap/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-bluepysnap/package.py
@@ -16,6 +16,7 @@ class PyBluepysnap(PythonPackage):
 
     version("develop", branch="master")
     version("1.0.7", sha256="84f8dac041bad2e8f730089e6b20637c7af0435d8405d428434568cd7637e067")
+    version("2.0.2", sha256="28e8584995cbff0be925f5296bd1385dd031d5262d8ab567ef7c0a6052256949")
 
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))
@@ -23,8 +24,10 @@ class PyBluepysnap(PythonPackage):
 
     depends_on("py-cached-property@1.0:", type=("build", "run"))
     depends_on("py-h5py@3.0.1:3", type=("build", "run"))
+    depends_on("py-importlib-resources@5:", when="@2", type=("build", "run"))
     depends_on("py-jsonschema@4", type=("build", "run"))
     depends_on("py-libsonata@0.1.21:", type=("build", "run"))
+    depends_on("py-libsonata@0.1.24:", when="@2", type=("build", "run"))
     depends_on("py-morphio@3", type=("build", "run"))
     depends_on("py-morph-tool@2.4.3:2", type=("build", "run"))
     depends_on("py-numpy@1.8:", type=("build", "run"))

--- a/bluebrain/repo-bluebrain/packages/py-connectome-manipulator/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-connectome-manipulator/package.py
@@ -21,7 +21,7 @@ class PyConnectomeManipulator(PythonPackage):
 
     depends_on("parquet-converters@0.8.0:", type="run")
 
-    depends_on("py-bluepysnap@1.0.5:", type=("build", "run"))
+    depends_on("py-bluepysnap@1.0.5:1", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-pandas", type=("build", "run"))
     depends_on("py-progressbar", type=("build", "run"))


### PR DESCRIPTION
### py-bluepysnap 1.0.7 -> 2.0.2
* [breaking changes](https://bluebrainsnap.readthedocs.io/en/stable/changelog.html#breaking-changes)
* previous version held:
  * `py-archngv`: @eleftherioszisis , @jacquemi-bbp 
  * `py-bluecellulab`: @anilbey 
  * `py-connectome-manipulator`: @chr-pok 
* intentionally using the new version:
  * `brainbuilder`: @GianlucaFicarelli 
  * `py-bbp-workflow`: @genric 