### PR TITLE
py-multiscale-run: code now hosted on GitHub

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-multiscale-run/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-multiscale-run/package.py
@@ -10,7 +10,7 @@ class PyMultiscaleRun(PythonPackage):
     """BBP multiscale simulation orchestrator"""
 
     homepage = "https://github.com/BlueBrain/MultiscaleRun"
-    git = "ssh://git@bbpgitlab.epfl.ch/hpc/MultiscaleRun.git"
+    git = "ssh://git@github.com:BlueBrain/MultiscaleRun.git"
 
     maintainers("tristan0x", "cattabiani")
 

--- a/bluebrain/repo-bluebrain/packages/py-multiscale-run/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-multiscale-run/package.py
@@ -9,8 +9,8 @@ from spack.package import *
 class PyMultiscaleRun(PythonPackage):
     """BBP multiscale simulation orchestrator"""
 
-    homepage = "https://bbpgitlab.epfl.ch/-/ide/project/molsys/multiscale_run"
-    git = "ssh://git@bbpgitlab.epfl.ch/molsys/multiscale_run.git"
+    homepage = "https://github.com/BlueBrain/MultiscaleRun"
+    git = "ssh://git@bbpgitlab.epfl.ch/hpc/MultiscaleRun.git"
 
     maintainers("tristan0x", "cattabiani")
 


### PR DESCRIPTION
Still fetches the git mirror repository on GitLab since the GitHub repository is private for now.