### PR TITLE
deploy: Revert "trigger NEURON CI when NEURON recipe is modified (#1966)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,6 @@ setup_environment:
     # All directories below should change for pull requests (replacing the
     # date)
     DEPLOYMENT_ROOT: "$DEPLOYMENT_BASE/$DEPLOYMENT_DATE"
-    DEPLOYMENT_ROOT_SUFFIX: ""
     DEPLOYMENT_UPSTREAM: "$DEPLOYMENT_BASE/$DEPLOYMENT_DATE"
     DEPLOYMENT_PROPRIETARY_MIRROR: "$DEPLOYMENT_BASE/$DEPLOYMENT_DATE/mirror/proprietary"
     # Artifacts to be passed back from the child pipeline: needs GitLab
@@ -56,7 +55,6 @@ setup_environment:
         DEPLOYMENT_ARTIFACTS: "$DEPLOYMENT_ROOT/artifacts/$CI_PIPELINE_IID"
         DEPLOYMENT_BRANCH: "$CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME"
         DEPLOYMENT_ROOT: "$DEPLOYMENT_BASE/pulls/$CI_EXTERNAL_PULL_REQUEST_IID"
-        DEPLOYMENT_ROOT_SUFFIX: "pulls/$CI_EXTERNAL_PULL_REQUEST_IID"
         DEPLOYMENT_PROPRIETARY_MIRROR: "$DEPLOYMENT_BASE/pulls/$CI_EXTERNAL_PULL_REQUEST_IID/mirror/proprietary"
         # Somewhat awkward, but "$DEPLOYMENT_ROOT/modules" is already used.
         MODULE_ROOT: "$DEPLOYMENT_ROOT/config/modules"
@@ -74,7 +72,6 @@ setup_environment:
     - echo "DEPLOYMENT_DATE=$DEPLOYMENT_DATE" >> deployment.env
     - echo "DEPLOYMENT_PROPRIETARY_MIRROR=$DEPLOYMENT_PROPRIETARY_MIRROR" >> deployment.env
     - echo "DEPLOYMENT_ROOT=$DEPLOYMENT_ROOT" >> deployment.env
-    - echo "DEPLOYMENT_ROOT_SUFFIX=$DEPLOYMENT_ROOT_SUFFIX" >> deployment.env
     - echo "DEPLOYMENT_UPSTREAM=$DEPLOYMENT_UPSTREAM" >> deployment.env
     - echo "MODULE_ROOT=$MODULE_ROOT" >> deployment.env
     - echo "OLD_DEPLOYMENT_MODULES=$OLD_DEPLOYMENT_MODULES" >> deployment.env
@@ -93,13 +90,6 @@ setup_environment:
 # pipelines run at the same time. SNAFU
 atomic_build:
   needs: [setup_environment]
-  rules:
-    # If the NEURON recipe has been modified then trigger the NEURON CI against
-    # the PR deployment directory.
-    - changes: [bluebrain/repo-patches/packages/neuron/package.py]
-      variables:
-        TRIGGER_CHILD_NEURON_PIPELINE: "1"
-    - when: always
   trigger:
     include: bluebrain/deployment/gitlab-ci.yml
     strategy: depend

--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -406,20 +406,6 @@ check_python_modules:
   script:
     - spack-check "$DEPLOYMENT_ROOT/config/modules.sh"
 
-# If the NEURON recipe has been modified then trigger the NEURON CI
-check_neuron_ci:
-  needs: [update_config]
-  rules:
-    - if: $TRIGGER_CHILD_NEURON_PIPELINE
-  trigger:
-    project: hpc/cellular/nrn
-    strategy: depend
-  variables:
-    # Warning: inconsistent results possible if the head of $CI_COMMIT_BRANCH
-    # is no longer $CI_COMMIT_SHA.
-    SPACK_BRANCH: $CI_COMMIT_BRANCH
-    SPACK_DEPLOYMENT_SUFFIX: $DEPLOYMENT_ROOT_SUFFIX
-
 github_feedback:
   stage: .post
   rules:


### PR DESCRIPTION


This reverts commit cdab83593a6eddaddca2a91a228ea5480dd19348.

As discussed on internal Slack, let's remove triggering nrn CI.