### PR TITLE
 deploy: update gmsh and boost variants on BB5

### DIFF
--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -40,7 +40,7 @@ spack:
   specs:
     - boost+atomic+chrono+date_time+filesystem+json+locale+log+math+program_options+python+random+regex+serialization+shared+signals+stacktrace+system+test+timer+type_erasure
     - caliper+cuda cuda_arch=70
-    - gmsh+metis+mpi+openmp+shared
+    - gmsh
     - hdf5+mpi
     - highfive+mpi
     - metis+int64

--- a/bluebrain/repo-bluebrain/packages/py-multiscale-run/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-multiscale-run/package.py
@@ -31,6 +31,7 @@ class PyMultiscaleRun(PythonPackage):
     depends_on("py-julia", type=("build", "run"))
     depends_on("py-libsonata", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
+    depends_on("py-nbconvert", type=("build", "run"))
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-pandas", type=("build", "run"))
     depends_on("py-psutil", type=("build", "run"))

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -12,7 +12,7 @@ packages:
     # Merged GCC / LLVM requirements
     variants: +gas+gold+ld+plugins~libiberty
   boost:
-    variants: +filesystem+pic+test
+    variants: +filesystem+pic+serialization+test
   coreneuron:
     # Keep this aligned with NEURON, otherwise the Spack solver may decide that
     # rolling back to NEURON 8.2.2 with external CoreNEURON is a net win
@@ -38,7 +38,7 @@ packages:
     # +strip added to force rebuild of GCC with -fno-canonical-system-headers
     variants: +binutils+strip
   gmsh:
-    variants: ~mmg~fltk
+    variants: ~cgns~fltk~med~mmg+mpi+openmp+shared
   hdf5:
     variants: +cxx+hl
   icu4c:


### PR DESCRIPTION
Build gmsh without support of useless libraries, including med which
depended on an older of hdf5. It induced specs of steps and dependent
packages like py-multiscale-run to duplicate a lot of packages.

Build boost with +serialization by default to meet highfive requirements and
thus reduce the number of boost packages installed.

This change may contribute to solve BSD-416