### PR TITLE
hdf5: workaround for HPE-MPI bug.

### DIFF
--- a/bluebrain/repo-bluebrain/packages/hdf5/hpe-mpi-type-free_v1.12.1.patch
+++ b/bluebrain/repo-bluebrain/packages/hdf5/hpe-mpi-type-free_v1.12.1.patch
@@ -1,0 +1,17 @@
+diff --git i/src/H5Smpio.c w/src/H5Smpio.c
+index 7b85209c65..8eaf02ba01 100644
+--- i/src/H5Smpio.c
++++ w/src/H5Smpio.c
+@@ -1076,9 +1076,9 @@ H5S__release_datatype(H5S_mpio_mpitype_list_t *type_list)
+         H5S_mpio_mpitype_node_t *next;     /* Pointer to next node in list */
+         int                      mpi_code; /* MPI return status code */
+ 
+-        /* Release the MPI data type for this span tree */
+-        if (MPI_SUCCESS != (mpi_code = MPI_Type_free(&curr->type)))
+-            HMPI_GOTO_ERROR(FAIL, "MPI_Type_free failed", mpi_code)
++        // /* Release the MPI data type for this span tree */
++        // if (MPI_SUCCESS != (mpi_code = MPI_Type_free(&curr->type)))
++        //     HMPI_GOTO_ERROR(FAIL, "MPI_Type_free failed", mpi_code)
+ 
+         /* Get pointer to next node in list */
+         next = curr->next;

--- a/bluebrain/repo-bluebrain/packages/hdf5/hpe-mpi-type-free_v1.14.0.patch
+++ b/bluebrain/repo-bluebrain/packages/hdf5/hpe-mpi-type-free_v1.14.0.patch
@@ -1,0 +1,17 @@
+diff --git i/src/H5Smpio.c w/src/H5Smpio.c
+index c1465d0090..6dde10fc75 100644
+--- i/src/H5Smpio.c
++++ w/src/H5Smpio.c
+@@ -1100,9 +1100,9 @@ H5S__release_datatype(H5S_mpio_mpitype_list_t *type_list)
+         H5S_mpio_mpitype_node_t *next;     /* Pointer to next node in list */
+         int                      mpi_code; /* MPI return status code */
+ 
+-        /* Release the MPI data type for this span tree */
+-        if (MPI_SUCCESS != (mpi_code = MPI_Type_free(&curr->type)))
+-            HMPI_GOTO_ERROR(FAIL, "MPI_Type_free failed", mpi_code)
++        // /* Release the MPI data type for this span tree */
++        // if (MPI_SUCCESS != (mpi_code = MPI_Type_free(&curr->type)))
++        //     HMPI_GOTO_ERROR(FAIL, "MPI_Type_free failed", mpi_code)
+ 
+         /* Get pointer to next node in list */
+         next = curr->next;

--- a/bluebrain/repo-bluebrain/packages/hdf5/package.py
+++ b/bluebrain/repo-bluebrain/packages/hdf5/package.py
@@ -12,6 +12,18 @@ class Hdf5(BuiltinHdf5):
         description="Enable the page buffer in parallel HDF5.",
     )
 
+    patch(
+        "hpe-mpi-type-free_v1.12.1.patch",
+        when="@1.12.1+mpi^hpe-mpi",
+        sha256="3daa6efc8c04354ea8e7bf0c6529a904c8b94d77c9ae4cfb06ea9efb3e5b6afe",
+    )
+
+    patch(
+        "hpe-mpi-type-free_v1.14.0.patch",
+        when="@1.14.0+mpi^hpe-mpi",
+        sha256="474b58caf52eeff5afacc2d4c5ef7b501d2b75f2d81684d303dc60697769e2ec",
+    )
+
     # Modifies the check that page buffering is incompatible with parallel
     # HDF5. The issue is that it should also work with the parallel version
     # of the library, but only if one doesn't ask for MPI-IO.


### PR DESCRIPTION
This commit intentionally introduces a leak in HDF5, because HPE-MPI crashes with an double free or corruption error when calling `MPI_Type_free`.