### PR TITLE
hpe-mpi: hdf5: add patched version received from HPE support

### DIFF
--- a/bluebrain/deployment/environments/externals.yaml
+++ b/bluebrain/deployment/environments/externals.yaml
@@ -112,7 +112,7 @@ spack:
     - graphviz
     - hdf5~mpi@1.10.7
     - help2man
-    - hpe-mpi@2.25.hmpt
+    - hpe-mpi@2.27.p1.hmpt
     - intel-mkl
     # Leads to issues down the line, where it is preferred over hpe-mpi
     # #providers

--- a/bluebrain/repo-bluebrain/packages/hdf5/package.py
+++ b/bluebrain/repo-bluebrain/packages/hdf5/package.py
@@ -14,13 +14,13 @@ class Hdf5(BuiltinHdf5):
 
     patch(
         "hpe-mpi-type-free_v1.12.1.patch",
-        when="@1.12.1+mpi^hpe-mpi",
+        when="@1.12.1+mpi^hpe-mpi@:2.25.hmpt",
         sha256="3daa6efc8c04354ea8e7bf0c6529a904c8b94d77c9ae4cfb06ea9efb3e5b6afe",
     )
 
     patch(
         "hpe-mpi-type-free_v1.14.0.patch",
-        when="@1.14.0+mpi^hpe-mpi",
+        when="@1.14.0+mpi^hpe-mpi@:2.25.hmpt",
         sha256="474b58caf52eeff5afacc2d4c5ef7b501d2b75f2d81684d303dc60697769e2ec",
     )
 

--- a/bluebrain/repo-patches/packages/hpe-mpi/package.py
+++ b/bluebrain/repo-patches/packages/hpe-mpi/package.py
@@ -44,6 +44,11 @@ class HpeMpi(Package):
         sha256="126a46bb2cbd4b63bd7b3aed74cee5e8d08e166e9748071fd0b308be29335e1a",
         url="file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.25.hmpt.tar.xz",
     )
+    version(
+        "2.27.p1.hmpt",
+        sha256="0004454307870c54b4dfd76e685e8047500d192706e6e00795cffb105f5d1117",
+        url="file:///gpfs/bbp.cscs.ch/apps/hpc/download/hpe-mpi/hpe-mpi-2.27.p1.hmpt.tar.xz",
+    )
 
     provides("mpi")
 


### PR DESCRIPTION
This patched version fixes the issue encountered by @1uc
  see https://github.com/1uc/hpe-mpi-io-bug