### PR TITLE
py-ninja: add 1.11.1.1

### DIFF
--- a/bluebrain/repo-patches/packages/py-ninja/package.py
+++ b/bluebrain/repo-patches/packages/py-ninja/package.py
@@ -14,4 +14,3 @@ class PyNinja(PythonPackage):
 
     version("1.11.1.1", sha256="9d793b08dd857e38d0b6ffe9e6b7145d7c485a42dcfea04905ca0cdb6017cc3c")
     depends_on("ninja@1.11.1", type=("build", "run"), when="@1.11.1.1")
-

--- a/bluebrain/repo-patches/packages/py-ninja/package.py
+++ b/bluebrain/repo-patches/packages/py-ninja/package.py
@@ -8,5 +8,7 @@ from spack.pkg.builtin.py_ninja import PyNinja as BuiltinPyNinja
 
 
 class PyNinja(BuiltinPyNinja):
+    __doc__ = BuiltinPyNinja.__doc__
+
     version("1.11.1.1", sha256="9d793b08dd857e38d0b6ffe9e6b7145d7c485a42dcfea04905ca0cdb6017cc3c")
     depends_on("ninja@1.11.1", type=("build", "run"), when="@1.11.1.1")

--- a/bluebrain/repo-patches/packages/py-ninja/package.py
+++ b/bluebrain/repo-patches/packages/py-ninja/package.py
@@ -7,10 +7,6 @@ from spack.package import *
 from spack.pkg.builtin.py_ninja import PyNinja as BuiltinPyNinja
 
 
-class PyNinja(PythonPackage):
-    __doc__ = BuiltinPyNinja.__doc__
-    homepage = BuiltinPyNinja.homepage
-    pypi = BuiltinPyNinja.pypi
-
+class PyNinja(BuiltinPyNinja):
     version("1.11.1.1", sha256="9d793b08dd857e38d0b6ffe9e6b7145d7c485a42dcfea04905ca0cdb6017cc3c")
     depends_on("ninja@1.11.1", type=("build", "run"), when="@1.11.1.1")

--- a/bluebrain/repo-patches/packages/py-ninja/package.py
+++ b/bluebrain/repo-patches/packages/py-ninja/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2024 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+from spack.pkg.builtin.py_ninja import PyNinja as BuiltinPyNinja
+
+
+class PyNinja(PythonPackage):
+    __doc__ = BuiltinPyNinja.__doc__
+    homepage = BuiltinPyNinja.homepage
+    pypi = BuiltinPyNinja.pypi
+
+    version("1.11.1.1", sha256="9d793b08dd857e38d0b6ffe9e6b7145d7c485a42dcfea04905ca0cdb6017cc3c")
+    depends_on("ninja@1.11.1", type=("build", "run"), when="@1.11.1.1")
+


### PR DESCRIPTION
Align this package to the default ninja version provided by spack 0.21.0.
It mostly prevents packages that require both py-ninja and ninja to see their ninja version downgraded.

#py-multiscale-run-build-takes-4ever