### PR TITLE
neuron: remove `codegen --force` from NMODL options

### DIFF
--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -84,7 +84,7 @@ class Neuron(BuiltinNeuron):
         spec = self.spec
 
         # extra optimisation specific option added
-        nmodl_options = "codegen --force"
+        nmodl_options = ""
         if spec.satisfies("+sympy"):
             nmodl_options += " sympy --analytic"
         if spec.satisfies("+sympyopt"):


### PR DESCRIPTION
Motivated by the discussion here https://github.com/BlueBrain/nmodl/issues/1188, it's perhaps worth considering disabling the `codegen --force` option to make `nrnivmodl-core` stop processing the file if NMODL encounters an issue, because the various compiler errors are not very user-friendly.