### PR TITLE
nmodl: testing variant to unbreak the tests

### DIFF
--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -25,7 +25,10 @@ class Nmodl(CMakePackage):
     variant("legacy-unit", default=False, description="Enable legacy units")
     variant("python", default=False, description="Enable python bindings")
     variant("llvm", default=False, description="Enable llvm codegen")
-    variant("llvm_cuda", default=False, description="Enable llvm codegen with CUDA backend")
+    variant(
+        "llvm_cuda", default=False, description="Enable llvm codegen with CUDA backend"
+    )
+    variant("testing", default=False, description="Install test dependencies")
 
     # Build with `ninja` instead of `make`
     generator("ninja")
@@ -55,6 +58,10 @@ class Nmodl(CMakePackage):
     depends_on("py-pyyaml@3.13:", type=("build", "run"))
     depends_on("spdlog")
     depends_on("py-find-libpython", type=("run",))
+
+    depends_on("py-pytest@3.3.0:", type="test", when="+testing")
+    depends_on("py-pytest-cov", type="test", when="+testing")
+    depends_on("py-numpy", type="test", when="+testing")
 
     def cmake_args(self):
         # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -59,30 +59,9 @@ class Nmodl(CMakePackage):
     depends_on("spdlog")
     depends_on("py-find-libpython", type=("run",))
 
-    depends_on(
-        "py-pytest@3.3.0:8.1.1",
-        type=(
-            "build",
-            "test",
-        ),
-        when="+tests",
-    )
-    depends_on(
-        "py-pytest-cov",
-        type=(
-            "build",
-            "test",
-        ),
-        when="+tests",
-    )
-    depends_on(
-        "py-numpy",
-        type=(
-            "build",
-            "test",
-        ),
-        when="+tests",
-    )
+    depends_on( "py-pytest@3.3.0:8.1.1", type=( "build", "test",), when="+tests")
+    depends_on( "py-pytest-cov", type=( "build", "test",), when="+tests")
+    depends_on( "py-numpy", type=( "build", "test",), when="+tests")
 
     def cmake_args(self):
         # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -76,7 +76,7 @@ class Nmodl(CMakePackage):
             # This recipe is used in CI pipelines that run the tests directly from
             # the build directory and not via Spack's --test=X option. Setting this
             # aims to override the implicit CMake argument that Spack injects.
-            self.define_from_variant("BUILD_TESTING", "test"),
+            self.define_from_variant("BUILD_TESTING", "tests"),
             self.define("PYTHON_EXECUTABLE", python.command),
             self.define_from_variant("NMODL_ENABLE_PYTHON_BINDINGS", "python"),
             self.define_from_variant("NMODL_ENABLE_LEGACY_UNITS", "legacy-unit"),

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -28,7 +28,7 @@ class Nmodl(CMakePackage):
     variant(
         "llvm_cuda", default=False, description="Enable llvm codegen with CUDA backend"
     )
-    variant("testing", default=False, description="Install test dependencies")
+    variant("tests", default=False, description="Enable building tests")
 
     # Build with `ninja` instead of `make`
     generator("ninja")
@@ -59,9 +59,30 @@ class Nmodl(CMakePackage):
     depends_on("spdlog")
     depends_on("py-find-libpython", type=("run",))
 
-    depends_on("py-pytest@3.3.0:", type="test", when="+testing")
-    depends_on("py-pytest-cov", type="test", when="+testing")
-    depends_on("py-numpy", type="test", when="+testing")
+    depends_on(
+        "py-pytest@3.3.0:8.1.1",
+        type=(
+            "build",
+            "test",
+        ),
+        when="+tests",
+    )
+    depends_on(
+        "py-pytest-cov",
+        type=(
+            "build",
+            "test",
+        ),
+        when="+tests",
+    )
+    depends_on(
+        "py-numpy",
+        type=(
+            "build",
+            "test",
+        ),
+        when="+tests",
+    )
 
     def cmake_args(self):
         # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 from spack.package import *
 
 
@@ -25,9 +24,7 @@ class Nmodl(CMakePackage):
     variant("legacy-unit", default=False, description="Enable legacy units")
     variant("python", default=False, description="Enable python bindings")
     variant("llvm", default=False, description="Enable llvm codegen")
-    variant(
-        "llvm_cuda", default=False, description="Enable llvm codegen with CUDA backend"
-    )
+    variant("llvm_cuda", default=False, description="Enable llvm codegen with CUDA backend")
     variant("tests", default=False, description="Enable building tests")
 
     # Build with `ninja` instead of `make`
@@ -59,9 +56,9 @@ class Nmodl(CMakePackage):
     depends_on("spdlog")
     depends_on("py-find-libpython", type=("run",))
 
-    depends_on( "py-pytest@3.3.0:8.1.1", type=( "build", "test",), when="+tests")
-    depends_on( "py-pytest-cov", type=( "build", "test",), when="+tests")
-    depends_on( "py-numpy", type=( "build", "test",), when="+tests")
+    depends_on("py-pytest@3.3.0:8.1.1", type=("build", "test"), when="+tests")
+    depends_on("py-pytest-cov", type=("build", "test"), when="+tests")
+    depends_on("py-numpy", type=("build", "test"), when="+tests")
 
     def cmake_args(self):
         # Do not use the cli11, fmt, pybind11 and spdlog submodule, use the one from

--- a/bluebrain/repo-bluebrain/packages/nmodl/package.py
+++ b/bluebrain/repo-bluebrain/packages/nmodl/package.py
@@ -97,7 +97,7 @@ class Nmodl(CMakePackage):
             # This recipe is used in CI pipelines that run the tests directly from
             # the build directory and not via Spack's --test=X option. Setting this
             # aims to override the implicit CMake argument that Spack injects.
-            self.define("BUILD_TESTING", True),
+            self.define_from_variant("BUILD_TESTING", "test"),
             self.define("PYTHON_EXECUTABLE", python.command),
             self.define_from_variant("NMODL_ENABLE_PYTHON_BINDINGS", "python"),
             self.define_from_variant("NMODL_ENABLE_LEGACY_UNITS", "legacy-unit"),


### PR DESCRIPTION
https://github.com/BlueBrain/spack/pull/2440 breaks the nmodl tests because they use pytest. Let's add a variant so we can install those optional dependencies when testing.