### PR TITLE
deploy: prefer caliper v2.9.1 due to segfault issue with the 2.10.0

### DIFF
--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -10,7 +10,7 @@ packages:
     variants: +filesystem+pic+serialization+test
   caliper:
     # see https://github.com/LLNL/Caliper/issues/529
-    version: [2.9.1]
+    require: "@2.9.1"
   coreneuron:
     # Keep this aligned with NEURON, otherwise the Spack solver may decide that
     # rolling back to NEURON 8.2.2 with external CoreNEURON is a net win

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -8,6 +8,9 @@ packages:
     variants: +gas+gold+ld+plugins~libiberty
   boost:
     variants: +filesystem+pic+serialization+test
+  caliper:
+    # see https://github.com/LLNL/Caliper/issues/529
+    version: [2.9.1]
   coreneuron:
     # Keep this aligned with NEURON, otherwise the Spack solver may decide that
     # rolling back to NEURON 8.2.2 with external CoreNEURON is a net win

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -27,7 +27,12 @@ class Caliper(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("2.10.0", sha256="14c4fb5edd5e67808d581523b4f8f05ace8549698c0e90d84b53171a77f58565")
-    version("2.9.1", sha256="4771d630de505eff9227e0ec498d0da33ae6f9c34df23cb201b56181b8759e9e")
+    # see https://github.com/LLNL/Caliper/issues/529
+    version(
+        "2.9.1",
+        sha256="4771d630de505eff9227e0ec498d0da33ae6f9c34df23cb201b56181b8759e9e",
+        preferred=True,
+    )
     version("2.9.0", sha256="507ea74be64a2dfd111b292c24c4f55f459257528ba51a5242313fa50978371f")
     version("2.8.0", sha256="17807b364b5ac4b05997ead41bd173e773f9a26ff573ff2fe61e0e70eab496e4")
     version(

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -27,12 +27,7 @@ class Caliper(CMakePackage, CudaPackage, ROCmPackage):
 
     version("master", branch="master")
     version("2.10.0", sha256="14c4fb5edd5e67808d581523b4f8f05ace8549698c0e90d84b53171a77f58565")
-    # see https://github.com/LLNL/Caliper/issues/529
-    version(
-        "2.9.1",
-        sha256="4771d630de505eff9227e0ec498d0da33ae6f9c34df23cb201b56181b8759e9e",
-        preferred=True,
-    )
+    version("2.9.1", sha256="4771d630de505eff9227e0ec498d0da33ae6f9c34df23cb201b56181b8759e9e")
     version("2.9.0", sha256="507ea74be64a2dfd111b292c24c4f55f459257528ba51a5242313fa50978371f")
     version("2.8.0", sha256="17807b364b5ac4b05997ead41bd173e773f9a26ff573ff2fe61e0e70eab496e4")
     version(


### PR DESCRIPTION
I will report the issue upstream. For now, lets use the older version that was working OK.

Edit: LLNL/Caliper/issues/529