### PR TITLE
circuit-build: fix snakemake dependency

### DIFF
--- a/bluebrain/repo-bluebrain/packages/circuit-build/package.py
+++ b/bluebrain/repo-bluebrain/packages/circuit-build/package.py
@@ -21,7 +21,7 @@ class CircuitBuild(PythonPackage):
     depends_on("py-click@7.0:", type=("build", "run"))
     depends_on("py-jsonschema@3.2.0:", type=("build", "run"))
     depends_on("py-pyyaml@5.0:", type=("build", "run"))
-    depends_on("snakemake@6.0:", type=("build", "run"))
+    depends_on("snakemake@7.0:", type=("build", "run"))
 
     def setup_run_environment(self, env):
         env.prepend_path("PATH", self.spec["snakemake"].prefix.bin)


### PR DESCRIPTION
In the latest modules, the resolved snakemake version installed with circuit-build has been downgraded from 7.22.0 to 6.15.1.
Try to enforce snakemake>=7 because 6.15.1 doesn't seem compatible with python 3.11
