### PR TITLE
deploy: use only one PETSc package

### DIFF
--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -34,9 +34,6 @@ spack:
           - python-dev
         projections:
           all: '{name}/{version}'
-  packages:
-    petsc:
-      variants: ~hypre
   specs:
     - boost+atomic+chrono+date_time+filesystem+json+locale+log+math+program_options+python+random+regex+serialization+shared+signals+stacktrace+system+test+timer+type_erasure
     - caliper+cuda cuda_arch=70

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -130,7 +130,7 @@ packages:
     - spec: perl@5.16.3
       prefix: /usr
   petsc:
-    variants: ~fortran
+    variants: ~debug~fortran~hypre+int64+mpi
   python:
     variants: +tk
     version: [3.10.8]


### PR DESCRIPTION
The deployment will provide a PETSc package that fullfills the requirements of all packages that `depends_on("petsc")` (steps, petsc4py, py-multiscale-run)

This change contributes to BSD-416