### PR TITLE
neurodamus-model: fix parsed arguments in build_neurodamus.sh

### DIFF
--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -271,8 +271,8 @@ if [ -n "{nrnivmodlcore_call}" ] && [ "$COMPILE_ONLY_NEURON" -eq "0" ]; then
             export LD_LIBRARY_PATH=$libpath:\\$LD_LIBRARY_PATH"
 fi
 
-'{nrnivmodl}' -incflags '{incflags} '"$2" -loadflags \
-    '{loadflags} '"$extra_loadflags $3" "$1"
+'{nrnivmodl}' -incflags '{incflags} '"$3" -loadflags \
+    '{loadflags} '"$extra_loadflags $4" "$1"
 
 # Final Cleanup
 if [ -d _core_mods ]; then

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -248,6 +248,17 @@ COMPILE_ONLY_NEURON=0
 if [[ "$2" == "--only-neuron" ]]; then
     echo "Compiling mechanisms only for NEURON"
     COMPILE_ONLY_NEURON=1
+    if [[ ! -z "$3" ]]; then
+        NRNIVMODL_EXTRA_INCLUDE_FLAGS="$3"
+    fi
+    if [[ ! -z "$4" ]]; then
+        NRNIVMODL_EXTRA_LOAD_FLAGS="$4"
+    fi
+elif [[ ! -z "$2" ]]; then
+    NRNIVMODL_EXTRA_INCLUDE_FLAGS="$2"
+    if [[ ! -z "$3" ]]; then
+        NRNIVMODL_EXTRA_LOAD_FLAGS="$3"
+    fi
 fi
 
 if [ -n "{nrnivmodlcore_call}" ] && [ "$COMPILE_ONLY_NEURON" -eq "0" ]; then
@@ -271,8 +282,8 @@ if [ -n "{nrnivmodlcore_call}" ] && [ "$COMPILE_ONLY_NEURON" -eq "0" ]; then
             export LD_LIBRARY_PATH=$libpath:\\$LD_LIBRARY_PATH"
 fi
 
-'{nrnivmodl}' -incflags '{incflags} '"$3" -loadflags \
-    '{loadflags} '"$extra_loadflags $4" "$1"
+'{nrnivmodl}' -incflags '{incflags} '"${NRNIVMODL_EXTRA_INCLUDE_FLAGS}" -loadflags \
+    '{loadflags} '"$extra_loadflags ${NRNIVMODL_EXTRA_LOAD_FLAGS}" "$1"
 
 # Final Cleanup
 if [ -d _core_mods ]; then

--- a/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
+++ b/bluebrain/repo-bluebrain/packages/neurodamus-model/package.py
@@ -248,17 +248,11 @@ COMPILE_ONLY_NEURON=0
 if [[ "$2" == "--only-neuron" ]]; then
     echo "Compiling mechanisms only for NEURON"
     COMPILE_ONLY_NEURON=1
-    if [[ ! -z "$3" ]]; then
-        NRNIVMODL_EXTRA_INCLUDE_FLAGS="$3"
-    fi
-    if [[ ! -z "$4" ]]; then
-        NRNIVMODL_EXTRA_LOAD_FLAGS="$4"
-    fi
+    NRNIVMODL_EXTRA_INCLUDE_FLAGS="$3"
+    NRNIVMODL_EXTRA_LOAD_FLAGS="$4"
 elif [[ ! -z "$2" ]]; then
     NRNIVMODL_EXTRA_INCLUDE_FLAGS="$2"
-    if [[ ! -z "$3" ]]; then
-        NRNIVMODL_EXTRA_LOAD_FLAGS="$3"
-    fi
+    NRNIVMODL_EXTRA_LOAD_FLAGS="$3"
 fi
 
 if [ -n "{nrnivmodlcore_call}" ] && [ "$COMPILE_ONLY_NEURON" -eq "0" ]; then


### PR DESCRIPTION
I was wrong about no extra CLI arguments..
With the current change we get a lot of warning from `icpc`:
```
 -> Compiling kir23_lts.cpp
...
icpc: command line warning #10006: ignoring unknown option '-fonly-neuron'
```