### PR TITLE
deploy: align hdf5 module and default spec

### DIFF
--- a/bluebrain/deployment/environments/applications_libraries.yaml
+++ b/bluebrain/deployment/environments/applications_libraries.yaml
@@ -7,7 +7,7 @@ spack:
           - boost
           - caliper
           - gmsh
-          - hdf5+mpi
+          - hdf5
           - highfive+mpi
           - libsonata-report
           - neuron+mpi
@@ -40,7 +40,7 @@ spack:
     - boost+atomic+chrono+date_time+filesystem+json+locale+log+math+program_options+python+random+regex+serialization+shared+signals+stacktrace+system+test+timer+type_erasure
     - caliper+cuda cuda_arch=70
     - gmsh
-    - hdf5+mpi
+    - hdf5+cxx+hl+mpi
     - highfive+mpi
     - libsonata-report
     - metis+int64

--- a/bluebrain/sysconfig/bluebrain5/packages.yaml
+++ b/bluebrain/sysconfig/bluebrain5/packages.yaml
@@ -45,7 +45,7 @@ packages:
   gmsh:
     variants: ~cgns~fltk~med~mmg+mpi+openmp+shared
   hdf5:
-    variants: +cxx+hl
+    variants: +cxx+hl+mpi
   icu4c:
     version: [64.1]
     # Drags in heavy PEARL dependencies


### PR DESCRIPTION
I noticed in the spack CI of multiscale-run that hdf5 gets rebuild all the time because its expected spec is +cxx+hl+mpi whereas the deployed module doesn't have +cxx. This +cxx must come from bluebrain/sysconfig/bluebrain5/packages.yaml since this variant is not mentionned explicitely elsewhere in the recipes.

This change intends to align the spec of the hdf5 module deployed on BB5 and its default spec, hoping to reduce the excessive time required to run the multiscale-run `spack_build` GitLab job.