### PR TITLE
julia: depend on llvm for runtime

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -55,7 +55,8 @@ class Julia(MakefilePackage):
     depends_on(
         "llvm"
         " targets=amdgpu,bpf,nvptx,webassembly"
-        " version_suffix=jl +link_llvm_dylib libunwind=none"
+        " version_suffix=jl +link_llvm_dylib libunwind=none",
+        type=("build", "link", "run")
     )
     depends_on("libuv", when="@:1.7")
     depends_on("libuv-julia@1.42.0", when="@1.8.0:1.8.1")

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -56,7 +56,7 @@ class Julia(MakefilePackage):
         "llvm"
         " targets=amdgpu,bpf,nvptx,webassembly"
         " version_suffix=jl +link_llvm_dylib libunwind=none",
-        type=("build", "link", "run")
+        type=("build", "link", "run"),
     )
     depends_on("libuv", when="@:1.7")
     depends_on("libuv-julia@1.42.0", when="@1.8.0:1.8.1")


### PR DESCRIPTION
Some packages need lld to successfully build.
