### PR TITLE
circuit-build: update to v5.1.2

### DIFF
--- a/bluebrain/repo-bluebrain/packages/circuit-build/package.py
+++ b/bluebrain/repo-bluebrain/packages/circuit-build/package.py
@@ -13,15 +13,15 @@ class CircuitBuild(PythonPackage):
     git = "ssh://git@bbpgitlab.epfl.ch/nse/circuit-build.git"
 
     version("develop", branch="main")
-    version("5.1.0", tag="circuit-build-v5.1.0")
+    version("5.1.2", tag="circuit-build-v5.1.2")
 
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))
 
     depends_on("py-click@7.0:", type=("build", "run"))
+    depends_on("py-jsonschema@3.2.0:", type=("build", "run"))
     depends_on("py-pyyaml@5.0:", type=("build", "run"))
     depends_on("snakemake@6.0:", type=("build", "run"))
-    depends_on("py-jsonschema@3.2.0:", type=("build", "run"))
 
     def setup_run_environment(self, env):
         env.prepend_path("PATH", self.spec["snakemake"].prefix.bin)


### PR DESCRIPTION
circuit-build 5.1.2 is compatible with Snakemake 8 (although not in Spack yet)