### PR TITLE
deploy: set default versions when merging modules.

### DIFF
--- a/bluebrain/deployment/bin/merge-modules
+++ b/bluebrain/deployment/bin/merge-modules
@@ -61,9 +61,9 @@ def run():
                 print("  ...deleting", path)
                 path.unlink()
         print("  Determining default versions")
-        for name, versions in modules.items():
+        for fragment, versions in modules.items():
             if len(versions) > 1:
-                default_name = f"DEFAULT_{name.name.upper()}_VERSION"
+                default_name = f"DEFAULT_{fragment.name.upper()}_VERSION"
                 default_version = os.environ.get(default_name)
                 if not default_version:
                     first_raw = sorted(versions)[-1]
@@ -71,7 +71,7 @@ def run():
                     if first_raw == first_parsed:
                         continue
                     default_version = first_parsed
-                (outdir / name / ".version").write_text(
+                (outdir / fragment / ".version").write_text(
                     VERSION_TEMPLATE.format(version=default_version)
                 )
 

--- a/bluebrain/deployment/bin/merge-modules
+++ b/bluebrain/deployment/bin/merge-modules
@@ -3,49 +3,78 @@
 """Merges modules from separate build stages and removes obsolete ones
 """
 
+import os
+
 from argparse import ArgumentParser
+from collections import defaultdict
 from pathlib import Path
 
 import spack.util.spack_yaml as syaml
+from spack.version import Version
+
+
+VERSION_TEMPLATE = """\
+#%Module1.0
+set ModulesVersion "{version}"
+"""
 
 
 def run():
-    """Merges modules from separate build stages and removes obsolete ones
-    """
+    """Merges modules from separate build stages and removes obsolete ones"""
     parser = ArgumentParser()
-    parser.add_argument('basedir', metavar='DIR', help="the base directory of the deployment")
+    parser.add_argument("basedir", metavar="DIR", help="the base directory of the deployment")
     args = parser.parse_args()
 
     basedir = Path(args.basedir)
-    module_root = basedir / 'modules'
+    module_root = basedir / "modules"
+    modules = defaultdict(set)
 
-    for stagedir in basedir.glob('stage_*'):
-        stage = stagedir.name.split('_', 1)[1]
+    for stagedir in basedir.glob("stage_*"):
+        stage = stagedir.name.split("_", 1)[1]
         outdir = module_root / stage
         outdir.mkdir(parents=True, exist_ok=True)
-        index = {'module_index': {}}
+        index = {"module_index": {}}
         copied = set()
         print("Processing", stage)
-        for moduledir in stagedir.glob('modules_tcl*'):
+        for moduledir in stagedir.glob("modules_tcl*"):
             print("  Reading {}".format(moduledir))
-            with (moduledir / 'module-index.yaml').open() as fd:
-                data = syaml.load(fd)['module_index']
-                index['module_index'].update(data)
-            for path in moduledir.glob('**/*'):
-                if path.is_file() and path.suffix != '.yaml':
+            with (moduledir / "module-index.yaml").open() as fd:
+                data = syaml.load(fd)["module_index"]
+                index["module_index"].update(data)
+            for path in moduledir.glob("**/*"):
+                if path.is_file() and path.suffix != ".yaml":
                     fragment = path.relative_to(moduledir)
+                    name = fragment.parent
+                    version = fragment.name
+                    modules[name].add(version)
                     target = outdir / fragment
                     target.parent.mkdir(parents=True, exist_ok=True)
                     target.write_text(path.read_text())
                     copied.add(target)
+
         print("  Writing new module index")
-        with (outdir / 'module-index.yaml').open('w') as fd:
+        with (outdir / "module-index.yaml").open("w") as fd:
             syaml.dump(index, stream=fd)
         print("  Cleaning up obsolete modules")
-        for path in outdir.glob('**/*'):
-            if path.is_file() and path.suffix != '.yaml' and path not in copied:
+        for path in outdir.glob("**/*"):
+            if path.is_file() and path.suffix != ".yaml" and path not in copied:
                 print("  ...deleting", path)
                 path.unlink()
+
+    print("  Determining default versions")
+    for name, versions in modules.items():
+        if len(versions) > 1:
+            default_name = f"DEFAULT_{name.name.upper()}_VERSION"
+            default_version = os.environ.get(default_name)
+            if not default_version:
+                first_raw = sorted(versions)[-1]
+                first_parsed = sorted(versions, key=Version)[-1]
+                if first_raw == first_parsed:
+                    continue
+                default_version = first_parsed
+            (outdir / name / ".version").write_text(
+                VERSION_TEMPLATE.format(version=default_version)
+            )
 
 
 if __name__ == "__main__":

--- a/bluebrain/deployment/bin/merge-modules
+++ b/bluebrain/deployment/bin/merge-modules
@@ -27,13 +27,13 @@ def run():
 
     basedir = Path(args.basedir)
     module_root = basedir / "modules"
-    modules = defaultdict(set)
 
     for stagedir in basedir.glob("stage_*"):
         stage = stagedir.name.split("_", 1)[1]
         outdir = module_root / stage
         outdir.mkdir(parents=True, exist_ok=True)
         index = {"module_index": {}}
+        modules = defaultdict(set)
         copied = set()
         print("Processing", stage)
         for moduledir in stagedir.glob("modules_tcl*"):
@@ -60,21 +60,20 @@ def run():
             if path.is_file() and path.suffix != ".yaml" and path not in copied:
                 print("  ...deleting", path)
                 path.unlink()
-
-    print("  Determining default versions")
-    for name, versions in modules.items():
-        if len(versions) > 1:
-            default_name = f"DEFAULT_{name.name.upper()}_VERSION"
-            default_version = os.environ.get(default_name)
-            if not default_version:
-                first_raw = sorted(versions)[-1]
-                first_parsed = sorted(versions, key=Version)[-1]
-                if first_raw == first_parsed:
-                    continue
-                default_version = first_parsed
-            (outdir / name / ".version").write_text(
-                VERSION_TEMPLATE.format(version=default_version)
-            )
+        print("  Determining default versions")
+        for name, versions in modules.items():
+            if len(versions) > 1:
+                default_name = f"DEFAULT_{name.name.upper()}_VERSION"
+                default_version = os.environ.get(default_name)
+                if not default_version:
+                    first_raw = sorted(versions)[-1]
+                    first_parsed = sorted(versions, key=Version)[-1]
+                    if first_raw == first_parsed:
+                        continue
+                    default_version = first_parsed
+                (outdir / name / ".version").write_text(
+                    VERSION_TEMPLATE.format(version=default_version)
+                )
 
 
 if __name__ == "__main__":

--- a/bluebrain/deployment/gitlab-ci.yml
+++ b/bluebrain/deployment/gitlab-ci.yml
@@ -332,18 +332,6 @@ update_config:
     - if grep -q -m1 -l -R '<failure' "$DEPLOYMENT_ARTIFACTS"; then exit 1; fi
     # Will create $DEPLOYMENT_ROOT/modules
     - merge-modules "$DEPLOYMENT_ROOT"
-    # Find the GCC and Python modules and set a default version
-    - |
-      gcc_module=$(find "$DEPLOYMENT_ROOT/modules" -wholename "*/gcc/$DEFAULT_GCC_VERSION")
-      cat <<EOF > "${gcc_module%$DEFAULT_GCC_VERSION}/.version"
-      #%Module1.0
-      set ModulesVersion "$DEFAULT_GCC_VERSION"
-      EOF
-      python_module=$(find "$DEPLOYMENT_ROOT/modules" -wholename "*/python/$DEFAULT_PYTHON_VERSION")
-      cat <<EOF > "${python_module%$DEFAULT_PYTHON_VERSION}/.version"
-      #%Module1.0
-      set ModulesVersion "$DEFAULT_PYTHON_VERSION"
-      EOF
 
     # Sync modules for the current month
     - mkdir -p "$MODULE_ROOT/$(date +%Y-%m)"


### PR DESCRIPTION
This came up with the recent Brayns release of 3.10, while a 3.8 version
was still deployed: the module system gave preference to the 3.8 version
due to lexical and not numerical sorting.

In the past we used special variables to pin the GCC and Python version
in the CI pipeline code itself.  This clearly does not scale, so move
the code into the merging of the modules (in Python!).

If there is more than one version of a module, first check if there is a
preference in the environment for a certain version (assumed to be
correct, existence of said version is not checked), use that. If not,
compare lexical and numerical sorting (via Spack's `Version`
functionality) and use the numerical version if not identical to the
best lexical one.
