### PR TITLE
py-find-libpython: backport upstream comments and 0.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-find-libpython/package.py
+++ b/var/spack/repos/builtin/packages/py-find-libpython/package.py
@@ -14,6 +14,9 @@ class PyFindLibpython(PythonPackage):
 
     license("MIT")
 
+    version("0.3.1", sha256="4dd75e54c0828cfa8e97287565d2499a6bd6216140afdf251c87a456e8e52cd3")
     version("0.3.0", sha256="6e7fe5d9af7fad6dc066cb5515a0e9c90a71f1feb2bb2f8e4cdbb4f83276e9e5")
 
-    depends_on("py-setuptools@43:", type="build")
+    depends_on("py-setuptools@42:", type="build")
+    depends_on("py-setuptools@43:", when="@0.3.1:", type="build")
+    depends_on("py-setuptools-scm+toml", when="@:0.3.0", type="build")


### PR DESCRIPTION
The previous PR had some upstream commits that weren't backported yet.
Now that 0.3.1 has a source tarball on pypi I've bumped upstream and am backporting that as well.